### PR TITLE
PnP Responsive UI improvements and suite bar feature

### DIFF
--- a/Core/OfficeDevPnP.Core/Resources/SP-Responsive-UI.js
+++ b/Core/OfficeDevPnP.Core/Resources/SP-Responsive-UI.js
@@ -1,75 +1,114 @@
-/* PnP SharePoint - Responsiveness */
+/**
+ * PnP SharePoint - Responsiveness
+ * @see {@link https://github.com/SharePoint/PnP-Guidance/blob/master/articles/Embedding-JavaScript-into-SharePoint.md|PnP Guidance}
+ * @see {@link http://usejsdoc.org/|JSDoc}
+ */
 
-var PnPResponsiveApp = PnPResponsiveApp || {};
+/*
+ * PnPResponsiveApp
+ * @namespace
+ */
+if (window.hasOwnProperty('Type')) {
+    Type.registerNamespace('PnPResponsiveApp');
+} else {
+    window.PnPResponsiveApp = window.PnPResponsiveApp || {};
+}
 
-PnPResponsiveApp.responsivizeSettings = function () {
-    // return if no longer on Settings page
-    if (window.location.href.indexOf('/settings.aspx') < 0) return;
-
-    // find the Settings root element, or wait if not available yet
-    var settingsRoot = $(".ms-siteSettings-root");
-    if (!settingsRoot.length) {
-        setTimeout(PnPResponsiveApp.responsivizeSettings, 100);
-        return;
+/**
+ * PnP Responsive
+ * @class
+ */
+PnPResponsiveApp.Main = (function () {
+    /**
+     * Toggle element class
+     * @param {element} el - Element
+     * @param {string} cls - CSS Class Name
+     * @private
+     */
+    function toggleClass(el, cls) {
+        if (hasClass(el, cls)) {
+            var reg = new RegExp('(\\s|^)' + cls + '(\\s|$)');
+            el.className = el.className.replace(reg, ' ');
+        } else {
+            el.className = el.className + ' ' + cls;
+        }
     }
 
-    $(".ms-siteSettings-root .ms-linksection-level1").each(function () {
-        var self = $(this);
-        var settingsDiv = $('<div>');
-        settingsDiv.addClass("pnp-settingsdiv");
-        self.find(".ms-linksection-iconCell img").appendTo(settingsDiv);
-        self.find(".ms-linksection-textCell").children().appendTo(settingsDiv);
-        settingsDiv.appendTo(settingsRoot);
-    });
-    settingsRoot.find("table").remove();
-};
+    /**
+     * Check if className exists
+     * @param {element} el - Element
+     * @param {string} cls - CSS Class Name
+     * @returns {boolean} True if element has css class
+     * @private
+     */
+    function hasClass(el, cls) {
+        try {
+            return (' ' + el.className + ' ').indexOf(' ' + cls + ' ') === -1 ? false : true;
+        } catch (hc) {
+            return false;
+        }
+    }
 
-PnPResponsiveApp.setUpToggling = function () {
-    // if it is already responsivized, return
-    if ($("#navbar-toggle").length)
-        return;
+    /**
+     * Dynamic CSS/JS embedding and loading
+     * @private
+     */
+    function loadCSS(url) {
+        var head = document.getElementsByTagName('head')[0];
+        var style = document.createElement('link');
+        style.type = 'text/css';
+        style.rel = 'stylesheet';
+        style.href = url;
+        head.appendChild(style);
+    }
 
-    // Set up sidenav toggling
-    var topNav = $('#DeltaTopNavigation');
-    var topNavClone = topNav.clone();
-    topNavClone.addClass('mobile-only');
-    topNavClone.attr('id', topNavClone.attr('id') + "_mobileClone");
-    topNav.addClass('no-mobile');
-    $('#sideNavBox').append(topNavClone);
-    var sideNavToggle = $('<button>');
-    sideNavToggle.attr('id', 'navbar-toggle');
-    sideNavToggle.addClass('mobile-only');
-    sideNavToggle.addClass('burger');
-    sideNavToggle.attr('type', 'button');
-    sideNavToggle.html("<span></span>");
-    sideNavToggle.click(function () {
-        $("body").toggleClass('shownav');
-        sideNavToggle.toggleClass('selected');
-    });
-    $("#pageTitle").before(sideNavToggle);
-};
+    /**
+     * Change element ID and all childs to avoid duplicates
+     * Add a feature to manage the case of attributes for the suiteBarButtons
+     * @param {element} el - Cloned Element
+     * @returns {element} Cloned Element with all childs with a unique id
+     * @private
+     */
+    function cloneSPIdNodes(el) {
+        el.id = el.getAttribute('id') + '_mobileClone';
+        var childs = el.getElementsByTagName('*');
+        /* Regex to Get all SiteActionsMenuMain and SiteActionsMenu occurences in childs attributes */
+        var regex = new RegExp("(.*?zz.*?(?:_SiteActionsMenuMain|_SiteActionsMenu))", "g");
+        for (var n = 0; n < childs.length; n++) {
+            if (childs[n].id) {
+                /* Update All Attributes that contains Regex ID */
+                var allAttributes = childs[n].attributes;
+                for (var a = 0; a < allAttributes.length; a++) {
+                    if (allAttributes[a].name != 'id') {
+                        allAttributes[a].value = allAttributes[a].value.replace(regex, "$1_mobileClone");
+                    }
+                }
+                /* Update Child ID */
+                childs[n].id = childs[n].getAttribute('id') + '_mobileClone';
+            }
+        }
+        return el;
+    }
 
-PnPResponsiveApp.init = function () {
-    if (!window.jQuery) {
-        // jQuery is needed for PnP Responsive UI to run, and is not fully loaded yet, try later
-        setTimeout(PnPResponsiveApp.init, 100);
-    } else {
-        $(function () { // only execute when DOM is fully loaded
-
-            // embedding and loading of all necessary CSS files and JS libraries
-            var currentScriptUrl = $('#PnPResponsiveUI').attr('src');
+    return {
+        /**
+         * PnP Responsive Initialization
+         * @constructor
+         * @public
+         */
+        init: function () {
+            var currentScriptUrl = document.getElementById('PnPResponsiveUI').src;
             if (currentScriptUrl != undefined) {
-                var currentScriptBaseUrl = currentScriptUrl.substring(0, currentScriptUrl.lastIndexOf("/") + 1);
-
-                addViewport();
+                var currentScriptBaseUrl = currentScriptUrl.substring(0, currentScriptUrl.lastIndexOf('/') + 1);
                 loadCSS(currentScriptBaseUrl + 'sp-responsive-ui.css');
             }
 
-            PnPResponsiveApp.setUpToggling();
-            PnPResponsiveApp.responsivizeSettings();
+            PnPResponsiveApp.Main.setUpToggling();
+            PnPResponsiveApp.Main.responsivizeSettings();
+            PnPResponsiveApp.Main.setUpSuiteBarToogling();
 
             // also listen for dynamic page change to Settings page
-            window.onhashchange = function () { PnPResponsiveApp.responsivizeSettings(); };
+            window.onhashchange = function () { PnPResponsiveApp.Main.responsivizeSettings(); };
 
             // Extend/override some SP native functions to fix resizing quirks
 
@@ -81,40 +120,149 @@ PnPResponsiveApp.init = function () {
                 // let sharepoint do its thing
                 originalResizeFunction();
                 // fix the body container width
-                $("#s4-bodyContainer").width($("#s4-workspace").width());
+                document.getElementById('s4-bodyContainer').style.width = document.getElementById('s4-workspace').offsetWidth;
             };
-        });
-    }
-};
+        },
+        /**
+         * Add viewport and support retina devices
+         * @public
+         */
+        addViewport: function () {
+            var head = document.getElementsByTagName('head')[0];
+            var viewport = document.createElement('meta');
+            viewport.name = 'viewport';
+            if (window.devicePixelRatio == 2) {
+                viewport.content = 'width=device-width, user-scalable=no, initial-scale=.5, maximum-scale=.5, minimum-scale=.5';
+            } else {
+                viewport.content = 'width=device-width, user-scalable=yes, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0';
+            }
+            var appleMeta = document.createElement('meta');
+            appleMeta.name = 'apple-mobile-web-app-capable';
+            appleMeta.content = 'yes';
+            head.appendChild(viewport);
+            head.appendChild(appleMeta);
+        },
+        /**
+         * Manage SharePoint Settings Page Responsive
+         * @public
+         */
+        responsivizeSettings: function () {
+            /* return if no longer on Settings page */
+            if (window.location.href.indexOf('/settings.aspx') < 0) return;
 
-/* Dynamic CSS/JS embedding and loading */
-function loadCSS(url) {
-    var head = document.getElementsByTagName('head')[0];
-    var style = document.createElement('link');
-	style.type = 'text/css';
-	style.rel = 'stylesheet';
-    style.href = url;
-    head.appendChild(style);
-}
-function loadScript(url, callback) {
-    var head = document.getElementsByTagName('head')[0];
-    var script = document.createElement('script');
-    script.type = 'text/javascript';
-    script.src = url;
-    script.onreadystatechange = callback;
-    script.onload = callback;
-    head.appendChild(script);
-}
-function addViewport() {
-    var head = document.getElementsByTagName('head')[0];
-    var viewport = document.createElement('meta');
-    viewport.name= "viewport";
-    viewport.content= "width=device-width, initial-scale=1"; 
-    head.appendChild(viewport);
-}
+            /* find the Settings root element, or wait if not available yet */
+            var settingsRoot = document.getElementsByClassName('ms-siteSettings-root')[0];
+            if (!settingsRoot) {
+                setTimeout(PnPResponsiveApp.Main.responsivizeSettings, 100);
+                return;
+            }
 
+            var linkSettingsSectionsLvl = settingsRoot.getElementsByClassName('ms-linksection-level1');
+            for (var i = 0; i < linkSettingsSectionsLvl.length; i++) {
+                var self = linkSettingsSectionsLvl[i];
+                var settingsDiv = document.createElement('div');
+                settingsDiv.className = 'pnp-settingsdiv';
+                settingsDiv.appendChild(self.getElementsByTagName('img')[0]);
+                settingsDiv.appendChild(self.getElementsByClassName('ms-linksection-textCell')[0]);
+                settingsRoot.appendChild(settingsDiv);
+            }
+            if (settingsRoot.getElementsByTagName('table')[0]) {
+                settingsRoot.removeChild(settingsRoot.getElementsByTagName('table')[0]);
+            }
+        },
+        /**
+         * Set up Toggle Button to Hide or Show responsive menu
+         * @public
+         */
+        setUpToggling: function () {
+            /* if it is already responsivized, return */
+            if (document.getElementById('navbar-toggle')) { return; }
 
-// embedding of jQuery, and initialization of responsiveness when ready
-loadScript("//code.jquery.com/jquery-1.12.0.min.js", function() {
-    PnPResponsiveApp.init();
-});
+            /* Set up sidenav toggling */
+            var topNav = document.getElementById('DeltaTopNavigation');
+            var topNavClone = topNav.cloneNode(true);
+            topNavClone.className = topNavClone.className + ' mobile-only';
+            topNavClone = cloneSPIdNodes(topNavClone);
+            topNav.className = topNav.className + ' no-mobile';
+            document.getElementById('sideNavBox').appendChild(topNavClone);
+
+            var sideNavToggle = document.createElement('button');
+            sideNavToggle.id = 'navbar-toggle';
+            sideNavToggle.className = 'mobile-only burger';
+            sideNavToggle.type = 'button';
+            sideNavToggle.innerHTML = '<span></span>';
+            sideNavToggle.addEventListener('click', function () {
+                toggleClass(document.getElementsByTagName('body')[0], 'shownav');
+                toggleClass(sideNavToggle, 'selected');
+            });
+            document.getElementById('pageTitle').parentNode.insertBefore(sideNavToggle, document.getElementById('pageTitle'));
+        },
+        /**
+         * Set Up Toggle and Top SuiteBar Responsive
+         * Available only for SharePoint 2013 (SharePoint 2016/Online have already a responsive suiteBar)
+         * @public
+         */
+        setUpSuiteBarToogling: function () {
+            if (document.getElementById('suiteBar')) {
+                /* Open Responsive Bar Button that replace Suite Bar Links */
+                var suiteBarToggle = document.createElement('button');
+                suiteBarToggle.id = 'suiteBar-open';
+                suiteBarToggle.className = 'mobile-only ms-button-emphasize';
+                suiteBarToggle.type = 'button';
+                suiteBarToggle.innerHTML = '<span></span>';
+                suiteBarToggle.addEventListener('click', function () {
+                    if (document.getElementById('suiteBar-rwd')) {
+                        toggleClass(document.getElementById('suiteBar-rwd'), 'ms-hide');
+                    }
+                });
+                document.getElementById('DeltaSuiteLinks').appendChild(suiteBarToggle);
+            }
+            PnPResponsiveApp.Main.setUpSuiteBarRwd();
+        },
+        /**
+         * Build and render Suite Bar Rwd Mode
+         * @public
+         */
+        setUpSuiteBarRwd: function () {
+            /* if it is already responsivized, return */
+            if (document.getElementById('suiteBar-rwd')) { return; }
+
+            /*
+             * Get if it's SharePoint 2013 environment
+             * 
+             * suiteBar is used by SharePoint 2013
+             * suiteBarDelta is used by SharePoint 2016/Online
+             */
+            if (document.getElementById('suiteBar')) {
+                /* Clone Suite Bar Buttons */
+                var suiteBarBtn = document.getElementById('suiteBarButtons');
+                var suiteBarBtnClone = suiteBarBtn.cloneNode(true);
+                suiteBarBtnClone = cloneSPIdNodes(suiteBarBtnClone);
+                /* Clone Suite Bar links (Newsfeed, OneDrive, Sites, etc.) */
+                var suiteLinksBox = document.getElementById('suiteLinksBox');
+                var suiteLinksBoxClone = suiteLinksBox.cloneNode(true);
+                suiteLinksBoxClone = cloneSPIdNodes(suiteLinksBoxClone);
+                /* Create responsive bar */
+                var suiteBarRwd = document.createElement('div');
+                suiteBarRwd.id = 'suiteBar-rwd';
+                suiteBarRwd.className = 'mobile-only ms-rteThemeBackColor-5-0 ms-hide';
+                /* Close Responsive Bar Button */
+                var closeSuiteBarRwd = document.createElement('button');
+                closeSuiteBarRwd.id = 'suiteBar-close';
+                closeSuiteBarRwd.type = 'button';
+                closeSuiteBarRwd.className = 'ms-button-emphasize';
+                closeSuiteBarRwd.addEventListener('click', function () {
+                    toggleClass(document.getElementById('suiteBar-rwd'), 'ms-hide');
+                });
+                /* Render Responsive Bar */
+                suiteBarRwd.appendChild(closeSuiteBarRwd);
+                suiteBarRwd.appendChild(suiteBarBtnClone);
+                suiteBarRwd.appendChild(suiteLinksBoxClone);
+                document.getElementById('aspnetForm').insertBefore(suiteBarRwd, document.getElementById('suiteBar'));
+            }
+        }
+    };
+})();
+
+PnPResponsiveApp.Main.addViewport();
+PnPResponsiveApp.Main.init();

--- a/Core/OfficeDevPnP.Core/Resources/SP-Responsive-UI_CSS.css
+++ b/Core/OfficeDevPnP.Core/Resources/SP-Responsive-UI_CSS.css
@@ -11,7 +11,7 @@
 }
 
 #contentBox {
