### PR TITLE
has uniqueroleassignments inheritance

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/OfficeDevPnP.Core.Tests.csproj
+++ b/Core/OfficeDevPnP.Core.Tests/OfficeDevPnP.Core.Tests.csproj
@@ -467,9 +467,6 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config">
-      <SubType>Designer</SubType>
-    </None>
     <None Include="App.config.sample" />
     <None Include="Framework\Functional\Templates\ct3document.docx" />
     <None Include="Framework\Functional\Templates\ct1document.docx" />

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
@@ -685,7 +685,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 if (_willProvision == true)
                 {
                     // if not subweb and site inheritance is not broken
-                    if (web.IsSubSite() && web.EnsureProperty(w => w.HasUniqueRoleAssignments) == false) 
+                    if (web.IsSubSite() && web.EnsureProperty(w => w.HasUniqueRoleAssignments) == true) 
                     {
                         _willProvision = false;
                     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |  yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?

In the breakroleinheritance there was a issue with _willprovision which was set to false. And needed to be True to break the roles. I was wondering if it really needs to check if the properties are filled as breakroleinheritance does not need new permisions.. or new admins etc.

Please only use the objectsitesecurity class.
