### PR TITLE
Token is not replaced for a SecurableObjectExtensions.RoleDefinition in SetSecurity

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Extensions/SecurableObjectExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Extensions/SecurableObjectExtensions.cs
@@ -39,7 +39,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Extensions
                 {
                     var roleDefinitionBindingCollection = new RoleDefinitionBindingCollection(context);
 
-                    var roleDefinition = webRoleDefinitions.FirstOrDefault(r => r.Name == roleAssignment.RoleDefinition);
+                    var roleAssignmentRoleDefinition = parser.ParseString(roleAssignment.RoleDefinition);
+                    var roleDefinition = webRoleDefinitions.FirstOrDefault(r => r.Name == roleAssignmentRoleDefinition);
 
                     if (roleDefinition != null)
                     {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | none

#### What's in this Pull Request?

A parameter/token cannot be used in the RoleDefinition of a RoleAssignment. The parse.ParseString method wasn't used when trying to retrieve the RoleDefinition on the Web. It will not retrieve a RoleDefinition and will produce an error when the RoleDefinitionCollection is empty when adding it to the RoleAssignment.