-	min-width: auto;
+    min-width: auto;
 }
 
 /* Make sure dialog windows don't break */
@@ -37,62 +37,183 @@
     .no-mobile {
         display: none;
     }
-	
-	/* Mobile and Table Burger styles */
-	.burger {
-		position: relative;
-		left: 0px;
-		top: 0px;
-		padding: 0px 7px;
-		display: inline-block;
-	}
-	.burger span,
-	.burger span:before,
-	.burger span:after {
-		display: block;
-		width: 100%;
-		height: 2px;
-		background: black;
-		-ms-transition: all 0.5s;
-		-webkit-transition: all 0.5s;
-		transition: all 0.5s;
-		-webkit-backface-visibility: hidden;
-		backface-visibility: hidden;
-	}
-	.burger span {
-		position: relative;
-		margin: 0 0 0 0;
-	}
-	.burger span:before,
-	.burger span:after {
-		position: absolute;
-		content: "";
-	}
-	.burger span:before {
-		top: -8px;
-	}
-	.burger span:after {
-		top: 8px;
-	}
-	.burger.selected span:before {
-		-ms-transform: translate(0px, 8px) rotate(90deg);
-		-webkit-transform: translate(0px, 8px) rotate(90deg);
-		transform: translate(0px, 8px) rotate(90deg);
-	}
-	.burger.selected span:after {
-		-ms-transform: translate(0px, -8px) rotate(90deg);
-		-webkit-transform: translate(0px, -8px) rotate(90deg);
-		transform: translate(0px, -8px) rotate(90deg);
-	}
-	.burger.selected span {
-		-ms-transform: rotate(-45deg);
-		-webkit-transform: rotate(-45deg);
-		transform: rotate(-45deg);
-	}
 
