### PR TITLE
ClientQueryable.GetEnumerator not implemented fix

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
@@ -136,7 +136,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             }
 
             // make sure fields are in the correct order
-            var existingFieldNames = existingContentType.FieldLinks.Select(fld => fld.Name).ToArray();
+            var existingFieldNames = existingContentType.FieldLinks.AsEnumerable().Select(fld => fld.Name).ToArray();
             var ctFieldNames = templateContentType.FieldRefs.Select(fld => parser.ParseString(fld.Name)).ToArray();
             if (!existingFieldNames.SequenceEqual(ctFieldNames))
             {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

Fixes exception when provisioning with early versions of Microsoft.SharePoint.Client.Runtime.dll (e.g. with 15.0.4561.1000 the one in PnP-Site-Core repo), where ClientQueryable.GetEnumerator method is not implemented.