### PR TITLE
Allow manage permissions on subsite

### DIFF
--- a/Core/OfficeDevPnP.Core.sln
+++ b/Core/OfficeDevPnP.Core.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeDevPnP.Core", "OfficeDevPnP.Core\OfficeDevPnP.Core.csproj", "{F2077977-8EBF-409D-BBF4-8EFB328928A8}"
 EndProject


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no 
| New sample?      | no 
| Related issues?  | fixes #806 and #167 

#### What's in this Pull Request?
When using unique permissions in a subsite any new groups listed in the pnp:security were not added, any missing role definitions would trip up the engine causing a failure. Added code to generate a warning in the log & removed the check for subsite (as mentioned in the same function at the top by Paolo Pialorsi)
