### PR TITLE
Fields with DefaultValue not extracted

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -1774,10 +1774,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
             var fieldsToProcess = siteList.Fields.AsEnumerable().Where(field => !field.Hidden || SpecialFields.Contains(field.InternalName)).ToArray();
 
-
             foreach (var field in fieldsToProcess)
             {
-
                 var siteColumn = siteColumns.FirstOrDefault(sc => sc.Id == field.Id);
                 if (siteColumn != null)
                 {
@@ -1793,8 +1791,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     if (siteColumn.DefaultValue != field.DefaultValue)
                     {
                         list.FieldDefaults.Add(field.InternalName, field.DefaultValue);
+                        addField = true;
                     }
-
 
                     var fieldElement = XElement.Parse(field.SchemaXml);
                     var sourceId = fieldElement.Attribute("SourceID") != null ? fieldElement.Attribute("SourceID").Value : null;
@@ -1836,9 +1834,9 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                             addField = false;
                         }
                     }
+
                     if (addField)
                     {
-
                         list.FieldRefs.Add(new FieldRef(field.InternalName)
                         {
                             Id = field.Id,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | n/a

#### What's in this Pull Request?

This PR fixes an issue where a site column on a list isn't extracted when the field on the list contains a different DefaultValue than the site column.