### PR TITLE
Complemented navigation objects and extensions

### DIFF
--- a/Core/OfficeDevPnP.Core/Entities/AreaNavigationEntity.cs
+++ b/Core/OfficeDevPnP.Core/Entities/AreaNavigationEntity.cs
@@ -47,5 +47,14 @@ namespace OfficeDevPnP.Core.Entities
         /// </summary>
         public StructuralNavigationSortBy SortBy { get; set; }
 
+        /// <summary>
+        /// Defines if new pages should be added to navigation when using managed metadata navigation
+        /// </summary>
+        public Boolean AddNewPagesToNavigation { get; set; }
+
+        /// <summary>
+        /// Defines if friendly URLs should be created for new pages when using managed metadata navigation
+        /// </summary>
+        public Boolean CreateFriendlyUrlsForNewPages { get; set; }
     }
 }

--- a/Core/OfficeDevPnP.Core/Entities/StructuralNavigationEntity.cs
+++ b/Core/OfficeDevPnP.Core/Entities/StructuralNavigationEntity.cs
@@ -20,7 +20,10 @@ namespace OfficeDevPnP.Core.Entities
             ShowSubsites = true;
             ShowPages = false;
         }
-
+        /// <summary>
+        /// Site navigation is inherited from parent web
+        /// </summary>
+        public bool InheritFromParentWeb { get; set; }
         /// <summary>
         /// Site navigation powered by the SharePoint managed metadata service (taxonomy). Use it to build site navigation derived from a managed metadata taxonomy. Managed navigation often works best with the product catalog
         /// </summary>

--- a/Core/OfficeDevPnP.Core/Extensions/NavigationExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/NavigationExtensions.cs
@@ -88,6 +88,28 @@ namespace Microsoft.SharePoint.Client
                         nav.GlobalNavigation.ManagedNavigation = managedNavigation;
                     }
                 }
+                // Get settings related to page creation
+                XElement pageNode = navigationSettings.XPathSelectElement("./NewPageSettings");
+                if (pageNode != null)
+                {
+                    if (pageNode.Attribute("AddNewPagesToNavigation") != null)
+                    {
+                        bool addNewPagesToNavigation;
+                        if (bool.TryParse(pageNode.Attribute("AddNewPagesToNavigation").Value, out addNewPagesToNavigation))
+                        {
+                            nav.AddNewPagesToNavigation = addNewPagesToNavigation;
+                        }
+                    }
+
+                    if (pageNode.Attribute("CreateFriendlyUrlsForNewPages") != null)
+                    {
+                        bool createFriendlyUrlsForNewPages;
+                        if (bool.TryParse(pageNode.Attribute("CreateFriendlyUrlsForNewPages").Value, out createFriendlyUrlsForNewPages))
+                        {
+                            nav.CreateFriendlyUrlsForNewPages = createFriendlyUrlsForNewPages;
+                        }
+                    }
+                }
             }
 
             // Only read the other values that make sense when not using managed navigation
@@ -196,6 +218,14 @@ namespace Microsoft.SharePoint.Client
             {
                 webNav.CurrentNavigation.Source = StandardNavigationSource.TaxonomyProvider;
             }
+
+            // If managed metadata navigation is used, set settings related to page creation
+            if (navigationSettings.GlobalNavigation.ManagedNavigation || navigationSettings.CurrentNavigation.ManagedNavigation)
+            {
+                webNav.AddNewPagesToNavigation = navigationSettings.AddNewPagesToNavigation;
+                webNav.CreateFriendlyUrlsForNewPages = navigationSettings.CreateFriendlyUrlsForNewPages;
+            }
+
             webNav.Update(taxonomySession);
             web.Context.ExecuteQueryRetry();
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no

#### What's in this Pull Request?

Made possible to get and set navigation settings (inheritance and managed navigation related settings):

- Complemented AreaNavigationEntity with managed metadata related properties:
-- AddNewPagesToNavigation
-- CreateFriendlyUrlsForNewPages

- Complemented StructuralNavigationEntity wit property:
-- InheritFromParentWeb

- Complemented NavigationExtensions methods with getting and setting the above properties.
