### PR TITLE
Implement *smart* WillProvision for ObjectLookupField

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/Field.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/Field.cs
@@ -24,7 +24,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model
         public string SchemaXml
         {
             get { return this._schemaXml; }
-            set { this._schemaXml = value; }
+            set
+            {
+                this._xelement = null;
+                this._schemaXml = value;
+            }
         }
 
         /// <summary>

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/Field.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/Field.cs
@@ -10,6 +10,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model
     {
         #region Private Members
         private string _schemaXml = string.Empty;
+        private XElement _xelement = null;
         #endregion
 
         #region Public Properties
@@ -24,6 +25,21 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model
         {
             get { return this._schemaXml; }
             set { this._schemaXml = value; }
+        }
+
+        /// <summary>
+        /// Gets an XElement representation of the SchemaXml property.
+        /// </summary>
+        public XElement SchemaXElement
+        {
+            get
+            {
+                if (this._xelement == null)
+                {
+                    this._xelement = XElement.Parse(this.SchemaXml);
+                }
+                return this._xelement;
+            }
         }
 
         #endregion

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectLookupFields.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectLookupFields.cs
@@ -55,7 +55,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
             foreach (var siteField in template.SiteFields)
             {
-                var fieldElement = XElement.Parse(siteField.SchemaXml);
+                var fieldElement = siteField.SchemaXElement;
 
                 if (fieldElement.Attribute("List") != null)
                 {
@@ -89,7 +89,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             {
                 foreach (var listField in listInstance.Fields)
                 {
-                    var fieldElement = XElement.Parse(listField.SchemaXml);
+                    var fieldElement = listField.SchemaXElement;
                     if (fieldElement.Attribute("List") == null) continue;
 
                     var fieldId = Guid.Parse(fieldElement.Attribute("ID").Value);
@@ -203,7 +203,20 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         {
             if (!_willProvision.HasValue)
             {
-                _willProvision = true;
+                bool hasSiteLookupFields = template
+                    .SiteFields
+                    .Where(x => x.SchemaXElement.Attribute("List") != null)
+                    .Any();
+
+                bool hasListLookupFields = template
+                    .Lists
+                    .Where(x => x
+                                .Fields
+                                .Where(y => y.SchemaXElement.Attribute("List") != null)
+                                .Any())
+                    .Any();
+
+                _willProvision = hasSiteLookupFields || hasListLookupFields;
             }
             return _willProvision.Value;
         }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | Yes
| New feature?    | No
| New sample?      | No
| Related issues?  | N/A

#### What's in this Pull Request?

The WillProvision method for ObjectLookupField was always returning true.  This would in turn always call ProvisionObjects and this would always execute queries against SharePoint before determining if the template had elements applicable to provisioning Lookup Fields.  This change fixes the performance *bug*.
1. Changes WillProvision to only return true if the template has lookup fields in SiteFields or in Lists.
2. Creates a helper property in Field to avoid multiple parsing of SchemaXml (used by WillProvision and ProvisionObjects).  This property returns the parsed XElement from the SchemaXml string and will be re-parsed whenever the underlying SchemaXml changes.