+    /* Mobile and Table Burger styles */
+    .burger {
+        position: relative;
+        left: 0px;
+        top: 0px;
+        padding: 0px 7px;
+        display: inline-block;
+    }
+
+        #suiteBar-rwd > #suiteBar-close:before,
+        #suiteBar-rwd > #suiteBar-close:after,
+        .burger span,
+        .burger span:before,
+        .burger span:after {
+            display: block;
+            width: 100%;
+            height: 2px;
+            background: black;
+            -ms-transition: all 0.5s;
+            -webkit-transition: all 0.5s;
+            transition: all 0.5s;
+            -webkit-backface-visibility: hidden;
+            backface-visibility: hidden;
+        }
+
+        .burger span {
+            position: relative;
+            margin: 0 0 0 0;
+        }
+
+            #suiteBar-rwd > #suiteBar-close:before,
+            #suiteBar-rwd > #suiteBar-close:after,
+            .burger span:before,
+            .burger span:after {
+                position: absolute;
+                content: "";
+            }
+
+            #suiteBar-rwd > #suiteBar-close:before,
+            .burger span:before {
+                top: -8px;
+            }
+
+            #suiteBar-rwd > #suiteBar-close:after,
+            .burger span:after {
+                top: 8px;
+            }
+
+        .burger.selected span:before {
+            -ms-transform: translate(0px, 8px) rotate(90deg);
+            -webkit-transform: translate(0px, 8px) rotate(90deg);
+            transform: translate(0px, 8px) rotate(90deg);
+        }
+
+        .burger.selected span:after {
+            -ms-transform: translate(0px, -8px) rotate(90deg);
+            -webkit-transform: translate(0px, -8px) rotate(90deg);
+            transform: translate(0px, -8px) rotate(90deg);
+        }
+
+        .burger.selected span {
+            -ms-transform: rotate(-45deg);
+            -webkit-transform: rotate(-45deg);
+            transform: rotate(-45deg);
+        }
+
+    #DeltaSuiteLinks > #suiteLinksBox {
+        display: none;
+    }
+
+    #suiteBar-open {
+        float: right;
+        height: 30px;
+        min-width: auto;
+        border: 0;
+        padding-top: 2px;
+    }
+
+        #suiteBar-open > span {
+            line-height: 20px;
+        }
+
+        #suiteBar-open:hover {
+            cursor: pointer;
+        }
+
+        #suiteBar-open > span:before {
+            content: '\2219 \2219 \2219';
+            font-size: 40px;
+            color: #fff;
+        }
+
+    #suiteBar-rwd {
+        position: absolute;
+        top: 0;
+        left: 0;
+        height: 30px;
+        width: 100%;
+        z-index: 1;
+    }
+
+        #suiteBar-rwd.mobile-only.ms-hide {
+            display: none;
+        }
+
+        #suiteBar-rwd > #suiteBar-close {
+            min-width: 40px;
+            height: 30px;
+            margin-left: 0;
+            border: 0;
+        }
+
+            #suiteBar-rwd > #suiteBar-close:hover {
+                cursor: pointer;
+            }
+
+            #suiteBar-rwd > #suiteBar-close:before {
+                -ms-transform: translate(0px, 22px) rotate(-45deg);
+                -webkit-transform: translate(0px, 21px) rotate(-45deg);
+                transform: translate(0px, 21px) rotate(-45deg);
+                background: #fff;
+                height: 3px;
+                width: 20px;
+            }
+
+            #suiteBar-rwd > #suiteBar-close:after {
+                -ms-transform: translate(0px, 5px) rotate(45deg);
+                -webkit-transform: translate(0px, 5px) rotate(45deg);
+                transform: translate(0px, 5px) rotate(45eg);
+                background: #fff;
+                height: 3px;
+                width: 20px;
+            }
+
+        #suiteBar-rwd > #suiteBarButtons_mobileClone {
+            float: right;
+            background-color: rgb( 239, 239, 239);
+            padding-right: 5px;
+        }
+
+    #suiteBarButtons {
+        display: none;
+    }
+
+    #suiteBar-rwd #suiteLinksBox_mobileClone {
+        float: right;
+    }
+    /*
+    * Support mobileClone Style to arrow of Suite Active Links
+    */
+    #suiteBar-rwd #Suite_ActiveLinkIndicator_Clip_mobileClone {
+        display: inline-block;
+        left: 50%;
+        position: absolute;
+        top: 16px;
+        z-index: 102;
+    }
+    /*
+    * Support mobileClone Style to Settings icon
+    */
+    #suiteBar-rwd .ms-siteactions-root > span > a.ms-selectedtitle,
+    #suiteBar-rwd .ms-siteactions-root > span > a.ms-unselectedtitle {
+        width: 16px;
+        height: 16px;
+        display: inline-block;
+        padding: 8px 7px 6px 8px;
+        border: 0;
+    }
+    /*
+    * Hide EDIT LINK from top navigation
+    */
+    a[id*='TopNavigationMenu_NavMenu_EditLinks'],
+    a[id*='TopNavigationMenuV4_NavMenu_EditLinks'] {
+        display: none;
+    }
 }
