### PR TITLE
Support sub nodes from Top Nav in RWD mode and other improvements

### DIFF
--- a/Core/OfficeDevPnP.Core/Resources/SP-Responsive-UI.js
+++ b/Core/OfficeDevPnP.Core/Resources/SP-Responsive-UI.js
@@ -201,6 +201,8 @@ PnPResponsiveApp.Main = (function () {
                 /* Add button to preserve html link */
                 var expandBtn = document.createElement('button');
                 expandBtn.type = 'button';
+                var expandSpan = document.createElement('span');
+                expandBtn.appendChild(expandSpan);
                 childs[c].parentNode.insertBefore(expandBtn, childs[c]);
                 expandBtn.addEventListener('click', function () {
                     toggleClass(this.parentNode, 'expand');

--- a/Core/OfficeDevPnP.Core/Resources/SP-Responsive-UI.js
+++ b/Core/OfficeDevPnP.Core/Resources/SP-Responsive-UI.js
@@ -195,6 +195,15 @@ PnPResponsiveApp.Main = (function () {
             var topNavClone = topNav.cloneNode(true);
             topNavClone.className = topNavClone.className + ' mobile-only';
             topNavClone = cloneSPIdNodes(topNavClone);
+            /* Sub nodes accordion */
+            var childs = topNavClone.querySelectorAll('a.dynamic-children');
+            for (var c = 0; c < childs.length; c++) {
+                childs[c].href = 'javascript:undefined';
+                childs[c].addEventListener('click', function (e) {
+                    toggleClass(this.parentNode, 'expand');
+                    return false;
+                });
+            }
             topNav.className = topNav.className + ' no-mobile';
             document.getElementById('sideNavBox').appendChild(topNavClone);
 

--- a/Core/OfficeDevPnP.Core/Resources/SP-Responsive-UI.js
+++ b/Core/OfficeDevPnP.Core/Resources/SP-Responsive-UI.js
@@ -144,9 +144,9 @@ PnPResponsiveApp.Main = (function () {
             var viewport = document.createElement('meta');
             viewport.name = 'viewport';
             if (window.devicePixelRatio == 2) {
-                viewport.content = 'width=device-width, user-scalable=no, initial-scale=.5, maximum-scale=.5, minimum-scale=.5';
+                viewport.content = 'width=device-width, user-scalable=yes, initial-scale=.5, shrink-to-fit';
             } else {
-                viewport.content = 'width=device-width, user-scalable=yes, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0';
+                viewport.content = 'width=device-width, user-scalable=yes, initial-scale=1.0, shrink-to-fit';
             }
             var appleMeta = document.createElement('meta');
             appleMeta.name = 'apple-mobile-web-app-capable';
@@ -202,7 +202,7 @@ PnPResponsiveApp.Main = (function () {
                 var expandBtn = document.createElement('button');
                 expandBtn.type = 'button';
                 childs[c].parentNode.insertBefore(expandBtn, childs[c]);
-                expandBtn.addEventListener('click', function (e) {
+                expandBtn.addEventListener('click', function () {
                     toggleClass(this.parentNode, 'expand');
                     return false;
                 });
@@ -291,6 +291,7 @@ PnPResponsiveApp.Main = (function () {
 // Register Responsive Behavior after SP page is loaded
 _spBodyOnLoadFunctionNames.push("responsiveStartup");
 
+/* exported responsiveStartup */
 function responsiveStartup() {
     PnPResponsiveApp.Main.addViewport();
     PnPResponsiveApp.Main.init();

--- a/Core/OfficeDevPnP.Core/Resources/SP-Responsive-UI.js
+++ b/Core/OfficeDevPnP.Core/Resources/SP-Responsive-UI.js
@@ -198,8 +198,11 @@ PnPResponsiveApp.Main = (function () {
             /* Sub nodes accordion */
             var childs = topNavClone.querySelectorAll('a.dynamic-children');
             for (var c = 0; c < childs.length; c++) {
-                childs[c].href = 'javascript:undefined';
-                childs[c].addEventListener('click', function (e) {
+                /* Add button to preserve html link */
+                var expandBtn = document.createElement('button');
+                expandBtn.type = 'button';
+                childs[c].parentNode.insertBefore(expandBtn, childs[c]);
+                expandBtn.addEventListener('click', function (e) {
                     toggleClass(this.parentNode, 'expand');
                     return false;
                 });

--- a/Core/OfficeDevPnP.Core/Resources/SP-Responsive-UI.js
+++ b/Core/OfficeDevPnP.Core/Resources/SP-Responsive-UI.js
@@ -192,6 +192,10 @@ PnPResponsiveApp.Main = (function () {
 
             /* Set up sidenav toggling */
             var topNav = document.getElementById('DeltaTopNavigation');
+            
+            /* No Top Nav */
+            if (topNav == undefined) { return; }
+
             var topNavClone = topNav.cloneNode(true);
             topNavClone.className = topNavClone.className + ' mobile-only';
             topNavClone = cloneSPIdNodes(topNavClone);

--- a/Core/OfficeDevPnP.Core/Resources/SP-Responsive-UI_CSS.css
+++ b/Core/OfficeDevPnP.Core/Resources/SP-Responsive-UI_CSS.css
@@ -141,7 +141,7 @@
         left: 0;
         height: 30px;
         width: 100%;
-        z-index: 1;
+        z-index: 101;
     }
 
         #suiteBar-rwd.mobile-only.ms-hide {

--- a/Core/OfficeDevPnP.Core/Resources/SP-Responsive-UI_CSS.css
+++ b/Core/OfficeDevPnP.Core/Resources/SP-Responsive-UI_CSS.css
@@ -341,6 +341,21 @@
             #DeltaTopNavigation_mobileClone div[id*='TopNavigationMenu'] .dynamic-children.expand > button span::after {
                 transition-delay: 0s, 0.3s;
             }
+
+    /*
+     * PnP Fix : Note Board horizontal scroll
+     */
+    .ms-socialCommentItem .socialcomment-contents {
+        max-width: 100%;
+        width: auto;
+    }
+
+    #siteIcon #DeltaSiteLogo img {
+        height: auto !important;
+        max-height: 75px !important;
+        display: inline-block;
+        vertical-align: middle;
+    }
 }
 
 

--- a/Core/OfficeDevPnP.Core/Resources/SP-Responsive-UI_CSS.css
+++ b/Core/OfficeDevPnP.Core/Resources/SP-Responsive-UI_CSS.css
@@ -535,6 +535,22 @@
         div#searchInputBox div.ms-srch-sb > a {
             float: right;
         }
+
+    /*
+     * Fix Search Tool bar width in WebPart Page
+     */
+    .ms-srch-sb-border,
+    .ms-srch-sb.ms-srch-sb-borderFocused {
+        width: 100%;
+        float: none;
+        margin: 10px 0;
+    }
+
+        .ms-srch-sb-border > a,
+        .ms-srch-sb.ms-srch-sb-borderFocused > a {
+            float: right;
+        }
+
     /* Title breadcrumb */
     #pageTitle #DeltaPlaceHolderPageTitleInTitleArea > span > span:not(:last-child-of-type) {
         font-size: .4em;

--- a/Core/OfficeDevPnP.Core/Resources/SP-Responsive-UI_CSS.css
+++ b/Core/OfficeDevPnP.Core/Resources/SP-Responsive-UI_CSS.css
@@ -2,7 +2,9 @@
     display: none;
 }
 
-#sideNavBox, #contentRow, #siteIcon {
+#sideNavBox,
+#contentRow,
+#siteIcon {
     -webkit-transition: all 400ms ease;
     -moz-transition: all 400ms ease;
     -ms-transition: all 400ms ease;
@@ -14,7 +16,9 @@
     min-width: auto;
 }
 
+
 /* Make sure dialog windows don't break */
+
 .ms-dialog #contentRow {
     margin-left: 0;
 }
@@ -28,8 +32,10 @@
     font-size: 1em;
 }
 
+
 /* Tablet/smartphones common styles for collapsibles */
-@media only screen and (max-width : 768px) {
+
+@media only screen and (max-width: 768px) {
     .mobile-only {
         display: block;
     }
@@ -37,7 +43,6 @@
     .no-mobile {
         display: none;
     }
-
     /* Mobile and Table Burger styles */
     .burger {
         position: relative;
@@ -209,23 +214,19 @@
     /*
     * Hide EDIT LINK from top navigation
     */
-    a[id*='TopNavigationMenu_NavMenu_EditLinks'],
-		a[id*='TopNavigationMenuV4_NavMenu_EditLinks'] {
+    #DeltaTopNavigation_mobileClone a[id*='_NavMenu_EditLinks'] {
         display: none;
     }
-
     /*
     * Support Top Nav rwd as accordion
     */
-    div[id*='TopNavigationMenu_mobileClone'],
-		div[id*='TopNavigationMenuV4_mobileClone'] {
+    #DeltaTopNavigation_mobileClone div[id*='TopNavigationMenu'] {
         width: 100%;
     }
         /*
         * Change position and collapse sub nodes
         */
-        div[id*='TopNavigationMenu_mobileClone'] li.dynamic-children > ul,
-				div[id*='TopNavigationMenuV4_mobileClone'] li.dynamic-children > ul {
+        #DeltaTopNavigation_mobileClone div[id*='TopNavigationMenu'] li.dynamic-children > ul {
             position: inherit;
             border: 0;
             box-shadow: none;
@@ -236,68 +237,116 @@
         /*
         * Expand sub nodes
         */
-        div[id*='TopNavigationMenu_mobileClone'] li.dynamic-children.expand > ul,
-				div[id*='TopNavigationMenuV4_mobileClone'] li.dynamic-children.expand > ul {
+        #DeltaTopNavigation_mobileClone div[id*='TopNavigationMenu'] li.dynamic-children.expand > ul {
             height: auto;
-            padding-left: 25px;
+            padding-left: 15px;
+            border-top-width: 1px;
+            border-top-style: dotted;
+            background-color: inherit;
         }
         /*
         * Nodes position
         */
-        div[id*='TopNavigationMenu_mobileClone'] li.dynamic-children .ms-core-listMenu-item,
-				div[id*='TopNavigationMenuV4_mobileClone'] li.dynamic-children .ms-core-listMenu-item {
+        #DeltaTopNavigation_mobileClone div[id*='TopNavigationMenu'] li.dynamic-children .ms-core-listMenu-item {
             padding: 0;
             margin-right: 0;
+            line-height: 30px;
+            font-size: 1.1em;
         }
         /*
         * Remove arrow background 
         */
-        div[id*='TopNavigationMenu_mobileClone'] .dynamic-children.additional-background,
-        div[id*='TopNavigationMenu_mobileClone'] .dynamic .additional-background.dynamic-children,
-				div[id*='TopNavigationMenuV4_mobileClone'] .dynamic-children.additional-background,
-				div[id*='TopNavigationMenuV4_mobileClone'] .dynamic .additional-background.dynamic-children {
+        #DeltaTopNavigation_mobileClone div[id*='TopNavigationMenu'] .dynamic-children.additional-background,
+        #DeltaTopNavigation_mobileClone div[id*='TopNavigationMenu'] .dynamic .additional-background.dynamic-children {
             background-image: none;
-            padding-left: 5px;
             padding-right: 0;
         }
 
-        div[id*='TopNavigationMenu_mobileClone'] .dynamic-children > a,
-				div[id*='TopNavigationMenuV4_mobileClone'] .dynamic-children > a {
+        #DeltaTopNavigation_mobileClone div[id*='TopNavigationMenu'] .dynamic-children > a {
             display: inline;
         }
         /*
         * Expand/Collapse button style
         */
-        div[id*='TopNavigationMenu_mobileClone'] .dynamic-children > button,
-				div[id*='TopNavigationMenuV4_mobileClone'] .dynamic-children > button {
-            min-width: 16px;
-            width: 16px;
-            height: 16px;
+        #DeltaTopNavigation_mobileClone div[id*='TopNavigationMenu'] .dynamic-children > button {
+            float: right;
+            display: block;
+            position: relative;
+            overflow: hidden;
             margin: 0;
             padding: 0;
+            width: 20px;
+            height: 30px;
+            font-size: 0;
+            text-indent: -9999px;
+            box-shadow: none;
+            border-radius: none;
+            border: none;
+            cursor: pointer;
+            background-color: inherit;
         }
-            /*
-            * content button when collapse
-            */
-            div[id*='TopNavigationMenu_mobileClone'] .dynamic-children > button::before,
-						div[id*='TopNavigationMenuV4_mobileClone'] .dynamic-children > button::before {
-                content: "+";
-                line-height: 12px;
-                vertical-align: top;
+
+            #DeltaTopNavigation_mobileClone div[id*='TopNavigationMenu'] .dynamic-children > button:focus {
+                outline: none;
             }
-        /*
-        * content button when expanded
-        */
-        div[id*='TopNavigationMenu_mobileClone'] .dynamic-children.expand > button::before,
-				div[id*='TopNavigationMenuV4_mobileClone'] .dynamic-children.expand > button::before {
-            content: "-";
-            line-height: 10px;
+
+            #DeltaTopNavigation_mobileClone div[id*='TopNavigationMenu'] .dynamic-children > button span {
+                display: block;
+                position: absolute;
+                top: 15px;
+                left: 3px;
+                right: 3px;
+                height: 1px;
+                background: #444;
+            }
+
+                #DeltaTopNavigation_mobileClone div[id*='TopNavigationMenu'] .dynamic-children > button span::before,
+                #DeltaTopNavigation_mobileClone div[id*='TopNavigationMenu'] .dynamic-children > button span::after {
+                    position: absolute;
+                    display: block;
+                    left: 0;
+                    width: 100%;
+                    height: 1px;
+                    background-color: #444;
+                    content: "";
+                    transition-duration: 0.3s, 0.3s;
+                    transition-delay: 0.3s, 0s;
+                }
+
+                #DeltaTopNavigation_mobileClone div[id*='TopNavigationMenu'] .dynamic-children > button span::before {
+                    top: -3px;
+                    transition-property: top, transform;
+                }
+
+                #DeltaTopNavigation_mobileClone div[id*='TopNavigationMenu'] .dynamic-children > button span::after {
+                    bottom: -3px;
+                    transition-property: bottom, transform;
+                }
+
+        #DeltaTopNavigation_mobileClone div[id*='TopNavigationMenu'] .dynamic-children.expand > button span {
+            background-color: inherit;
         }
+
+            #DeltaTopNavigation_mobileClone div[id*='TopNavigationMenu'] .dynamic-children.expand > button span::before {
+                top: 0;
+                transform: rotate(45deg);
+            }
+
+            #DeltaTopNavigation_mobileClone div[id*='TopNavigationMenu'] .dynamic-children.expand > button span::after {
+                bottom: 0;
+                transform: rotate(-45deg);
+            }
+
+            #DeltaTopNavigation_mobileClone div[id*='TopNavigationMenu'] .dynamic-children.expand > button span::before,
+            #DeltaTopNavigation_mobileClone div[id*='TopNavigationMenu'] .dynamic-children.expand > button span::after {
+                transition-delay: 0s, 0.3s;
+            }
 }
 
-/* Tablets */
-@media only screen and (min-width: 481px) and (max-width : 768px) {
 
+/* Tablets */
+
+@media only screen and (min-width: 481px) and (max-width: 768px) {
     /* Sidebar navigation toggling */
     #titleAreaBox {
         position: relative;
@@ -344,9 +393,9 @@
     #DeltaTopNavigation {
         display: none;
     }
-
     /* Stack title area */
-    div#titleAreaBox, div#titleAreaRow {
+    div#titleAreaBox,
+    div#titleAreaRow {
         display: block;
         margin: 0;
     }
@@ -359,7 +408,10 @@
         display: block;
     }
 
-    #siteIcon, .ms-siteicon-img, .ms-siteicon-a, #s4-titlerow {
+    #siteIcon,
+    .ms-siteicon-img,
+    .ms-siteicon-a,
+    #s4-titlerow {
         height: 75px;
     }
 
@@ -372,16 +424,21 @@
         margin-bottom: 0;
     }
 
-    .ms-core-listMenu-horizontalBox ul, .ms-core-listMenu-horizontalBox li, .ms-core-listMenu-horizontalBox .ms-core-listMenu-item, .ms-core-listMenu-horizontalBox > ul > li > table {
+    .ms-core-listMenu-horizontalBox ul,
+    .ms-core-listMenu-horizontalBox li,
+    .ms-core-listMenu-horizontalBox .ms-core-listMenu-item,
+    .ms-core-listMenu-horizontalBox > ul > li > table {
         display: block;
     }
 
     .ms-breadcrumb-box {
         height: auto;
     }
-
     /* Main content panel */
-    table#layoutsTable, table#layoutsTable > tbody, table#layoutsTable > tbody > tr, table#layoutsTable > tbody > tr > td {
+    table#layoutsTable,
+    table#layoutsTable > tbody,
+    table#layoutsTable > tbody > tr,
+    table#layoutsTable > tbody > tr > td {
         display: block;
     }
 
@@ -409,18 +466,19 @@
     }
 }
 
-/* Smartphones */
-@media screen and (max-width: 480px) {
 
+/* Smartphones */
+
+@media screen and (max-width: 480px) {
     div#s4-bodyContainer {
         width: auto !important;
         margin-left: 10px;
         margin-right: 10px;
         font-size: 1.1em;
     }
-
     /* Stack logo, top nav and search */
-    div#titleAreaBox, div#titleAreaRow {
+    div#titleAreaBox,
+    div#titleAreaRow {
         display: block;
         margin: 0;
     }
@@ -450,7 +508,8 @@
         max-height: 100px;
     }
 
-    div#s4-titlerow, .ms-breadcrumb-box {
+    div#s4-titlerow,
+    .ms-breadcrumb-box {
         height: auto;
     }
 
@@ -466,7 +525,8 @@
         width: 80%;
     }
 
-    div#searchInputBox, div#searchInputBox div.ms-srch-sb {
+    div#searchInputBox,
+    div#searchInputBox div.ms-srch-sb {
         float: none;
         height: 22px;
         display: block;
@@ -475,7 +535,6 @@
         div#searchInputBox div.ms-srch-sb > a {
             float: right;
         }
-
     /* Title breadcrumb */
     #pageTitle #DeltaPlaceHolderPageTitleInTitleArea > span > span:not(:last-child-of-type) {
         font-size: .4em;
@@ -492,9 +551,11 @@
     #pageTitle #DeltaPlaceHolderPageDescription {
         display: none;
     }
