### PR TITLE
Support modifying Forms pages by null-checking ListItemAllfields

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/FileFolderExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/FileFolderExtensions.cs
@@ -1274,7 +1274,7 @@ namespace Microsoft.SharePoint.Client
             {
                 var context = file.Context;
 
-                bool normalFile = true;
+                bool normalFile = !file.ListItemAllFields.ServerObjectIsNull ?? false; //normal files have listItemAllFields;
                 var checkOutRequired = false;
                 if (normalFile)
                 {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | none

#### What's in this Pull Request?
When treating files its a bit dangerous to assume all files live in lists. One example of this is when modifying existing forms pages, e.g. adding webparts to these. For us this is a pretty common scenario, we often add a content editor webpart or script editor webpart to forms pages so we can modify OOB functionaltity without creating custom Forms pages.

In order to support adding webparts to pages which are NOT normal files, we have to do a null check on listitemallfields whenever we use that.
