### PR TITLE
Siteretrieval via search by index doc

### DIFF
--- a/Core/OfficeDevPnP.Core/AppModelExtensions/WebExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/WebExtensions.cs
@@ -564,7 +564,7 @@ namespace Microsoft.SharePoint.Client
         /// are not returned
         /// </summary>
         /// <param name="web">Site to be processed - can be root web or sub site</param>
-        /// <returns>All site collections - Duplicates are not being trimmed.</returns>
+        /// <returns>All site collections</returns>
         public static List<SiteEntity> SiteSearch(this Web web)
         {
             return web.SiteSearch(string.Empty);
@@ -575,7 +575,7 @@ namespace Microsoft.SharePoint.Client
         /// </summary>
         /// <param name="web">Site to be processed - can be root web or sub site</param>
         /// <param name="keywordQueryValue">Keyword query</param>
-        /// <param name="trimDuplicates">Indicates if duplicates should be trimmed or not. Defaults to false</param>
+        /// <param name="trimDuplicates">Indicates if dublicates should be trimmed or not</param>
         /// <returns>All found site collections</returns>
         [SuppressMessage("Microsoft.Globalization", "CA1303:Do not pass literals as localized parameters", MessageId = "OfficeDevPnP.Core.Diagnostics.Log.Debug(System.String,System.String,System.Object[])")]
         public static List<SiteEntity> SiteSearch(this Web web, string keywordQueryValue, bool trimDuplicates = false)
@@ -591,20 +591,22 @@ namespace Microsoft.SharePoint.Client
 
                 if (keywordQueryValue.Length == 0)
                 {
+
                     keywordQueryValue = "contentclass:\"STS_Site\"";
+
                 }
 
-                int startRow = 0;
+                //int startRow = 0;
                 int totalRows = 0;
 
-                totalRows = web.ProcessQuery(keywordQueryValue, sites, keywordQuery, startRow);
+                totalRows = web.ProcessQuery(keywordQueryValue, sites, keywordQuery);
+
 
                 if (totalRows > 0)
                 {
-                    while (totalRows >= sites.Count)
+                    while (totalRows > 0)
                     {
-                        startRow += 500;
-                        totalRows = web.ProcessQuery(keywordQueryValue, sites, keywordQuery, startRow);
+                        totalRows = web.ProcessQuery(keywordQueryValue + " AND IndexDocId >" + sites.Last().IndexDocId, sites, keywordQuery);// From the second Query get the next set (rowlimit) of search result based on IndexDocId
                     }
                 }
 
@@ -626,7 +628,7 @@ namespace Microsoft.SharePoint.Client
         /// <returns>All found site collections</returns>
         public static List<SiteEntity> SiteSearchScopedByUrl(this Web web, string siteUrl)
         {
-            string keywordQuery = $"contentclass:\"STS_Site\" AND site:{siteUrl}";
+            string keywordQuery = String.Format("contentclass:\"STS_Site\" AND site:{0}", siteUrl);
             return web.SiteSearch(keywordQuery);
         }
 
@@ -638,7 +640,7 @@ namespace Microsoft.SharePoint.Client
         /// <returns>All found site collections</returns>
         public static List<SiteEntity> SiteSearchScopedByTitle(this Web web, string siteTitle)
         {
-            string keywordQuery = $"contentclass:\"STS_Site\" AND Title:{siteTitle}";
+            string keywordQuery = String.Format("contentclass:\"STS_Site\" AND Title:{0}", siteTitle);
             return web.SiteSearch(keywordQuery);
         }
 
@@ -650,20 +652,21 @@ namespace Microsoft.SharePoint.Client
         /// <param name="keywordQueryValue">keyword query </param>
         /// <param name="sites">sites variable that hold the resulting sites</param>
         /// <param name="keywordQuery">KeywordQuery object</param>
-        /// <param name="startRow">Start row of the resultset to be returned</param>
+
         /// <returns>Total number of rows for the query</returns>
-        private static int ProcessQuery(this Web web, string keywordQueryValue, List<SiteEntity> sites, KeywordQuery keywordQuery, int startRow)
+        private static int ProcessQuery(this Web web, string keywordQueryValue, List<SiteEntity> sites, KeywordQuery keywordQuery)
         {
             int totalRows = 0;
 
             keywordQuery.QueryText = keywordQueryValue;
-            keywordQuery.RowLimit = 500;
-            keywordQuery.StartRow = startRow;
+            keywordQuery.RowLimit = 4;
+            // keywordQuery.StartRow = startRow;
             keywordQuery.SelectProperties.Add("Title");
             keywordQuery.SelectProperties.Add("SPSiteUrl");
             keywordQuery.SelectProperties.Add("Description");
             keywordQuery.SelectProperties.Add("WebTemplate");
-            keywordQuery.SortList.Add("SPSiteUrl", SortDirection.Ascending);
+            keywordQuery.SelectProperties.Add("IndexDocId"); // Change : Include IndexDocId property to get the IndexDocId for paging
+            keywordQuery.SortList.Add("IndexDocId", SortDirection.Ascending); // Change : Sort by IndexDocId
             SearchExecutor searchExec = new SearchExecutor(web.Context);
 
             // Important to avoid trimming "similar" site collections
@@ -686,6 +689,7 @@ namespace Microsoft.SharePoint.Client
                             Url = row["SPSiteUrl"] != null ? row["SPSiteUrl"].ToString() : "",
                             Description = row["Description"] != null ? row["Description"].ToString() : "",
                             Template = row["WebTemplate"] != null ? row["WebTemplate"].ToString() : "",
+                            IndexDocId = row["DocId"] != null ? double.Parse(row["DocId"].ToString()) : 0, // Change : Include IndexDocId in the sites List
                         });
                     }
                 }

