### PR TITLE
Null exception in TokenParser class when having empty parameter in provisioning template

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
@@ -111,7 +111,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             // Add parameters
             foreach (var parameter in template.Parameters)
             {
-                _tokens.Add(new ParameterToken(web, parameter.Key, parameter.Value));
+                _tokens.Add(new ParameterToken(web, parameter.Key, parameter.Value ?? string.Empty));
             }
 
             // Add TermSetIds


### PR DESCRIPTION


| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no


#### What's in this Pull Request?
When having empty parameter values in a provisioning template I get an exception from the TokenParser class as the empty value get translated to a null value and gives an error in the `regex.Replace` call. Converting null value to empty string at creation solves the issue.