### PR TITLE
#1208: filter content types that come with content type syndication

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ProvisioningTemplateCreationInformation.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ProvisioningTemplateCreationInformation.cs
@@ -25,6 +25,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         private bool skipVersionCheck = false;
         private List<ExtensibilityHandler> extensibilityHandlers = new List<ExtensibilityHandler>();
         private Handlers handlersToProcess = Handlers.All;
+        private bool includeContentTypesFromSyndication = false;
 
         public ProvisioningProgressDelegate ProgressDelegate { get; set; }
         public ProvisioningMessagesDelegate MessagesDelegate { get; set; }
@@ -234,6 +235,18 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         {
             get { return skipVersionCheck; }
             set { skipVersionCheck = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to include content types from syndication or not.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if the export should contains content types issued from syndication
+        /// </value>
+        public bool IncludeContentTypesFromSyndication
+        {
+            get { return includeContentTypesFromSyndication; }
+            set { includeContentTypesFromSyndication = value; }
         }
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no 
| New feature?    |  yes
| New sample?      | no 
| Related issues?  | fixes #1208

#### What's in this Pull Request?

When a content type is provisioned through content type syndication, it's flagged as *read-only* in the site collection.

This leads to provisioning error because the PNP provisioning engine try to create the content type, which is already here because of the ct syndication.

My solution was simply to check if the content type is syndicated or not, to avoid exporting the content type.

A flag has also been added to the `ProvisioningTemplateCreationInformation` to reenable exporting this kind of content types.

Hope that helps