### PR TITLE
Fixed Publishing provisioning if web is compliant and template specif…

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPublishing.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPublishing.cs
@@ -318,7 +318,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         }
                     }
                 }
-                else
+                else if(!webFeatureActive)
                 {
                     throw new Exception("Publishing Feature not active. Provisioning failed");
                 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?

If specifying AutoCheckRequirements="FailIfNotCompliant" in the Publishing node of the provisioning template an exception will be thrown during provisioning even if the web is compliant. This happens due to failure to check if web is compliant before throwing exception.