### PR TITLE
Handling duplicated field reference causing formula syntax error for …

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectHandlerBase.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectHandlerBase.cs
@@ -60,7 +60,10 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 var formulaString = formula.Value;
                 if (formulaString != null)
                 {
-                    var fieldRefs = schemaElement.Descendants("FieldRef");
+                    //It could be possible that a formula is referring to one field for mutliple times and thus generating kind of duplicated field reference, the duplication should be removed
+                    //For example, formula =IF(NOT(ISBLANK(Region)),Title&" - "&[Project No.]&" ("&Region&")","") will creates 2 reference to Region field and leads to an incorrect formula
+                    var fieldRefs = schemaElement.Descendants("FieldRef").GroupBy(f => new { f.Attribute("Name").Value }).Select(g => g.First()).ToList();
+                    
                     foreach (var fieldRef in fieldRefs)
                     {
                         var fieldInternalName = fieldRef.Attribute("Name").Value;


### PR DESCRIPTION
…calucated field

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

When a calucated field contains formula referring to one field for mutliple times, formula =IF(NOT(ISBLANK(Region)),Title&" - "&[Project No.]&" ("&Region&")","") which is referring to Region twice and thus region field will be listed twice in the FieldRef and in thise case the current implementation will try to replace Region twice and leads to incorrect syntax in formula