### PR TITLE
Template creation: Add some automatic fields that don't need to be referenced

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -1724,7 +1724,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                             field.InternalName == "FileLeafRef" ||
                             field.InternalName == "FileSizeDisplay" ||
                             field.InternalName == "Preview" ||
-                            field.InternalName == "ThumbnailOnForm")
+                            field.InternalName == "ThumbnailOnForm" ||
+                            field.InternalName == "CheckoutUser" ||
+                            field.InternalName == "Modified_x0020_By" ||
+                            field.InternalName == "Created_x0020_By"
+                            )
                         {
                             addField = false;
                         }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no 
| New sample?      | no 
| Related issues?  | -

#### What's in this Pull Request?

I created a template from a migrated SharePoint 2010 site collection. I found that the template contained some field references to automatic fields that caused errors during provisioning.

I seems like old site collections can use different names for some out of the box fields. 
As a quick fix I added the names that were in my site collection to the code. In the long run we should use the Field.ID property to identify those fields by their Guid.