-
     /* Breadcrumb navigation in title area */
-    .ms-core-listMenu-horizontalBox ul, .ms-core-listMenu-horizontalBox li, .ms-core-listMenu-horizontalBox .ms-core-listMenu-item, .ms-core-listMenu-horizontalBox > ul > li > table {
+    .ms-core-listMenu-horizontalBox ul,
+    .ms-core-listMenu-horizontalBox li,
+    .ms-core-listMenu-horizontalBox .ms-core-listMenu-item,
+    .ms-core-listMenu-horizontalBox > ul > li > table {
         display: block;
     }
 
@@ -506,7 +567,6 @@
         margin-bottom: 25px;
         display: block;
     }
-
     /* Sidebar navigation toggling */
     #navbar-toggle {
         margin: 0;
@@ -538,7 +598,6 @@
         max-height: 850px;
         overflow: visible;
     }
-
     /* Main content panel */
     #contentRow {
         padding-top: 0;
@@ -551,7 +610,10 @@
         min-width: 0;
     }
 
-    table#layoutsTable, table#layoutsTable > tbody, table#layoutsTable > tbody > tr, table#layoutsTable > tbody > tr > td {
+    table#layoutsTable,
+    table#layoutsTable > tbody,
+    table#layoutsTable > tbody > tr,
+    table#layoutsTable > tbody > tr > td {
         display: block;
     }
 
