### PR TITLE
Fix to #1045: Removed token match from regular expression on GetLeftOverTokens

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
@@ -303,7 +303,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         public IEnumerable<string> GetLeftOverTokens(string input)
         {
             List<string> values = new List<string>();
-            var matches = Regex.Matches(input, "(?<guid>\\{\\S{8}-\\S{4}-\\S{4}-\\S{4}-\\S{12}?\\})|(?<token>\\{.+?\\})").OfType<Match>().Select(m => m.Value);
+            var matches = Regex.Matches(input, "(?<guid>\\{\\S{8}-\\S{4}-\\S{4}-\\S{4}-\\S{12}?\\})").OfType<Match>().Select(m => m.Value);
             foreach (var match in matches)
             {
                 Guid gout;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes
| Related issues?  | fixes #1045 

#### What's in this Pull Request?
Following @jansenbe instructions. This is a Fix to #1045: Removed token match from regular expression on GetLeftOverTokens (see comments on Bug detail).



#### Guidance
*You can delete this section when you are submitting the pull request.* 
* *Please update this PR information accordingly. We'll use this as part of our release notes in monthly communications.*
* *Please target your PR to Dev branch.*