### PR TITLE
re-introducing usage of ONPREMISES compiler flag for GetWebParts as t…

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/PageExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/PageExtensions.cs
@@ -83,7 +83,7 @@ namespace Microsoft.SharePoint.Client
 
             IEnumerable<WebPartDefinition> query;
 
-#if SP2016
+#if ONPREMISES
             // As long as we've no CSOM library that has the ZoneID we can't use the version check as things don't compile...
             query = web.Context.LoadQuery(limitedWebPartManager.WebParts.IncludeWithDefaultProperties(wp => wp.Id, wp => wp.WebPart, wp => wp.WebPart.Title, wp => wp.WebPart.Properties, wp => wp.WebPart.Hidden));
 #else


### PR DESCRIPTION
…he version check has proven unreliable. This extension method is used not only by ObjectPages but by the ObjectFiles handler and in its current state it appears to make it impossible to provision web-parts to webpart pages onpremises

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no?
| New sample?      | no?
| Related issues?  | fixes #866, related to #1140 

#### What's in this Pull Request?

Changed compiler flag from 2016 to ONPREMISES
