### PR TITLE
Fix CurrentNavigation inheritance

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectNavigation.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectNavigation.cs
@@ -140,6 +140,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                     template.Navigation.GlobalNavigation.StructuralNavigation, parser, applyingInformation.ClearNavigation, scope);
                                 break;
                         }
+                        navigationSettings.Update(TaxonomySession.GetTaxonomySession(web.Context));
                         web.Context.ExecuteQueryRetry();
                     }
 
@@ -178,6 +179,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                     template.Navigation.CurrentNavigation.StructuralNavigation, parser, applyingInformation.ClearNavigation, scope);
                                 break;
                         }
+                        navigationSettings.Update(TaxonomySession.GetTaxonomySession(web.Context));
                         web.Context.ExecuteQueryRetry();
                     }
                 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?

Inheritance of current navigation does not work. The reason is, that WebNavigationSettings.Update() was not called to apply the configuration. Interestingly this had no impact on the other navigation options.

To reproduce apply the following template to a subsite.
`<?xml version="1.0"?>
<pnp:Provisioning xmlns:pnp="http://schemas.dev.office.com/PnP/2016/05/ProvisioningSchema">
  <pnp:Preferences Generator="OfficeDevPnP.Core, Version=2.9.1611.0, Culture=neutral, PublicKeyToken=d8f0f7d8ea55cb0a" />
  <pnp:Templates ID="CONTAINER-TEMPLATE-DD6D590BBF6D4D31A19021D8512C86C6">
    <pnp:ProvisioningTemplate ID="TEMPLATE-DD6D590BBF6D4D31A19021D8512C86C6" Version="1">
      <pnp:Navigation><!-- This does not work -->
        <pnp:GlobalNavigation NavigationType="Inherit"/>
        <pnp:CurrentNavigation NavigationType="Inherit"/>
      </pnp:Navigation>
    </pnp:ProvisioningTemplate>
  </pnp:Templates>
</pnp:Provisioning>`
