### PR TITLE
Allow removal of default content types from an asset list.

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectListInstanceTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectListInstanceTests.cs
@@ -145,6 +145,43 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
         }
 
         [TestMethod]
+        public void DefaultContentTypeShouldBeRemovedFromProvisionedAssetLibraries()
+        {
+            using (var ctx = TestCommon.CreateClientContext())
+            {
+                // Arrange
+                var listInstance = new Core.Framework.Provisioning.Model.ListInstance();
+                listInstance.Url = $"lists/{listName}";
+                listInstance.Title = listName;
+                // An asset must be created by using the 
+                // template type AND the template feature id
+                listInstance.TemplateType = 851;
+                listInstance.TemplateFeatureID = new Guid("4bcccd62-dcaf-46dc-a7d4-e38277ef33f4");
+                // Also attachements are not allowed on an asset list
+                listInstance.EnableAttachments = false;
+                listInstance.ContentTypesEnabled = true;
+                listInstance.RemoveExistingContentTypes = true;
+                listInstance.ContentTypeBindings.Add(new ContentTypeBinding
+                {
+                    ContentTypeId = BuiltInContentTypeId.DublinCoreName,
+                    Default = true
+                });
+                var template = new ProvisioningTemplate();
+                template.Lists.Add(listInstance);
+
+                // Act
+                ctx.Web.ApplyProvisioningTemplate(template);
+                var list = ctx.Web.GetListByUrl(listInstance.Url);
+                var contentTypes = list.EnsureProperty(l => l.ContentTypes);
+                // Assert
+                // Asset list should only have the custom content type we defined
+                // and the folder content type
+                Assert.AreEqual(contentTypes.Count, 2);
+            }
+
+        }
+
+        [TestMethod]
         public void UpdatedListTitleShouldBeAvailableAsToken()
         {
             var listUrl = string.Format("lists/{0}", listName);

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -1443,7 +1443,9 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 foreach (var ct in contentTypesToRemove)
                 {
                     var shouldDelete = true;
-                    shouldDelete &= (createdList.BaseTemplate != (int)ListTemplateType.DocumentLibrary || !ct.StringId.StartsWith(BuiltInContentTypeId.Folder + "00"));
+                    shouldDelete &= ((createdList.BaseTemplate != (int)ListTemplateType.DocumentLibrary
+                        && createdList.BaseTemplate != 851)
+                        || !ct.StringId.StartsWith(BuiltInContentTypeId.Folder + "00"));
 
                     if (shouldDelete)
                     {


### PR DESCRIPTION
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes 
| New sample?      | no
| Related issues?  | none

#### What's in this Pull Request?
This change will allow the removal of the default content types from an asset list, if there are custom content types defined for this list. Before this change this was possible for a lot of OOTB lists, but not for the asset list.