-
-
 
 /* Tablets */
 @media only screen and (min-width: 481px) and (max-width : 768px) {
@@ -110,7 +231,7 @@
         position: absolute;
         top: 0;
         left: 0;
-		width: 21px;
+        width: 21px;
         height: 73px;
         padding: 5px;
     }
@@ -184,10 +305,10 @@
         display: block;
     }
 
-    table#layoutsTable > tbody > tr > td {
-        width: auto !important;
-        padding: 0;
-    }
+        table#layoutsTable > tbody > tr > td {
+            width: auto !important;
+            padding: 0;
+        }
 
     table.ms-listviewtable {
         border-collapse: collapse;
@@ -224,17 +345,17 @@
         margin: 0;
     }
 
-    div#titleAreaRow > div {
-        display: block;
-        float: none;
-        clear: both;
-        margin: 0;
-    }
+        div#titleAreaRow > div {
+            display: block;
+            float: none;
+            clear: both;
+            margin: 0;
+        }
 
-    div#titleAreaRow .ms-core-pageTitle {
-	overflow: hidden;
-	white-space: nowrap;
-    }
+        div#titleAreaRow .ms-core-pageTitle {
+            overflow: hidden;
+            white-space: nowrap;
+        }
 
     #DeltaTopNavigation {
         display: none;
