### PR TITLE
Fix: Web.SiteLogoUrl refering to _layouts page causes Exception when using GetProvisioningTemplate()

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectWebSettings.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectWebSettings.cs
@@ -130,7 +130,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             {
                 if (creationInfo.FileConnector != null)
                 {
-                    if (serverRelativeUrl.IsIisVirtualDirectory())
+                    if (UrlUtility.IsIisVirtualDirectory(serverRelativeUrl))
                     {
                         scope.LogWarning("File is not located in the content database. Not retrieving {0}", serverRelativeUrl);
                         return success;

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectWebSettings.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectWebSettings.cs
@@ -130,6 +130,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             {
                 if (creationInfo.FileConnector != null)
                 {
+                    if (serverRelativeUrl.IsIisVirtualDirectory())
+                    {
+                        scope.LogWarning("File is not located in the content database. Not retrieving {0}", serverRelativeUrl);
+                        return success;
+                    }
 
                     try
                     {

--- a/Core/OfficeDevPnP.Core/Utilities/UrlUtility.cs
+++ b/Core/OfficeDevPnP.Core/Utilities/UrlUtility.cs
@@ -119,9 +119,9 @@ namespace OfficeDevPnP.Core.Utilities
         {
 	    return new Regex(INVALID_CHARS_REGEX).Replace(content, replacer);
         }
-        public static bool IsIisVirtualDirectory(this string content)
+        public static bool IsIisVirtualDirectory(string url)
         {
-            return Regex.IsMatch(content, IIS_MAPPED_PATHS_REGEX, RegexOptions.IgnoreCase);
+            return Regex.IsMatch(url, IIS_MAPPED_PATHS_REGEX, RegexOptions.IgnoreCase);
         }
 
     }

--- a/Core/OfficeDevPnP.Core/Utilities/UrlUtility.cs
+++ b/Core/OfficeDevPnP.Core/Utilities/UrlUtility.cs
@@ -14,6 +14,7 @@ namespace OfficeDevPnP.Core.Utilities
 #else
         const string INVALID_CHARS_REGEX = @"[\\~#%&*{}/:<>?+|\""]";
 #endif
+        const string IIS_MAPPED_PATHS_REGEX = @"/(_layouts|_admin|_app_bin|_controltemplates|_login|_vti_bin|_vti_pvt|_windows|_wpresources)/";
 
         #region [ Combine ]
         /// <summary>
@@ -117,6 +118,10 @@ namespace OfficeDevPnP.Core.Utilities
         public static string ReplaceInvalidUrlChars(this string content, string replacer)
         {
 	    return new Regex(INVALID_CHARS_REGEX).Replace(content, replacer);
+        }
+        public static bool IsIisVirtualDirectory(this string content)
+        {
+            return Regex.IsMatch(content, IIS_MAPPED_PATHS_REGEX, RegexOptions.IgnoreCase);
         }
 
     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | -

#### What's in this Pull Request?

I experienced an Exception when I tried to persist a web that referred _layouts-paths in the SiteLogoUrl and AlternateCssUrl properties. 
I extended the ObjectWebSettings.PersistFile() to skip URLs referring IIS Virtual Directories.
