### PR TITLE
Fixed small bug related to handling of OpenXML PnP Packages downloade…

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Connectors/OpenXML/PnPPackageHelper.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Connectors/OpenXML/PnPPackageHelper.cs
@@ -35,7 +35,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors.OpenXML
         public static PnPInfo UnpackTemplate(this MemoryStream stream)
         {
             PnPInfo siteTemplate;
-            using (PnPPackage package = PnPPackage.Open(stream, FileMode.Open, FileAccess.ReadWrite))
+            using (PnPPackage package = PnPPackage.Open(stream, FileMode.Open, 
+                stream.CanWrite ? FileAccess.ReadWrite : FileAccess.Read))
             {
                 siteTemplate = LoadPnPPackage(package);
             }


### PR DESCRIPTION
…d from the templates gallery

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | --

#### What's in this Pull Request?

Fixes the error "cannot open package because filemode or file access value is not valid for the stream" when playing with templates downloaded from the PnP Templates Gallery.