### PR TITLE
Two new TokenDefinitions, TermIdToken and SiteCollectionTermIdToken

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/TokenParserTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/TokenParserTests.cs
@@ -126,9 +126,13 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                 var listUrl = "Lists/TestList";
                 var webPartTitle = @"Webpart (\*+?|{[()^$.#";
                 var webPartId = Guid.NewGuid();
+                var termPath = @"Test Term (\*+?{[()^$.#";
+                var subTermPath = @"Test Term (\*+?{[()^$.#;Test SubTerm (\*+?{[()^$.#";
                 var termSetName = @"Test TermSet (\*+?{[()^$.#";
                 var termGroupName = @"Group Name (\*+?{[()^$.#";
                 var termStoreName = @"Test TermStore (\*+?{[()^$.#";
+                var termId = Guid.NewGuid();
+                var subTermId = Guid.NewGuid();
                 var termSetId = Guid.NewGuid();
                 var termStoreId = Guid.NewGuid();
 
@@ -138,6 +142,8 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                 parser.AddToken(new ListIdToken(web, listTitle, listGuid));
                 parser.AddToken(new ListUrlToken(web, listTitle, listUrl));
                 parser.AddToken(new WebPartIdToken(web, webPartTitle, webPartId));
+                parser.AddToken(new TermIdToken(web, termGroupName, termSetName, termPath, termId));
+                parser.AddToken(new TermIdToken(web, termGroupName, termSetName, subTermPath, subTermId));
                 parser.AddToken(new TermSetIdToken(web, termGroupName, termSetName, termSetId));
                 parser.AddToken(new TermStoreIdToken(web, termStoreName, termStoreId));
 
@@ -149,6 +155,8 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                 var parameterTest1 = parser.ParseString("abc{parameter:TEST(T)}/test");
                 var parameterTest2 = parser.ParseString("abc{$test(T)}/test");
                 var resolvedWebpartId = parser.ParseString($"{{webpartid:{webPartTitle}}}");
+                var resolvedTermId = parser.ParseString($"{{termid:{termGroupName}:{termSetName}:{termPath}}}");
+                var resolvedSubTermId = parser.ParseString($"{{termid:{termGroupName}:{termSetName}:{subTermPath}}}");
                 var resolvedTermSetId = parser.ParseString($"{{termsetid:{termGroupName}:{termSetName}}}");
                 var resolvedTermStoreId = parser.ParseString($"{{termstoreid:{termStoreName}}}");
 
@@ -160,6 +168,8 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                 Assert.IsTrue(parameterTest1 == parameterExpectedResult);
                 Assert.IsTrue(parameterTest2 == parameterExpectedResult);
                 Assert.IsTrue(Guid.TryParse(resolvedWebpartId, out outGuid));
