### PR TITLE
Added handling of terms with a comma.

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/AppModelExtensions/TaxonomyExtensionsTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/AppModelExtensions/TaxonomyExtensionsTests.cs
@@ -529,14 +529,14 @@ namespace Microsoft.SharePoint.Client.Tests
         }
 
         [TestMethod()]
-        public void HandleTermsWithCommaTest()
+        public void HandleTermsWithCommaQuotesTest()
         {
             using (var clientContext = TestCommon.CreateClientContext())
             {
                 var site = clientContext.Site;
 
                 var termName1 = "Comma,Comma";
-                var termName2 = "Quote \" Quoute";
+                var termName2 = "Quote \" Quote";
 
                 List<string> termLines = new List<string>();
                 string termSrc1 = _termGroupName + "|" + _termSetName + "|\"" + termName1 + "\"";

--- a/Core/OfficeDevPnP.Core.Tests/AppModelExtensions/TaxonomyExtensionsTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/AppModelExtensions/TaxonomyExtensionsTests.cs
@@ -529,20 +529,52 @@ namespace Microsoft.SharePoint.Client.Tests
         }
 
         [TestMethod()]
-        public void HandleTermsWithCommaQuotesTest()
+        public void HandleTermsWithCommaTest()
         {
             using (var clientContext = TestCommon.CreateClientContext())
             {
                 var site = clientContext.Site;
 
                 var termName1 = "Comma,Comma";
-                var termName2 = "Quote \" Quote";
 
                 List<string> termLines = new List<string>();
                 string termSrc1 = _termGroupName + "|" + _termSetName + "|\"" + termName1 + "\"";
+                termLines.Add(termSrc1);
+
+                TaxonomySession session = TaxonomySession.GetTaxonomySession(clientContext);
+                var termStore = session.GetDefaultSiteCollectionTermStore();
+                site.ImportTerms(termLines.ToArray(), 1033, termStore, "|");
+
+                var terms = site.ExportTermSet(_termSetId, false);
+                string termDest1 = terms.SingleOrDefault(t => t.Contains(termName1));
+                Assert.AreEqual(termSrc1, termDest1);
+            }
+        }
+
+        [TestMethod()]
+        public void HandleTermsWithQuotesTest()
+        {
+            using (var clientContext = TestCommon.CreateClientContext())
+            {
+                var site = clientContext.Site;
+
+                var termName1 = "\"Quotes and , comma\"";
+                var termName2 = "Quote \" In the Middle";
+                var termName3 = "\"Quote Start";
+                var termName4 = "Quote End\"";
+                var termName5 = "\"StartQuote \" MiddleQuote";
+
+                List<string> termLines = new List<string>();
+                string termSrc1 = _termGroupName + "|" + _termSetName + "|" + termName1;
                 string termSrc2 = _termGroupName + "|" + _termSetName + "|" + termName2;
+                string termSrc3 = _termGroupName + "|" + _termSetName + "|" + termName3;
+                string termSrc4 = _termGroupName + "|" + _termSetName + "|" + termName4;
+                string termSrc5 = _termGroupName + "|" + _termSetName + "|" + termName5;
                 termLines.Add(termSrc1);
                 termLines.Add(termSrc2);
+                termLines.Add(termSrc3);
+                termLines.Add(termSrc4);
+                termLines.Add(termSrc5);
 
                 TaxonomySession session = TaxonomySession.GetTaxonomySession(clientContext);
                 var termStore = session.GetDefaultSiteCollectionTermStore();
@@ -553,6 +585,12 @@ namespace Microsoft.SharePoint.Client.Tests
                 Assert.AreEqual(termSrc1, termDest1);
                 string termDest2 = terms.SingleOrDefault(t => t.Contains(termName2));
                 Assert.AreEqual(termSrc2, termDest2);
+                string termDest3 = terms.SingleOrDefault(t => t.Contains(termName3));
+                Assert.AreEqual(termSrc3, termDest3);
+                string termDest4 = terms.SingleOrDefault(t => t.Contains(termName4));
+                Assert.AreEqual(termSrc4, termDest4);
+                string termDest5 = terms.SingleOrDefault(t => t.Contains(termName5));
+                Assert.AreEqual(termSrc5, termDest5);
             }
         }
 

--- a/Core/OfficeDevPnP.Core.Tests/AppModelExtensions/TaxonomyExtensionsTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/AppModelExtensions/TaxonomyExtensionsTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Microsoft.SharePoint.Client;
 using OfficeDevPnP.Core.Tests;
 using Microsoft.SharePoint.Client.Taxonomy;
 using System.Linq;
@@ -40,7 +39,7 @@ namespace Microsoft.SharePoint.Client.Tests
                     _termGroupName = "Test_Group_" + DateTime.Now.ToFileTime();
                     _termSetName = "Test_Termset_" + DateTime.Now.ToFileTime();
                     _termName = "Test_Term_" + DateTime.Now.ToFileTime();
-                    
+
                     var taxSession = TaxonomySession.GetTaxonomySession(clientContext);
                     var termStore = taxSession.GetDefaultSiteCollectionTermStore();
 
@@ -530,6 +529,34 @@ namespace Microsoft.SharePoint.Client.Tests
         }
 
         [TestMethod()]
