### PR TITLE
Fix: WelcomePage can now be overwritten when tokens are used to build urls

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPages.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPages.cs
@@ -26,6 +26,14 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                 web.EnsureProperties(w => w.ServerRelativeUrl, w => w.RootFolder.WelcomePage);
 
+                string welcomePageUrl = web.RootFolder.WelcomePage;
+
+                string welcomePageServerRelativeUrl = null;
+                if (!string.IsNullOrEmpty(welcomePageUrl))
+                {
+                    welcomePageServerRelativeUrl = UrlUtility.Combine(web.ServerRelativeUrl, welcomePageUrl);
+                }
+
                 // Check if this is not a noscript site as we're not allowed to update some properties
                 bool isNoScriptSite = web.IsNoScriptSite();
 
@@ -61,12 +69,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                             {
                                 scope.LogDebug(CoreResources.Provisioning_ObjectHandlers_Pages_Overwriting_existing_page__0_, url);
 
-                                bool overwriteWelcomePage = false;
-                                if (!string.IsNullOrEmpty(page.ParentTemplate.WebSettings.WelcomePage))
-                                {
-                                    string welcomePageUrl = UrlUtility.Combine(web.ServerRelativeUrl, page.ParentTemplate.WebSettings.WelcomePage);
-                                    overwriteWelcomePage = string.Equals(url, welcomePageUrl, StringComparison.InvariantCultureIgnoreCase);
-                                }
+                                bool overwriteWelcomePage = string.Equals(url, welcomePageServerRelativeUrl, StringComparison.InvariantCultureIgnoreCase);
 
                                 if (overwriteWelcomePage)
                                 {
@@ -87,7 +90,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                                 if (overwriteWelcomePage)
                                 {
-                                    web.SetHomePage(page.ParentTemplate.WebSettings.WelcomePage);
+                                    web.SetHomePage(welcomePageUrl);
                                 }
                             }
                             catch (Exception ex)

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPages.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPages.cs
@@ -61,8 +61,13 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                             {
                                 scope.LogDebug(CoreResources.Provisioning_ObjectHandlers_Pages_Overwriting_existing_page__0_, url);
 
-                                if (page.WelcomePage && url.Contains(web.RootFolder.WelcomePage))
+                                string welcomePageUrl = UrlUtility.Combine(web.ServerRelativeUrl, page.ParentTemplate.WebSettings.WelcomePage);
+                                bool overwriteHomepage = string.Equals(url, welcomePageUrl, StringComparison.InvariantCultureIgnoreCase);
+
+                                if (overwriteHomepage)
+                                {
                                     web.SetHomePage(string.Empty);
+                                }
 
                                 file.DeleteObject();
                                 web.Context.ExecuteQueryRetry();
@@ -74,6 +79,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                 else
                                 {
                                     web.AddLayoutToWikiPage(page.Layout, url);
+                                }
+
+                                if (overwriteHomepage)
+                                {
+                                    web.SetHomePage(page.ParentTemplate.WebSettings.WelcomePage);
                                 }
                             }
                             catch (Exception ex)
@@ -102,13 +112,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         {
                             scope.LogError(CoreResources.Provisioning_ObjectHandlers_Pages_Creating_new_page__0__failed___1_____2_, url, ex.Message, ex.StackTrace);
                         }
-                    }
-
-                    if (page.WelcomePage)
-                    {
-                        web.RootFolder.EnsureProperty(p => p.ServerRelativeUrl);
-                        var rootFolderRelativeUrl = url.Substring(web.RootFolder.ServerRelativeUrl.Length);
-                        web.SetHomePage(rootFolderRelativeUrl);
                     }
 
 #if !SP2013

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPages.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPages.cs
@@ -61,10 +61,14 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                             {
                                 scope.LogDebug(CoreResources.Provisioning_ObjectHandlers_Pages_Overwriting_existing_page__0_, url);
 
-                                string welcomePageUrl = UrlUtility.Combine(web.ServerRelativeUrl, page.ParentTemplate.WebSettings.WelcomePage);
-                                bool overwriteHomepage = string.Equals(url, welcomePageUrl, StringComparison.InvariantCultureIgnoreCase);
+                                bool overwriteWelcomePage = false;
+                                if (!string.IsNullOrEmpty(page.ParentTemplate.WebSettings.WelcomePage))
+                                {
+                                    string welcomePageUrl = UrlUtility.Combine(web.ServerRelativeUrl, page.ParentTemplate.WebSettings.WelcomePage);
+                                    overwriteWelcomePage = string.Equals(url, welcomePageUrl, StringComparison.InvariantCultureIgnoreCase);
+                                }
 
-                                if (overwriteHomepage)
+                                if (overwriteWelcomePage)
                                 {
                                     web.SetHomePage(string.Empty);
                                 }
@@ -81,7 +85,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                     web.AddLayoutToWikiPage(page.Layout, url);
                                 }
 
-                                if (overwriteHomepage)
+                                if (overwriteWelcomePage)
                                 {
                                     web.SetHomePage(page.ParentTemplate.WebSettings.WelcomePage);
                                 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no 
| Related issues?  | -

#### What's in this Pull Request?

The provisioning framework failed when a Page that was set as a WelcomePage was to be overwritten and tokens were used to build the Page URL. 
I updated the comparison mechanism to to detect if the current page is the WelcomePage, removed some deprecated references and changed the code that updates the WelcomePage property after the Page was provisioned.