--- a/Core/OfficeDevPnP.Core/AppModelExtensions/WebExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/WebExtensions.cs
@@ -659,7 +659,7 @@ namespace Microsoft.SharePoint.Client
             int totalRows = 0;
 
             keywordQuery.QueryText = keywordQueryValue;
-            keywordQuery.RowLimit = 4;
+            keywordQuery.RowLimit = 500;
             // keywordQuery.StartRow = startRow;
             keywordQuery.SelectProperties.Add("Title");
             keywordQuery.SelectProperties.Add("SPSiteUrl");

--- a/Core/OfficeDevPnP.Core/Entities/SiteEntity.cs
+++ b/Core/OfficeDevPnP.Core/Entities/SiteEntity.cs
@@ -53,6 +53,15 @@ namespace OfficeDevPnP.Core.Entities
         }
 
         /// <summary>
+        /// IndexDocId for Search Paging
+        /// </summary>
+        public double IndexDocId
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// The site locale. See http://technet.microsoft.com/en-us/library/ff463597.aspx for a complete list of Lcid's
         /// </summary>
         public uint Lcid


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no [Performance improvement]
| New sample?      | Yes [Change to existing sample]
| Related issues?  | Fixes the severe performance issue with using "StartRow" property for paging the search results
#### What's in this Pull Request?

Search Product Group has recently found severe performance issue with using "StartRow" property of "KeywordQuery" class for paging the search results. The recommendation is to use the "IndexDocId" property to get the subsequent results after sorting the results from first query based on IndexDocId. 

This pull request contains changes to "SiteSearch" method and "ProcessQuery" method in OfficeDevPnP.Core\AppModelExtensions\WebExtensions.cs to implement paging based on "IndexDocId" instead of using StartRow. This is very vital as most of the customers uses the site retrieval using search from PnP sample as explained here https://dev.office.com/patterns-and-practices-detail/1932 . The change in this PR covers all the scenario explained including My sites, search by title and url. 

Please reach out to me to know more about the importance of this change and for the knowledge base reference from search PG.


#### Guidance
*You can delete this section when you are submitting the pull request.* 
* *Please update this PR information accordingly. We'll use this as part of our release notes in monthly communications.*
* *Please target your PR to Dev branch.*