### PR TITLE
Added logic and tests to get a provisioning template which contains o…

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/Extensions/WebExtensionsTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Extensions/WebExtensionsTests.cs
@@ -10,6 +10,7 @@ using OfficeDevPnP.Core.Tests;
 using System.IO;
 using OfficeDevPnP.Core.Framework.Provisioning.Model;
 using OfficeDevPnP.Core;
+using OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers;
 
 namespace Microsoft.SharePoint.Client.Tests
 {
@@ -21,6 +22,8 @@ namespace Microsoft.SharePoint.Client.Tests
         private string _value_string = null;
         private int _value_int = 12345;
         const string APPNAME = "HelloWorldApp";
+        const string contentTypeName = "PnP Test Content Type";
+        const string contentTypeGroupName = "PnP Web Extensions Test";
         private ClientContext clientContext;
 
         #region Test initialize and cleanup
@@ -36,6 +39,22 @@ namespace Microsoft.SharePoint.Client.Tests
             clientContext.Load(clientContext.Site, s => s.Id);
             clientContext.ExecuteQueryRetry();
             clientContext.Site.ActivateFeature(Constants.FeatureId_Site_AppSideLoading);
+
+            var provisionTemplate = new ProvisioningTemplate();
+            var contentType = new OfficeDevPnP.Core.Framework.Provisioning.Model.ContentType()
+            {
+                Id = "0x010100503B9E20E5455344BFAC2292DC6FAB81",
+                Name = contentTypeName,
+                Group = contentTypeGroupName,
+                Description = "Test Description",
+                Overwrite = true,
+                Hidden = false
+            };
+
+            provisionTemplate.ContentTypes.Add(contentType);
+            TokenParser parser = new TokenParser(clientContext.Web, provisionTemplate);
+            new ObjectContentType().ProvisionObjects(clientContext.Web, provisionTemplate, parser,
+                new ProvisioningTemplateApplyingInformation());
         }
 
         [TestCleanup()]
@@ -98,6 +117,14 @@ namespace Microsoft.SharePoint.Client.Tests
                     break;
                 }
             }
+
+            var ct = clientContext.Web.GetContentTypeByName(contentTypeName);
+            if (ct != null)
+            {
+                ct.DeleteObject();
+                clientContext.ExecuteQueryRetry();
+            }
+
             clientContext.Dispose();
         }
         #endregion
@@ -410,6 +437,44 @@ namespace Microsoft.SharePoint.Client.Tests
             {
                 var template = clientContext.Web.GetProvisioningTemplate();
                 Assert.IsInstanceOfType(template, typeof(ProvisioningTemplate));
+            }
+        }
+
+        [TestMethod]
+        public void GetProvisioningTemplateWithSelectedContentTypesTest()
+        {
+            using (var clientContext = TestCommon.CreateClientContext())
+            {
+                var web = clientContext.Web;
+
+                // Arrange
+                var creationInfo = new ProvisioningTemplateCreationInformation(web);
+                creationInfo.ContentTypeGroupsToInclude.Add(contentTypeGroupName);
+
+                // Act
+                var template = web.GetProvisioningTemplate(creationInfo);
+
+                // Assert
+                Assert.AreEqual(1, template.ContentTypes.Count);
+                StringAssert.Equals(contentTypeGroupName, template.ContentTypes[0].Group);
+            }
+        }
+
+        [TestMethod]
+        public void GetProvisioningTemplateWithOutSelectedContentTypesTest()
+        {
+            using (var clientContext = TestCommon.CreateClientContext())
+            {
+                var web = clientContext.Web;
+
+                // Arrange
+                var creationInfo = new ProvisioningTemplateCreationInformation(web);
+
+                // Act
+                var template = web.GetProvisioningTemplate(creationInfo);
+
+                // Assert
+                Assert.IsTrue(template.ContentTypes.Count > 1);
             }
         }
         #endregion

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
@@ -490,7 +490,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 currentCtIndex++;
                 WriteMessage($"Content Type|{ct.Name}|{currentCtIndex}|{cts.Count()}", ProvisioningMessageType.Progress);
 
-                if (!BuiltInContentTypeId.Contains(ct.StringId))
+                if (!BuiltInContentTypeId.Contains(ct.StringId) && 
+                    (creationInfo.ContentTypeGroupsToInclude.Count == 0 || creationInfo.ContentTypeGroupsToInclude.Contains(ct.Group)))
                 {
                     string ctDocumentTemplate = null;
                     if (!string.IsNullOrEmpty(ct.DocumentTemplate))

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ProvisioningTemplateCreationInformation.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ProvisioningTemplateCreationInformation.cs
@@ -179,7 +179,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             set { this.propertyBagPropertiesToPreserve = value; }
         }
 
-        internal List<String> ContentTypeGroupsToInclude {
+        public List<String> ContentTypeGroupsToInclude {
             get { return this.contentTypeGroupsToInclude; }
             set { this.contentTypeGroupsToInclude = value; }
         }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ProvisioningTemplateCreationInformation.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ProvisioningTemplateCreationInformation.cs
@@ -19,6 +19,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         private bool includeTermGroupsSecurity = false;
         private bool includeSearchConfiguration = false;
         private List<String> propertyBagPropertiesToPreserve;
+        private List<String> contentTypeGroupsToInclude;
         private bool persistPublishingFiles = false;
         private bool includeNativePublishingFiles = false;
         private bool skipVersionCheck = false;
@@ -32,6 +33,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         {
             this.baseTemplate = web.GetBaseTemplate();
             this.propertyBagPropertiesToPreserve = new List<String>();
+            this.contentTypeGroupsToInclude = new List<String>();
         }
 
         /// <summary>
@@ -175,6 +177,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         {
             get { return this.propertyBagPropertiesToPreserve; }
             set { this.propertyBagPropertiesToPreserve = value; }
+        }
+
+        internal List<String> ContentTypeGroupsToInclude {
+            get { return this.contentTypeGroupsToInclude; }
+            set { this.contentTypeGroupsToInclude = value; }
         }
 
         public bool IncludeSiteGroups


### PR DESCRIPTION
Added logic and tests to make it possible to get a provisioning template which contains only content types of a given list of content type groups.

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no 
| Related issues?  | none

#### What's in this Pull Request?

With these changes it is now possible to create a provisioning template which only contains content types which belong to the given group(s).