@@ -577,12 +639,10 @@
     td.ms-cellstyle .ms-list-itemLink {
         height: auto;
     }
-
     /* Fix excessive width of document list view */
     .ms-webpartPage-root {
         border-spacing: 0;
     }
-
     /* Remove text from icon+text action buttons for document list view */
     .ms-viewlsts .ms-vl-sectionHeaderRow .ms-splinkbutton-text {
         display: none;
@@ -591,9 +651,9 @@
     .ms-viewlsts .ms-vl-sectionHeaderRow .ms-vl-settingsmarginleft {
         margin-left: 5px;
     }
-
     /* Hide detail columns in document list view */
-    .ms-listviewtable thead tr th:nth-child(n+5), .ms-listviewtable tbody tr td:nth-child(n+5) {
+    .ms-listviewtable thead tr th:nth-child(n+5),
+    .ms-listviewtable tbody tr td:nth-child(n+5) {
         display: none;
     }
 
@@ -604,9 +664,12 @@
     div.ms-dragDropAttract-subtle {
         min-width: auto;
     }
-
     /* Newsfeed fixes for mobile less than 450px */
-    .ms-microfeed-fullMicrofeedDiv, .ms-microfeed-microblogpart, .ms-microfeed-attachmentPreviewDiv, .ms-microfeed-feedPart, .ms-microfeed-rootText {
+    .ms-microfeed-fullMicrofeedDiv,
+    .ms-microfeed-microblogpart,
+    .ms-microfeed-attachmentPreviewDiv,
+    .ms-microfeed-feedPart,
+    .ms-microfeed-rootText {
         min-width: 200px;
     }
 
@@ -620,7 +683,9 @@
     }
 }
 
+
 /* SETTINGS */
+
 .pnp-settingsdiv {
     width: 250px;
     display: inline-block;

--- a/Core/OfficeDevPnP.Core/Resources/SP-Responsive-UI_CSS.css
+++ b/Core/OfficeDevPnP.Core/Resources/SP-Responsive-UI_CSS.css
@@ -220,58 +220,69 @@
     div[id*='TopNavigationMenu_mobileClone'] {
         width: 100%;
     }
-    /*
-    * Change position and collapse sub nodes
-    */
-    div[id*='TopNavigationMenu_mobileClone'] li.dynamic-children ul {
-        position: inherit;
-        border: 0;
-        box-shadow: none;
-        padding: 0;
-        overflow: hidden;
-        height: 0;
-    }
-    /*
-    * Expand sub nodes
-    */
-    div[id*='TopNavigationMenu_mobileClone'] li.dynamic-children.expand ul {
-        height: auto;
-    }
-    /*
-    * Nodes position
-    */
-    div[id*='TopNavigationMenu_mobileClone'] li.dynamic-children .ms-core-listMenu-item {
-        padding: 5px 0;
-        margin-right: 0;
-    }
-    div[id*='TopNavigationMenu_mobileClone'] li.dynamic-children ul.dynamic .ms-core-listMenu-item {
-        padding-left: 25px;
-    }
-    /*
-    * Remove background arrow
-    */
-    div[id*='TopNavigationMenu_mobileClone'] .dynamic-children.additional-background {
-        background-image: none;
-        padding-left: 5px;
-        padding-right: 0;
-    }
-    /*
-    * Set an left arrow at the left of node
-    */
-    div[id*='TopNavigationMenu_mobileClone'] .dynamic-children.additional-background::before {
-        content: '\25b6';
-        float: left;
-        font-size: 10px;
-        line-height: 18px;
-    }
-    /*
-    * Rotate arrow to the bottom when expand sub nodes
-    */
-    div[id*='TopNavigationMenu_mobileClone'] .dynamic-children.expand .dynamic-children.additional-background::before {
-        -moz-transform: rotate(90deg);
-        -webkit-transform: rotate(90deg);
-        transform: rotate(90deg);
-    }
+        /*
+        * Change position and collapse sub nodes
+        */
+        div[id*='TopNavigationMenu_mobileClone'] li.dynamic-children > ul {
+            position: inherit;
+            border: 0;
+            box-shadow: none;
+            padding: 0;
+            overflow: hidden;
+            height: 0;
+        }
+        /*
+        * Expand sub nodes
+        */
+        div[id*='TopNavigationMenu_mobileClone'] li.dynamic-children.expand > ul {
+            height: auto;
+            padding-left: 25px;
+        }
+        /*
+        * Nodes position
+        */
+        div[id*='TopNavigationMenu_mobileClone'] li.dynamic-children .ms-core-listMenu-item {
+            padding: 0;
+            margin-right: 0;
+        }
+        /*
+        * Remove arrow background 
+        */
+        div[id*='TopNavigationMenu_mobileClone'] .dynamic-children.additional-background,
+        div[id*='TopNavigationMenu_mobileClone'] .dynamic .additional-background.dynamic-children {
+            background-image: none;
+            padding-left: 5px;
+            padding-right: 0;
+        }
+
+        div[id*='TopNavigationMenu_mobileClone'] .dynamic-children > a {
+            display: inline;
+        }
+        /*
+        * Expand/Collapse button style
+        */
+        div[id*='TopNavigationMenu_mobileClone'] .dynamic-children > button {
+            min-width: 16px;
+            width: 16px;
+            height: 16px;
+            margin: 0;
+            padding: 0;
+        }
+            /*
+            * content button when collapse
+            */
+            div[id*='TopNavigationMenu_mobileClone'] .dynamic-children > button::before {
+                content: "+";
+                line-height: 12px;
+                vertical-align: top;
+            }
+        /*
+        * content button when expanded
+        */
+        div[id*='TopNavigationMenu_mobileClone'] .dynamic-children.expand > button::before {
+            content: "-";
+            line-height: 10px;
+        }
 }
 
 /* Tablets */

--- a/Core/OfficeDevPnP.Core/Resources/SP-Responsive-UI_CSS.css
+++ b/Core/OfficeDevPnP.Core/Resources/SP-Responsive-UI_CSS.css
@@ -213,6 +213,65 @@
     a[id*='TopNavigationMenuV4_NavMenu_EditLinks'] {
         display: none;
     }
+
+    /*
+    * Support Top Nav rwd as accordion
+    */
+    div[id*='TopNavigationMenu_mobileClone'] {
+        width: 100%;
+    }
+    /*
+    * Change position and collapse sub nodes
+    */
+    div[id*='TopNavigationMenu_mobileClone'] li.dynamic-children ul {
+        position: inherit;
+        border: 0;
+        box-shadow: none;
+        padding: 0;
+        overflow: hidden;
+        height: 0;
+    }
+    /*
+    * Expand sub nodes
+    */
+    div[id*='TopNavigationMenu_mobileClone'] li.dynamic-children.expand ul {
+        height: auto;
+    }
+    /*
+    * Nodes position
+    */
+    div[id*='TopNavigationMenu_mobileClone'] li.dynamic-children .ms-core-listMenu-item {
+        padding: 5px 0;
+        margin-right: 0;
+    }
+    div[id*='TopNavigationMenu_mobileClone'] li.dynamic-children ul.dynamic .ms-core-listMenu-item {
+        padding-left: 25px;
+    }
+    /*
+    * Remove background arrow
+    */
+    div[id*='TopNavigationMenu_mobileClone'] .dynamic-children.additional-background {
+        background-image: none;
+        padding-left: 5px;
+        padding-right: 0;
+    }
+    /*
+    * Set an left arrow at the left of node
+    */
+    div[id*='TopNavigationMenu_mobileClone'] .dynamic-children.additional-background::before {
+        content: '\25b6';
+        float: left;
+        font-size: 10px;
+        line-height: 18px;
+    }
+    /*
+    * Rotate arrow to the bottom when expand sub nodes
+    */
+    div[id*='TopNavigationMenu_mobileClone'] .dynamic-children.expand .dynamic-children.additional-background::before {
+        -moz-transform: rotate(90deg);
+        -webkit-transform: rotate(90deg);
+        transform: rotate(90deg);
+    }
 }
 
 /* Tablets */

