### PR TITLE
Replaces static for normal variables for Timerjob #936

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/TimerJobs/TimerJob.cs
+++ b/Core/OfficeDevPnP.Core/Framework/TimerJobs/TimerJob.cs
@@ -63,8 +63,8 @@ namespace OfficeDevPnP.Core.Framework.TimerJobs
         private List<string> sitesToProcess;
         private bool expandSubSites = false;
         // Threading
-        private static int numberOfThreadsNotYetCompleted;
-        private static ManualResetEvent doneEvent;
+        private int numberOfThreadsNotYetCompleted;
+        private ManualResetEvent doneEvent;
         private bool useThreading = true;
         private int maximumThreads = 5;
         #endregion


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |  yes
| New feature?    | no
| New sample?      | no
| Related issues?  | Issue 936

#### What's in this Pull Request?

The timerjob class is fixed to not use static variables which gives problems when using multiple timerjobs in a single windows service or console application