+        public void HandleTermsWithCommaTest()
+        {
+            using (var clientContext = TestCommon.CreateClientContext())
+            {
+                var site = clientContext.Site;
+
+                var termName1 = "Comma,Comma";
+                var termName2 = "Quote \" Quoute";
+
+                List<string> termLines = new List<string>();
+                string termSrc1 = _termGroupName + "|" + _termSetName + "|\"" + termName1 + "\"";
+                string termSrc2 = _termGroupName + "|" + _termSetName + "|" + termName2;
+                termLines.Add(termSrc1);
+                termLines.Add(termSrc2);
+
+                TaxonomySession session = TaxonomySession.GetTaxonomySession(clientContext);
+                var termStore = session.GetDefaultSiteCollectionTermStore();
+                site.ImportTerms(termLines.ToArray(), 1033, termStore, "|");
+
+                var terms = site.ExportTermSet(_termSetId, false);
+                string termDest1 = terms.SingleOrDefault(t => t.Contains(termName1));
+                Assert.AreEqual(termSrc1, termDest1);
+                string termDest2 = terms.SingleOrDefault(t => t.Contains(termName2));
+                Assert.AreEqual(termSrc2, termDest2);
+            }
+        }
+
+        [TestMethod()]
         public void ImportTermSetSampleShouldCreateSetTest()
         {
             var importSetId = Guid.NewGuid();
@@ -552,7 +579,7 @@ namespace Microsoft.SharePoint.Client.Tests
                 var rootCollection = createdSet.Terms;
                 clientContext.Load(createdSet);
                 clientContext.Load(allTerms);
-                clientContext.Load(rootCollection, ts => ts.Include(t=> t.Name, t => t.Description, t => t.IsAvailableForTagging));
+                clientContext.Load(rootCollection, ts => ts.Include(t => t.Name, t => t.Description, t => t.IsAvailableForTagging));
                 clientContext.ExecuteQueryRetry();
 
                 Assert.AreEqual("Political Geography", createdSet.Name);
@@ -601,7 +628,7 @@ namespace Microsoft.SharePoint.Client.Tests
                 var termGroup = termStore.GetGroup(_termGroupId);
 
                 // Act
-                var termSet = termGroup.ImportTermSet(SampleUpdateTermSetPath, UpdateTermSetId, synchroniseDeletions:true, termSetIsOpen:true);
+                var termSet = termGroup.ImportTermSet(SampleUpdateTermSetPath, UpdateTermSetId, synchroniseDeletions: true, termSetIsOpen: true);
             }
 
             using (var clientContext = TestCommon.CreateClientContext())

--- a/Core/OfficeDevPnP.Core/AppModelExtensions/TaxonomyExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/TaxonomyExtensions.cs
@@ -1435,8 +1435,13 @@ namespace Microsoft.SharePoint.Client
         {
             if (name == null)
                 return (string)null;
-            else
-                return TrimSpacesRegex.Replace(name, " ").Replace('＆', '&').Replace('＂', '"');
+
+            name = TrimSpacesRegex.Replace(name, " ").Replace('＆', '&').Replace('＂', '"');
+            if (name.Contains(",") && !name.StartsWith("\"") && !name.EndsWith("\""))
+            {
+                name = '"' + name + '"'; //Add quotes for terms with comma, if not parsing breaks on import
+            }
+            return name;
         }
 
         /// <summary>
@@ -1966,7 +1971,7 @@ namespace Microsoft.SharePoint.Client
                 throw new ArgumentException("Bound TaxonomyItem must be either a TermSet or a Term");
 
             termSet.EnsureProperties(ts => ts.TermStore);
-            
+
             // set the SSP ID and Term Set ID on the taxonomy field
             var taxField = clientContext.CastTo<TaxonomyField>(field);
             taxField.SspId = termSet.TermStore.Id;

--- a/Core/OfficeDevPnP.Core/AppModelExtensions/TaxonomyExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/TaxonomyExtensions.cs
@@ -583,8 +583,6 @@ namespace Microsoft.SharePoint.Client
                 var items = line.Split(new[] { delimiter }, StringSplitOptions.None);
                 if (items.Any())
                 {
-
-
                     List<string> terms = null;
 
                     var groupItem = items[0];
@@ -669,7 +667,7 @@ namespace Microsoft.SharePoint.Client
                                 item = items[q + 2];
                                 item = item.Replace(";#", "|");
                             }
-                            sb.AppendFormat("{0},", item);
+                            sb.AppendFormat("{0},", NormalizeName(item));
                         }
                         if (terms != null)
                         {
@@ -1425,10 +1423,14 @@ namespace Microsoft.SharePoint.Client
 
         private static string NormalizeName(string name)
         {
-            if (name == null)
-                return (string)null;
-            else
-                return TrimSpacesRegex.Replace(name, " ").Replace('&', '＆').Replace('"', '＂');
+            if (name == null) return (string)null;
+            name = TrimSpacesRegex.Replace(name, " ").Replace('&', '＆');
+
+            if (!name.Contains(",") || !name.StartsWith("\"") || !name.EndsWith("\""))
+            {
+                name = name.Replace('"', '＂');
+            }
+            return name;
         }
 
         private static string DenormalizeName(string name)


### PR DESCRIPTION
If term had a comma and no quotes, it would split into parent/child term on import

| Q               | A
| --------------- | ---
| Bug fix?        | yes

#### What's in this Pull Request?

If you have a term with a comma in it, it will be exported as:
`Group|Set|TermX,TermY`

On import this would import **TermX** as parent and **TermY** as child instead of **TermX,TermY**. By adding quotes around it it works as expected.

`Group|Set|"TermX,TermY"`

Also added a test for terms with quotes. Edge case where a term has quotes around it as the label is not handle and currently not supported, as the import will then strip away the quotes.
