### PR TITLE
Added missing checks for null value when creating a term.

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTermGroups.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTermGroups.cs
@@ -402,8 +402,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                             if (termTerm == null)
                             {
                                 var returnTuple = CreateTerm<Term>(web, modelTermTerm, term, termStore, parser, scope);
-                                modelTermTerm.Id = returnTuple.Item1;
-                                parser = returnTuple.Item2;
+                                if (returnTuple != null)
+                                {
+                                    modelTermTerm.Id = returnTuple.Item1;
+                                    parser = returnTuple.Item2;
+                                }
                             }
                             else
                             {
@@ -418,8 +421,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     else
                     {
                         var returnTuple = CreateTerm<Term>(web, modelTermTerm, term, termStore, parser, scope);
-                        modelTermTerm.Id = returnTuple.Item1;
-                        parser = returnTuple.Item2;
+                        if (returnTuple != null)
+                        {
+                            modelTermTerm.Id = returnTuple.Item1;
+                            parser = returnTuple.Item2;
+                        }
                     }
                 }
                 if (modelTerm.Terms.Any(t => t.CustomSortOrder > -1))


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?

When adding terms that are reused but not the source a null reference exception is thrown because the CreateTerm method will return null in this scenario. there are 5 references to that method and only three has a null check implemented for the return value. I have added this check to the remaining 2 references.