### PR TITLE
Possible workaround to fix issue #849

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
@@ -226,6 +226,28 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             return schemaElement.ToString();
         }
 
+        /// <summary>
+        /// Replace Field Internal name by Display Name in the Validation formula
+        /// (due to a SP issue that when provisioning the field, is expecting the Display name)
+        /// https://github.com/SharePoint/PnP-Sites-Core/issues/849
+        /// </summary>
+        /// <param name="field"></param>
+        /// <param name="schemaXml"></param>
+        /// <returns></returns>
+        internal static string TokenizeFieldValidationFormula(SPField field, string schemaXml)
+        {
+            var schemaElement = XElement.Parse(field.SchemaXml);
+
+            var validationNode = schemaElement.Elements("Validation").FirstOrDefault();
+            if (validationNode != null)
+            {
+                var validationNodeValue = validationNode.Value;
+                validationNode.Value = validationNodeValue.Replace(field.InternalName, string.Format("[{0}]", field.Title));
+            }
+
+            return schemaElement.ToString();
+        }
+
         private string ParseFieldSchema(string schemaXml, ListCollection lists)
         {
             foreach (var list in lists)
@@ -558,7 +580,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 _willExtract = true;
             }
             return _willExtract.Value;
-        }
+        }        
     }
 
     internal static class XElementStringExtensions

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -1840,6 +1840,12 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         schemaXml = ObjectField.TokenizeFieldFormula(siteList.Fields, (FieldCalculated)field, schemaXml);
                     }
 
+                    //Field has column Validation
+                    if (fieldElement.Elements("Validation").FirstOrDefault() != null)
+                    {
+                        schemaXml = ObjectField.TokenizeFieldValidationFormula(field, schemaXml);
+                    }
+
                     if (creationInfo.PersistMultiLanguageResources)
                     {
 #if !SP2013


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #849 

#### What's in this Pull Request?

Possible workaround to issue #849. As described in the issue, this is not a problem with PnP Core. Problem is because the Field definition contains the Internal name of the field in the Validation Formula:

```xml
<Field Type="Text" Title="Validate Formula" DisplayName="Validate Formula" Required="FALSE" ID="{41e93963-b9c4-4f33-a8c4-8f1adbb4d40e}" SourceID="{{listid:PnP Issue 849}}" StaticName="Validate_x0020_Formula" Name="Validate_x0020_Formula" ColName="nvarchar3" RowOrdinal="0" Version="3" EnforceUniqueValues="FALSE" Indexed="FALSE" MaxLength="255">
    <Validation Message="Text must contain PnP">=ISNUMBER(FIND("PnP",Validate_x0020_Formula))</Validation>
```
However, with that Internal name, it raises an error when Provisioning, because is expecting the DisplayName. This workaround replaces the internal name by the Display name (enclosed with [])