### PR TITLE
Re index patch

### DIFF
--- a/Core/OfficeDevPnP.Core/AppModelExtensions/ListExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/ListExtensions.cs
@@ -1377,7 +1377,14 @@ namespace Microsoft.SharePoint.Client
             {
                 searchversion = (int)list.GetPropertyBagValueInt(reIndexKey, 0);
             }
-            list.SetPropertyBagValue(reIndexKey, searchversion + 1);
+            try
+            {
+                list.SetPropertyBagValue(reIndexKey, searchversion + 1);
+            }
+            catch (ServerUnauthorizedAccessException)
+            {
+                Log.Warning(Constants.LOGGING_SOURCE, CoreResources.ListExtensions_SkipNoCrawlLists);
+            }
         }
     }
 }

--- a/Core/OfficeDevPnP.Core/AppModelExtensions/WebExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/WebExtensions.cs
@@ -332,7 +332,7 @@ namespace Microsoft.SharePoint.Client
         public static bool IsNoScriptSite(this Web web)
         {
 #if !ONPREMISES
-            string[] NoScriptSiteTemplates = new string[] { "GROUP" };
+            string[] NoScriptSiteTemplates = new string[] { "GROUP", "POINTPUBLISHINGTOPIC", "POINTPUBLISHINGPERSONAL" };
             web.EnsureProperties(w => w.WebTemplate, w => w.EffectiveBasePermissions);
 
             // Definition of no-script is not having the AddAndCustomizePages permission


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| Related issues?  | fixes #895 

#### What's in this Pull Request?

Re-added check for new blog and video portal templates to be skipped using re-indexed on root property bag, as they seemed to have been list in the refactoring done by @jansenbe. 

Added try/catch on list re-index as some lists cannot be updated - and they should be skipped. Eg. *Forms Designer* list