@@ -271,17 +392,17 @@
         display: block;
     }
 
-    div#searchInputBox div.ms-srch-sb > a {
-        float: right;
-    }
+        div#searchInputBox div.ms-srch-sb > a {
+            float: right;
+        }
 
     /* Title breadcrumb */
     #pageTitle #DeltaPlaceHolderPageTitleInTitleArea > span > span:not(:last-child-of-type) {
-	font-size: .4em;
+        font-size: .4em;
     }
 
     #pageTitle #DeltaPlaceHolderPageTitleInTitleArea > span > span:last-child-of-type {
-	display: block;
+        display: block;
     }
 
     #pageTitle #DeltaPlaceHolderPageTitleInTitleArea > span > span > span > span {
@@ -289,7 +410,7 @@
     }
 
     #pageTitle #DeltaPlaceHolderPageDescription {
-	display: none;
+        display: none;
     }
 
     /* Breadcrumb navigation in title area */
@@ -310,17 +431,17 @@
     #navbar-toggle {
         margin: 0;
         min-width: 0;
-		width: 33px;
-		height: 33px;
+        width: 33px;
+        height: 33px;
         float: right;
         margin-top: 1.2em;
-		z-index: 100;
-		position: relative;
-		-webkit-box-shadow: -10px -2px 10px 10px #fff;
-		box-shadow: -10px -2px 10px 10px #fff;
+        z-index: 100;
+        position: relative;
+        -webkit-box-shadow: -10px -2px 10px 10px #fff;
+        box-shadow: -10px -2px 10px 10px #fff;
     }
