### PR TITLE
Fix in composed look extraction : Files handler shouldn't be added if…

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectComposedLook.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectComposedLook.cs
@@ -130,27 +130,27 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                             DownLoadFile(spConnector, spConnectorRoot, creationInfo.FileConnector, web.Url, parser.ParseString(composedLook.BackgroundFile), scope);
                             DownLoadFile(spConnector, spConnectorRoot, creationInfo.FileConnector, web.Url, parser.ParseString(composedLook.ColorFile), scope);
                             DownLoadFile(spConnector, spConnectorRoot, creationInfo.FileConnector, web.Url, parser.ParseString(composedLook.FontFile), scope);
-                        }
-                        // Create file entries for the custom theme files  
-                        if (!string.IsNullOrEmpty(template.ComposedLook.BackgroundFile))
-                        {
-                            var f = GetComposedLookFile(template.ComposedLook.BackgroundFile);
-                            f.Folder = Tokenize(f.Folder, web.Url);
-                            template.Files.Add(f);
-                        }
-                        if (!string.IsNullOrEmpty(template.ComposedLook.ColorFile))
-                        {
-                            var f = GetComposedLookFile(template.ComposedLook.ColorFile);
-                            f.Folder = Tokenize(f.Folder, web.Url);
-                            template.Files.Add(f);
-                        }
-                        if (!string.IsNullOrEmpty(template.ComposedLook.FontFile))
-                        {
-                            var f = GetComposedLookFile(template.ComposedLook.FontFile);
-                            f.Folder = Tokenize(f.Folder, web.Url);
-                            template.Files.Add(f);
-                        }
 
+                            // Create file entries for the custom theme files  
+                            if (!string.IsNullOrEmpty(template.ComposedLook.BackgroundFile))
+                            {
+                                var f = GetComposedLookFile(template.ComposedLook.BackgroundFile);
+                                f.Folder = Tokenize(f.Folder, web.Url);
+                                template.Files.Add(f);
+                            }
+                            if (!string.IsNullOrEmpty(template.ComposedLook.ColorFile))
+                            {
+                                var f = GetComposedLookFile(template.ComposedLook.ColorFile);
+                                f.Folder = Tokenize(f.Folder, web.Url);
+                                template.Files.Add(f);
+                            }
+                            if (!string.IsNullOrEmpty(template.ComposedLook.FontFile))
+                            {
+                                var f = GetComposedLookFile(template.ComposedLook.FontFile);
+                                f.Folder = Tokenize(f.Folder, web.Url);
+                                template.Files.Add(f);
+                            }
+                        }
                     }
                     catch (JsonSerializationException)
                     {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?

Fix when extracting an existing web with the provisioning engine and using it as a template for creating new sites : composed look files are now added to the template as Files element only if related files have been downloaded. Otherwise provisioning would then fail as it would try to upload non existing files.