### PR TITLE
Fixed the directory recursion issue - #898

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
@@ -530,11 +530,17 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             if (directory.Recursive)
             {
                 var subFolders = directory.ParentTemplate.Connector.GetFolders(directory.Src);
+                var parentFolder = directory;
                 foreach (var folder in subFolders)
                 {
-                    directory.Src += @"\" + folder;
-                    directory.Folder += @"\" + folder;
+                    directory.Src = parentFolder.Src + @"\" + folder;
+                    directory.Folder = parentFolder.Folder + @"\" + folder;
+
                     result.AddRange(directory.GetDirectoryFiles(metadataProperties));
+
+                    //Remove the subfolder path(added above) as the second subfolder should come under its parent folder and not under its sibling
+                    parentFolder.Src = parentFolder.Src.Substring(0, parentFolder.Src.LastIndexOf(@"\"));
+                    parentFolder.Folder = parentFolder.Folder.Substring(0, parentFolder.Folder.LastIndexOf(@"\"));
                 }
             }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | Yes
| New feature?    | No
| New sample?      | No
| Related issues?  | #898 

#### What's in this Pull Request?

Please describe the changes in this PR. Sample description or details around bugs which are being fixed.

In case of folder hierarchy more than two level deep with multiple folders as siblings inside a parent folder, the ObjectFiles.cs code fails.

In recursion code below, when you have sibling folder under a parent folder, the code breaks when in case of recursion for second sibling.
                foreach (var folder in subFolders)
                {
                    directory.Src += @"\" + folder;
                    directory.Folder += @"\" + folder;
                    result.AddRange(directory.GetDirectoryFiles(metadataProperties));
                }

I've made a fix by removing the last folder name added to the path using substring method.