--- a/Core/OfficeDevPnP.Core/Resources/SP-Responsive-UI_CSS.css
+++ b/Core/OfficeDevPnP.Core/Resources/SP-Responsive-UI_CSS.css
@@ -209,21 +209,23 @@
     /*
     * Hide EDIT LINK from top navigation
     */
-    a[id*='TopNavigationMenu_NavMenu_EditLinks'],
-    a[id*='TopNavigationMenuV4_NavMenu_EditLinks'] {
+    a[id*='TopNavigationMenu_NavMenu_EditLinks'],
+		a[id*='TopNavigationMenuV4_NavMenu_EditLinks'] {
         display: none;
     }
 
     /*
     * Support Top Nav rwd as accordion
     */
-    div[id*='TopNavigationMenu_mobileClone'] {
+    div[id*='TopNavigationMenu_mobileClone'],
+		div[id*='TopNavigationMenuV4_mobileClone'] {
         width: 100%;
     }
         /*
         * Change position and collapse sub nodes
         */
-        div[id*='TopNavigationMenu_mobileClone'] li.dynamic-children > ul {
+        div[id*='TopNavigationMenu_mobileClone'] li.dynamic-children > ul,
+				div[id*='TopNavigationMenuV4_mobileClone'] li.dynamic-children > ul {
             position: inherit;
             border: 0;
             box-shadow: none;
@@ -234,14 +236,16 @@
         /*
         * Expand sub nodes
         */
-        div[id*='TopNavigationMenu_mobileClone'] li.dynamic-children.expand > ul {
+        div[id*='TopNavigationMenu_mobileClone'] li.dynamic-children.expand > ul,
+				div[id*='TopNavigationMenuV4_mobileClone'] li.dynamic-children.expand > ul {
             height: auto;
             padding-left: 25px;
         }
         /*
         * Nodes position
         */
-        div[id*='TopNavigationMenu_mobileClone'] li.dynamic-children .ms-core-listMenu-item {
+        div[id*='TopNavigationMenu_mobileClone'] li.dynamic-children .ms-core-listMenu-item,
+				div[id*='TopNavigationMenuV4_mobileClone'] li.dynamic-children .ms-core-listMenu-item {
             padding: 0;
             margin-right: 0;
         }
@@ -249,19 +253,23 @@
         * Remove arrow background 
         */
         div[id*='TopNavigationMenu_mobileClone'] .dynamic-children.additional-background,
-        div[id*='TopNavigationMenu_mobileClone'] .dynamic .additional-background.dynamic-children {
+        div[id*='TopNavigationMenu_mobileClone'] .dynamic .additional-background.dynamic-children,
+				div[id*='TopNavigationMenuV4_mobileClone'] .dynamic-children.additional-background,
+				div[id*='TopNavigationMenuV4_mobileClone'] .dynamic .additional-background.dynamic-children {
             background-image: none;
             padding-left: 5px;
             padding-right: 0;
         }
 
-        div[id*='TopNavigationMenu_mobileClone'] .dynamic-children > a {
+        div[id*='TopNavigationMenu_mobileClone'] .dynamic-children > a,
+				div[id*='TopNavigationMenuV4_mobileClone'] .dynamic-children > a {
             display: inline;
         }
         /*
         * Expand/Collapse button style
         */
-        div[id*='TopNavigationMenu_mobileClone'] .dynamic-children > button {
+        div[id*='TopNavigationMenu_mobileClone'] .dynamic-children > button,
+				div[id*='TopNavigationMenuV4_mobileClone'] .dynamic-children > button {
             min-width: 16px;
             width: 16px;
             height: 16px;
@@ -271,7 +279,8 @@
             /*
             * content button when collapse
             */
-            div[id*='TopNavigationMenu_mobileClone'] .dynamic-children > button::before {
+            div[id*='TopNavigationMenu_mobileClone'] .dynamic-children > button::before,
+						div[id*='TopNavigationMenuV4_mobileClone'] .dynamic-children > button::before {
                 content: "+";
                 line-height: 12px;
                 vertical-align: top;
@@ -279,7 +288,8 @@
         /*
         * content button when expanded
         */
-        div[id*='TopNavigationMenu_mobileClone'] .dynamic-children.expand > button::before {
+        div[id*='TopNavigationMenu_mobileClone'] .dynamic-children.expand > button::before,
+				div[id*='TopNavigationMenuV4_mobileClone'] .dynamic-children.expand > button::before {
             content: "-";
             line-height: 10px;
         }

--- a/Core/OfficeDevPnP.Core/Resources/SP-Responsive-UI_CSS.css
+++ b/Core/OfficeDevPnP.Core/Resources/SP-Responsive-UI_CSS.css
@@ -166,7 +166,7 @@
             #suiteBar-rwd > #suiteBar-close:after {
                 -ms-transform: translate(0px, 5px) rotate(45deg);
                 -webkit-transform: translate(0px, 5px) rotate(45deg);
-                transform: translate(0px, 5px) rotate(45eg);
+                transform: translate(0px, 5px) rotate(45deg);
                 background: #fff;
                 height: 3px;
                 width: 20px;


### PR DESCRIPTION
|  Q              | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| New sample?     | no
| Related issues? | Fixes SharePoint/PnP-Tools/issues/94

#### What's in this Pull Request?
Performs some change to supports subsites node from the Top Navigation into the responsive mode.

##### JavaScript
* Get links and add button when sub nodes are available (with this solution, the user keep the link available and for expand the nodes, he have to click on the button)
* Add an event Listener onto the button at the click event to toggle the parent css class

##### CSS
* Hide or show sub nodes in accordance with the parent class attribute

> Note: this PR was tested on SharePoint 2013/2016 On-Premise and SharePoint Online.

#### Use Case
| Environment | Tested |
|--------------|-------|
| SharePoint 2013 | yes |
| SharePoint 2016 | yes |
| SharePoint Online | yes |

#### Guidance
1. If you have already deployed PnP Responsive UI, you can replace the JS and CSS files, otherwise, follow the guidance at https://github.com/SharePoint/PnP-Tools/tree/master/Solutions/SharePoint.UI.Responsive and replace the files of this PR
2. Create Sub Site that inherit the top navigation
3. For each sub sites, into the navigation settings, check the checkbox "Show subsites"

<a name="overview"></a>
#### Overview
##### Desktop
![sp-pnp-responsive-ui_topnav_desktop](https://cloud.githubusercontent.com/assets/15279205/23339924/c12700f6-fc2c-11e6-8568-39bb2cc39bc3.PNG)

##### Tablet
|  Collapse              | Expand
| --------------- | ---
| ![pr-pnpresponsiveui-tabletmode_collapse](https://cloud.githubusercontent.com/assets/15279205/24548561/10dd6f60-1616-11e7-8679-bbac6892f565.PNG) | ![pr-pnpresponsiveui-tabletmode_expand](https://cloud.githubusercontent.com/assets/15279205/24548560/10dca33c-1616-11e7-9037-1a3d917528ca.PNG)

##### Smartphone
|  Collapse              | Expand
| --------------- | ---
| ![pr-pnpresponsiveui-smartphonemode_collapse](https://cloud.githubusercontent.com/assets/15279205/24548534/f1e3b0ba-1615-11e7-9502-dc159df1eae2.PNG) | ![pr-pnpresponsiveui-smartphonemode_expand](https://cloud.githubusercontent.com/assets/15279205/24548535/f1e59c22-1615-11e7-9c77-24c30ae51056.PNG)

