### PR TITLE
Added parsing of description resource to TermGroup, TermSet and Term.

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTermGroups.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTermGroups.cs
@@ -64,9 +64,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         g => g.Id == modelTermGroup.Id || g.Name == normalizedGroupName.Value);
                     if (group == null)
                     {
+                        var parsedGroupName = parser.ParseString(modelTermGroup.Name);
+                        var parsedDescription = parser.ParseString(modelTermGroup.Description);
+
                         if (modelTermGroup.Name == "Site Collection" ||
-                            parser.ParseString(modelTermGroup.Name) ==
-                            siteCollectionTermGroupNameToken.GetReplaceValue() ||
+                            parsedGroupName == siteCollectionTermGroupNameToken.GetReplaceValue() ||
                             modelTermGroup.SiteCollectionTermGroup)
                         {
                             var site = (web.Context as ClientContext).Site;
@@ -78,7 +80,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         }
                         else
                         {
-                            var parsedGroupName = parser.ParseString(modelTermGroup.Name);
                             var parsedNormalizedGroupName = TaxonomyItem.NormalizeName(web.Context, parsedGroupName);
                             web.Context.ExecuteQueryRetry();
 
@@ -92,7 +93,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                 }
                                 group = termStore.CreateGroup(parsedGroupName, modelTermGroup.Id);
 
-                                group.Description = modelTermGroup.Description;
+                                group.Description = parsedDescription;
 
 #if !ONPREMISES
 
@@ -161,7 +162,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                 }
                             }
                             newTermSet = true;
-                            set.Description = modelTermSet.Description;
+                            set.Description = parser.ParseString(modelTermSet.Description);
                             set.IsOpenForTermCreation = modelTermSet.IsOpenForTermCreation;
                             set.IsAvailableForTagging = modelTermSet.IsAvailableForTagging;
                             foreach (var property in modelTermSet.Properties)
@@ -301,7 +302,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             }
             if (!string.IsNullOrEmpty(modelTerm.Description))
             {
-                term.SetDescription(modelTerm.Description, modelTerm.Language ?? termStore.DefaultLanguage);
+                term.SetDescription(parser.ParseString(modelTerm.Description), modelTerm.Language ?? termStore.DefaultLanguage);
             }
             if (!string.IsNullOrEmpty(modelTerm.Owner))
             {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | N/A

#### What's in this Pull Request?

If description for TermGroup, TermSet or Term contains a resource token, it must be parsed before it is applied.