### PR TITLE
Added localization of list field refs

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -31,7 +31,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             {
                 if (template.Lists.Any())
                 {
-                    var rootWeb = (web.Context as ClientContext).Site.RootWeb;
+                    var rootWeb = ((ClientContext)web.Context).Site.RootWeb;
 
                     web.EnsureProperties(w => w.ServerRelativeUrl, w => w.SupportedUILanguageIds);
 
@@ -131,7 +131,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     #endregion
 
                     #region FieldRefs
-                    
+
                     foreach (var listInfo in processedLists)
                     {
 
@@ -155,11 +155,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                                 if (!listInfo.SiteList.FieldExistsById(fieldRef.Id))
                                 {
-                                    field = CreateFieldRef(listInfo, field, fieldRef);
+                                    field = CreateFieldRef(listInfo, field, fieldRef, parser);
                                 }
                                 else
                                 {
-                                    field = UpdateFieldRef(listInfo.SiteList, field.Id, fieldRef);
+                                    field = UpdateFieldRef(listInfo.SiteList, field.Id, fieldRef, parser);
                                 }
 
                                 field.EnsureProperties(f => f.InternalName, f => f.Title);
@@ -216,7 +216,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                             total = listInfo.TemplateList.Fields.Count;
                             foreach (var field in listInfo.TemplateList.Fields)
                             {
-                                
+
                                 var fieldElement = XElement.Parse(parser.ParseString(field.SchemaXml, "~sitecollection", "~site"));
                                 if (fieldElement.Attribute("ID") == null)
                                 {
@@ -302,11 +302,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                     #region Views
 
-                    
-    
+
+
                     foreach (var listInfo in processedLists)
                     {
-                        
+
 
                         var list = listInfo.TemplateList;
                         var createdList = listInfo.SiteList;
@@ -367,7 +367,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     }
                     web.Context.ExecuteQueryRetry();
 
-                    WriteMessage("Done processing lists",ProvisioningMessageType.Completed);
+                    WriteMessage("Done processing lists", ProvisioningMessageType.Completed);
                 }
             }
             return parser;
@@ -574,7 +574,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             }
         }
 
-        private static Field UpdateFieldRef(List siteList, Guid fieldId, FieldRef fieldRef)
+        private static Field UpdateFieldRef(List siteList, Guid fieldId, FieldRef fieldRef, TokenParser parser)
         {
             // find the field in the list
             var listField = siteList.Fields.GetById(fieldId);
@@ -583,9 +583,16 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             siteList.Context.ExecuteQueryRetry();
 
             var isDirty = false;
-            if (!string.IsNullOrEmpty(fieldRef.DisplayName) && fieldRef.DisplayName != listField.Title)
+            if (!string.IsNullOrEmpty(fieldRef.DisplayName) && (fieldRef.DisplayName != listField.Title || fieldRef.DisplayName.ContainsResourceToken()))
             {
-                listField.Title = fieldRef.DisplayName;
+                if (fieldRef.DisplayName.ContainsResourceToken())
+                {
+                    listField.TitleResource.SetUserResourceValue(fieldRef.DisplayName, parser);
+                }
+                else
+                {
+                    listField.Title = fieldRef.DisplayName;
+                }
                 isDirty = true;
             }
             // We cannot configure Hidden property for Phonetic fields 
@@ -616,7 +623,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             return listField;
         }
 
-        private static Field CreateFieldRef(ListInfo listInfo, Field field, FieldRef fieldRef)
+        private static Field CreateFieldRef(ListInfo listInfo, Field field, FieldRef fieldRef, TokenParser parser)
         {
             field.EnsureProperty(f => f.SchemaXmlWithResourceTokens);
             XElement element = XElement.Parse(field.SchemaXmlWithResourceTokens);
@@ -646,9 +653,16 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             createdField.Context.ExecuteQueryRetry();
 
             var isDirty = false;
-            if (!string.IsNullOrEmpty(fieldRef.DisplayName) && createdField.Title != fieldRef.DisplayName)
+            if (!string.IsNullOrEmpty(fieldRef.DisplayName) && (createdField.Title != fieldRef.DisplayName || fieldRef.DisplayName.ContainsResourceToken()))
             {
-                createdField.Title = fieldRef.DisplayName;
+                if (fieldRef.DisplayName.ContainsResourceToken())
+                {
+                    createdField.TitleResource.SetUserResourceValue(fieldRef.DisplayName, parser);
+                }
+                else
+                {
+                    createdField.Title = fieldRef.DisplayName;
+                }
                 isDirty = true;
             }
             if (createdField.Hidden != fieldRef.Hidden)
@@ -1631,7 +1645,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 }
 
             }
-            WriteMessage("Done processing lists",ProvisioningMessageType.Completed);
+            WriteMessage("Done processing lists", ProvisioningMessageType.Completed);
             return template;
         }
 
@@ -1727,11 +1741,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             }
 
             var fieldsToProcess = siteList.Fields.AsEnumerable().Where(field => !field.Hidden || SpecialFields.Contains(field.InternalName)).ToArray();
-        
-            
+
+
             foreach (var field in fieldsToProcess)
             {
-        
+
                 var siteColumn = siteColumns.FirstOrDefault(sc => sc.Id == field.Id);
                 if (siteColumn != null)
                 {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| New feature?    | yes

#### What's in this Pull Request?

If you add localized site columns directly to a list, they will show as the default language on the list itself. In order to fix this you need to set the **DisplayName** property of the **pnp:FieldRef**. This did not have a handler for localization, which has now been added.

Without this PR the label would the token instead of the resource.

Sample template.

```xml
<pnp:ListInstance Title="{resource:ExternalSharedDocumentsTitle}" TemplateType="101" Url="External Shared Documents" EnableVersioning="true" MinorVersionLimit="0" MaxVersionLimit="0" DraftVersionVisibility="0" OnQuickLaunch="true">
  <pnp:FieldRefs>
    <pnp:FieldRef ID="a063ae0e-a815-41cb-a356-06fe2622259b" Name="{parameter:GenericFieldsPrefix}Country" DisplayName="{resource:SiteDirectory_Country}" />
    <pnp:FieldRef ID="4c4651ce-3825-4611-9c07-d0878170c286" Name="{parameter:GenericFieldsPrefix}ProjectCategory" DisplayName="{resource:SiteDirectory_ProjectCategory}" />
    <pnp:FieldRef ID="f5c54caf-fd83-4e2f-a3ea-993cffe02a20" Name="{parameter:GenericFieldsPrefix}ProjectNumber" DisplayName="{resource:SiteDirectory_ProjectNumber}" />
    <pnp:FieldRef ID="6c957444-79d2-4e88-a993-b01b2952fb12" Name="{parameter:GenericFieldsPrefix}Organization" DisplayName="{resource:SiteDirectory_Organization}" />
  </pnp:FieldRefs>
</pnp:ListInstance>
```