-	
-	#sideNavBox {
+
+    #sideNavBox {
         float: none;
         clear: both;
         width: auto;
@@ -328,7 +449,6 @@
         margin-right: 0;
         margin-left: 0;
         padding-left: 20px;
-
         /* Start out as collapsed*/
         max-height: 0;
         overflow: hidden;
@@ -355,10 +475,10 @@
         display: block;
     }
 
-    table#layoutsTable > tbody > tr > td {
-        width: auto !important;
-        padding: 0;
-    }
+        table#layoutsTable > tbody > tr > td {
+            width: auto !important;
+            padding: 0;
+        }
 
     table.ms-listviewtable {
         border-collapse: collapse;
@@ -380,40 +500,42 @@
 
     /* Fix excessive width of document list view */
     .ms-webpartPage-root {
-	border-spacing: 0;
+        border-spacing: 0;
     }
 
     /* Remove text from icon+text action buttons for document list view */
     .ms-viewlsts .ms-vl-sectionHeaderRow .ms-splinkbutton-text {
-	display: none;
+        display: none;
     }
 
     .ms-viewlsts .ms-vl-sectionHeaderRow .ms-vl-settingsmarginleft {
-	margin-left: 5px;
+        margin-left: 5px;
     }
 
     /* Hide detail columns in document list view */
     .ms-listviewtable thead tr th:nth-child(n+5), .ms-listviewtable tbody tr td:nth-child(n+5) {
-	display: none;
+        display: none;
     }
 
     .ms-qcb-button {
-	padding-right: 5px;
+        padding-right: 5px;
     }
 
     div.ms-dragDropAttract-subtle {
         min-width: auto;
     }
-	
-	/* Newsfeed fixes for mobile less than 450px */
+
+    /* Newsfeed fixes for mobile less than 450px */
     .ms-microfeed-fullMicrofeedDiv, .ms-microfeed-microblogpart, .ms-microfeed-attachmentPreviewDiv, .ms-microfeed-feedPart, .ms-microfeed-rootText {
         min-width: 200px;
     }
-   .ms-microfeed-replyArea {
+
+    .ms-microfeed-replyArea {
         min-width: 150px !important;
         margin-left: 20px !important;
     }
-	.ms-secondaryCommandLink {
+
+    .ms-secondaryCommandLink {
         word-break: break-all;
     }
 }
@@ -428,10 +550,10 @@
     margin-bottom: 20px;
 }
 
-.pnp-settingsdiv:nth-child(last):after {
-    clear: both;
-}
+    .pnp-settingsdiv:nth-child(last):after {
+        clear: both;
+    }
 
-.pnp-settingsdiv img {
-    display: none;
-}
+    .pnp-settingsdiv img {
+        display: none;
+    }


### PR DESCRIPTION
|  Q              | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| New sample?     | no
| Related issues? | [#45 PnP Tool](https://github.com/SharePoint/PnP-Tools/issues/45)

#### What's in this Pull Request?

> I previously submitted a first PR ([#902](https://github.com/SharePoint/PnP-Sites-Core/pull/902)), but I clumsily deleted the fork. In this PR you'll find the ressources of the first one as well as some improvements.

This PR uses the concept of PnP Guidance, resolves some HTML troubles and speed improvement :

- Change PnP Responsive script structure in accordance with PnP Guidance Embedding JavaScript SharePoint (MDS Support)
- Remove the JQuery dependency (Full JavaScipt DOM)
- Speed improvement
- Fix IDs doublons caused by cloneNode JavaScript element
- Hide "EDIT LINK" from cloned Top bar (to avoid feedback that this link doesn't work)
    - [#82 PnP Tool](https://github.com/SharePoint/PnP-Tools/issues/82)
- The new responsive SuiteBar background uses the theme background color
- Support viewport for retina screens

#### Guidance

If you have already deployed PnP Responsive UI, you can replace the JS and CSS files, otherwise, follow the guidance at https://github.com/SharePoint/PnP-Tools/tree/master/Solutions/SharePoint.UI.Responsive and replace the files of this PR

#### Action Plan

|Action|SharePoint 2013|SharePoint 2016|SharePoint Online|
|------|---------------|---------------|-----------------|
|Testing|OK|In progress...|OK|
|Responsive Suite Bar|Available|In progress...|Not Available*|

> Not available * : in this context, the version of SharePoint has already a responsive feature that introduces this behavior. See [Overview](#overview) for more details

<a name="overview"></a>
#### Overview
In the following screenshots you can see a sample rendering of the Home Page of a Team Site, for the three supported rendering models and environments.

|Mode|SharePoint Online|SharePoint 2013|
|-------|-------------------|------------------|
|Desktop|![spo_desktop_suitebar](https://cloud.githubusercontent.com/assets/15279205/21735396/e7c487be-d469-11e6-8111-686978edfa96.png)|![pnpresponsiveui_desktop_suitebar](https://cloud.githubusercontent.com/assets/15279205/21735395/e7c14964-d469-11e6-86ea-1145e4079904.png)|
|Tablet|![spo_tablet_suitebar](https://cloud.githubusercontent.com/assets/15279205/21735401/e7d7a5c4-d469-11e6-87f6-0f68a5ff2074.png)|![pnpresponsiveui_tablet_suitebar_close](https://cloud.githubusercontent.com/assets/15279205/21735399/e7c7b07e-d469-11e6-9226-22ab27edcc42.png)|
|SmartPhone|![spo_mobile_suitebar_close](https://cloud.githubusercontent.com/assets/15279205/21735397/e7c4981c-d469-11e6-8458-2a23a19e5429.png)|![pnpresponsiveui_mobile_suitebar_close](https://cloud.githubusercontent.com/assets/15279205/21735398/e7c65c7e-d469-11e6-9f73-c85aedb1fab2.png)![pnpresponsiveui_mobile_suitebar_open](https://cloud.githubusercontent.com/assets/15279205/21735400/e7ca09f0-d469-11e6-9bf7-eab830fd3347.png)|
