### PR TITLE
Added support for pinning and reusing terms with children.

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/Term.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/Term.cs
@@ -25,6 +25,9 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model
         public String Owner { get; set; }
         public Boolean IsAvailableForTagging { get; set; }
         public Boolean IsReused { get; set; }
+        public Boolean IsPinned { get; set; }
+        public Boolean IsPinnedRoot { get; set; }
+        public Boolean ReuseChildren { get; set; }
         public Boolean IsSourceTerm { get; set; }
         public Guid SourceTermId { get; set; }
         public Boolean IsDeprecated { get; set; }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTermGroups.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTermGroups.cs
@@ -346,7 +346,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         {
                             //Set term local properties as this is a newly reused or pinned term hierarchy with children.
                             SetTermLocalProperties(modelTerm, parser, termTerm);
-                            parser = CreateChildTerms(web, modelTermTerm, term, termStore, parser, scope, true);
+                            parser = CreateChildTerms(web, modelTermTerm, termTerm, termStore, parser, scope, true);
                         }
                     }
                     else


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| New sample? | no |
| Related issues? |  |
#### What's in this Pull Request?

Extended provisioning template with support for pinning terms and reusing terms with children. Also added support for setting term local custom properties when pinning/reusing terms with children. 
Schema changes has been added to PR#116 in OfficeDev/PnP-Provisioning-Schema

I have not checked in the necessary changes that needs to be done in the schema formatter. Is there any guidance for doing this?

This PR includes all changes made in PR #718. If it takes time to include this PR then I would like to keep that PR so that it can be implemented sooner. Otherwise that PR can be closed.
