### PR TITLE
Issue with SiteCollection TermSet and Terms

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTermGroups.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTermGroups.cs
@@ -148,10 +148,16 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         }
                         if (set == null)
                         {
+                            if (modelTermGroup.SiteCollectionTermGroup)
+                            {
+                                modelTermSet.Id = Guid.NewGuid();
+                            }
+
                             if (modelTermSet.Id == Guid.Empty)
                             {
                                 modelTermSet.Id = Guid.NewGuid();
                             }
+
                             set = group.CreateTermSet(parser.ParseString(modelTermSet.Name), modelTermSet.Id,
                                 modelTermSet.Language ?? termStore.DefaultLanguage);
                             parser.AddToken(new TermSetIdToken(web, group.Name, modelTermSet.Name, modelTermSet.Id));
@@ -285,6 +291,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 });
                 return null;
             }
+            else // if the term isn't reused, give it a new Guid 
+                modelTerm.Id = Guid.NewGuid();
 
             // Create new term
             Term term;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | NA

#### What's in this Pull Request?

Consider this scenario.
1. Export a SiteCollection Term and TermSet and assign the exported template to a variable
2. Apply the template to a Site Collection
3. Apply the same template to another Site Collection
You now get the error "Failed to read from or write to database".

The issue is that Term and TermSet is assigned a Id. When the TermSet and Term are created the second site collection a TermSet and Term ids already exist in the database. 

This fix assigns a new id to the TermSet if the TermGroup is SiteCollection.
Also if a Term isn't a reused Term a new Id is assigned.