+                Assert.IsTrue(Guid.TryParse(resolvedTermId, out outGuid));
+                Assert.IsTrue(Guid.TryParse(resolvedSubTermId, out outGuid));
                 Assert.IsTrue(Guid.TryParse(resolvedTermSetId, out outGuid));
                 Assert.IsTrue(Guid.TryParse(resolvedTermStoreId, out outGuid));
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/SiteCollectionTermIdToken.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/SiteCollectionTermIdToken.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Text.RegularExpressions;
+using Microsoft.SharePoint.Client;
+
+namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitions
+{
+    public class SiteCollectionTermIdToken : TokenDefinition
+    {
+        private readonly string _termId;
+
+        public SiteCollectionTermIdToken(Web ctxWeb, string termsetName, string termPath, Guid termId) : base(ctxWeb, $"{{sitecollectiontermid:{Regex.Escape(termsetName)}:{Regex.Escape(termPath)}}}")
+        {
+            _termId = termId.ToString("D");
+        }
+
+        public override string GetReplaceValue()
+        {
+            if (string.IsNullOrEmpty(CacheValue))
+            {
+                CacheValue = _termId;
+            }
+            return CacheValue;
+        }
+    }
+}

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/TermIdToken.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/TermIdToken.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Text.RegularExpressions;
+using Microsoft.SharePoint.Client;
+
+namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitions
+{
+    public class TermIdToken : TokenDefinition
+    {
+        private readonly string _termId;
+
+        public TermIdToken(Web ctxWeb, string groupName, string termsetName, string termPath, Guid termId) : base(ctxWeb, $"{{termid:{Regex.Escape(groupName)}:{Regex.Escape(termsetName)}:{Regex.Escape(termPath)}}}")
+        {
+            _termId = termId.ToString("D");
+        }
+
+        public override string GetReplaceValue()
+        {
+            if (string.IsNullOrEmpty(CacheValue))
+            {
+                CacheValue = _termId;
+            }
+            return CacheValue;
+        }
+    }
+}

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
@@ -140,6 +140,18 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     foreach (var termSet in termGroup.TermSets)
                     {
                         _tokens.Add(new TermSetIdToken(web, termGroup.Name, termSet.Name, termSet.Id));
+                        var allTerms = termSet.GetAllTerms();
+                        web.Context.Load(allTerms,
+                            tc => tc.Include(
+                                t => t.Name,
+                                t => t.Id,
+                                t => t.PathOfTerm
+                            ));
+                        web.Context.ExecuteQueryRetry();
+                        foreach (var term in allTerms)
+                        {
+                            _tokens.Add(new TermIdToken(web, termGroup.Name, termSet.Name, term.PathOfTerm, term.Id));
+                        }
                     }
                 }
             }
@@ -163,6 +175,18 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         foreach (var termSet in siteCollectionTermGroup.TermSets)
                         {
                             _tokens.Add(new SiteCollectionTermSetIdToken(web, termSet.Name, termSet.Id));
+                            var allTerms = termSet.GetAllTerms();
+                            web.Context.Load(allTerms,
+                                tc => tc.Include(
+                                    t => t.Name,
+                                    t => t.Id,
+                                    t => t.PathOfTerm
+                                ));
+                            web.Context.ExecuteQueryRetry();
+                            foreach (var term in allTerms)
+                            {
+                                _tokens.Add(new SiteCollectionTermIdToken(web, termSet.Name, term.PathOfTerm, term.Id));
+                            }
                         }
                     }
                 }

--- a/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
+++ b/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
@@ -417,6 +417,8 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>CoreResources.resx</DependentUpon>
     </Compile>
+    <Compile Include="Framework\Provisioning\ObjectHandlers\TokenDefinitions\SiteCollectionTermIdToken.cs" />
+    <Compile Include="Framework\Provisioning\ObjectHandlers\TokenDefinitions\TermIdToken.cs" />
     <Compile Include="Pages\ClientSidePageCanvas.cs" />
     <Compile Include="Pages\ClientSidePageControls.cs" />
     <Compile Include="Pages\ClientSidePagesControlData.cs" />


### PR DESCRIPTION
Added tokens to TokenParser and TokenParserTests

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no
| Related issues?  | fixes https://github.com/SharePoint/PnP-Provisioning-Schema/issues/177, partially #961

#### What's in this Pull Request?

Two new TokenDefinitions, TermIdToken and SiteCollectionTermIdToken
Added tokens to TokenParser and TokenParserTests

#### Guidance
If setting a taxonomyfield AnchorId or DefaultValue, or adding DataRows with taxonomy values
Use token `{termid:<Group>:<Set>:<PathOfTerm>} `or `{sitecollectiontermid:<Set>:<PathOfTerm>} `in place of GUID value
Example: `{termid:MyTermGroup:MyTermSet:ParentTerm;SubTerm}` --> `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
Setting a taxonomy value in a DataRow then becomes
`<pnp:DataValue FieldName="MyTaxonomyField">-1;#SubTerm|{termid:MyTermGroup:MyTermSet:ParentTerm;SubTerm}</pnp:DataValue>`