### PR TITLE
Re-order fields when content type is updated

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
@@ -209,6 +209,19 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     scope.LogDebug(CoreResources.Provisioning_ObjectHandlers_ContentTypes_Adding_field__0__to_content_type, fieldId);
                     web.AddFieldToContentType(existingContentType, field, fieldRef.Required, fieldRef.Hidden);
                 }
+
+                // reload content type fields
+                web.Context.Load(existingContentType, ct => ct.FieldLinks);
+                web.Context.ExecuteQueryRetry();
+
+                // make sure fields are in the correct order
+                existingFieldNames = existingContentType.FieldLinks.Select(fld => fld.Name).ToArray();
+
+                if (!existingFieldNames.SequenceEqual(ctFieldNames))
+                {
+                    existingContentType.FieldLinks.Reorder(ctFieldNames);
+                    isDirty = true;
+                }
             }
 
             isDirty = false;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?    |  yes
| New feature?    | no
| New sample?      | no 
| Related issues?  | not found

#### What's in this Pull Request?

Updated the content type object handler to reorder the content type field after adding new fields to the content type. Re-order was called too early so new fields added to the content type always ended up at the bottom. Reduced to one re-order call.