### PR TITLE
Fix the GetWebPartXML function

### DIFF
--- a/Core/OfficeDevPnP.Core/AppModelExtensions/PageExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/PageExtensions.cs
@@ -383,11 +383,9 @@ namespace Microsoft.SharePoint.Client
                 var uri = new Uri(web.Context.Url);
                 var serverRelativeUrl = web.EnsureProperty(w => w.ServerRelativeUrl);
                 
-                    var webUrl = uri.Port !- 80 and uri.Port != 443 ? $"{uri.Scheme}://{uri.Host}:{uri.Port}{serverRelativeUrl}" : $"{uri.Scheme}://{uri.Host}{serverRelativeUrl}";
-                    var pageUrl = uri.Port !- 80 and uri.Port != 443 ? $"{uri.Scheme}://{uri.Host}:{uri.Port}{serverRelativePageUrl}" : "{uri.Scheme}://{uri.Host}{serverRelativePageUrl}";
-                if(webUrl.endsWith("/")) {
-                    webUrl = webUrl.substring(0, webUrl.length-1);
-                }
+                var webUrl =  $"{uri.Scheme}://{uri.Host}:{uri.Port}{serverRelativeUrl}";
+                var pageUrl = $"{uri.Scheme}://{uri.Host}:{uri.Port}{serverRelativePageUrl}";
+                webUrl = UrlUtility.EnsureTrailingSlash(webUrl);
                 var request = (HttpWebRequest)WebRequest.Create($"{webUrl}_vti_bin/exportwp.aspx?pageurl={pageUrl}&guidstring={id}");
 
                 request.Credentials = web.Context.Credentials;

--- a/Core/OfficeDevPnP.Core/AppModelExtensions/PageExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/PageExtensions.cs
@@ -382,9 +382,13 @@ namespace Microsoft.SharePoint.Client
                 }
                 var uri = new Uri(web.Context.Url);
                 var serverRelativeUrl = web.EnsureProperty(w => w.ServerRelativeUrl);
-                var webUrl = $"{uri.Scheme}://{uri.Host}{serverRelativeUrl}";
-                var pageUrl = $"{uri.Scheme}://{uri.Host}{serverRelativePageUrl}";
-                var request = (HttpWebRequest)WebRequest.Create($"{webUrl}/_vti_bin/exportwp.aspx?pageurl={pageUrl}&guidstring={id}");
+                
+                    var webUrl = uri.Port !- 80 and uri.Port != 443 ? $"{uri.Scheme}://{uri.Host}:{uri.Port}{serverRelativeUrl}" : $"{uri.Scheme}://{uri.Host}{serverRelativeUrl}";
+                    var pageUrl = uri.Port !- 80 and uri.Port != 443 ? $"{uri.Scheme}://{uri.Host}:{uri.Port}{serverRelativePageUrl}" : "{uri.Scheme}://{uri.Host}{serverRelativePageUrl}";
+                if(webUrl.endsWith("/")) {
+                    webUrl = webUrl.substring(0, webUrl.length-1);
+                }
+                var request = (HttpWebRequest)WebRequest.Create($"{webUrl}_vti_bin/exportwp.aspx?pageurl={pageUrl}&guidstring={id}");
 
                 request.Credentials = web.Context.Credentials;
 


### PR DESCRIPTION
Fix an issue with GetWebPartXML which creates a bad URL request "//_vti_bin/exportwp.aspx" when run on the root web, and fix so that it includes port information when port information is not 80 or 443.

| Q               | A
| --------------- | ---
| Bug fix?        | Yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #907

#### What's in this Pull Request?

Fix an issue with GetWebPartXML which creates a bad URL request "//_vti_bin/exportwp.aspx" when run on the root web, and fix so that it includes port information when port information is not 80 or 443.
