### PR TITLE
Add new tokendefinition (RoleDefinitionId) incl. UTs

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectSiteSecurityTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectSiteSecurityTests.cs
@@ -51,14 +51,16 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
         public void CanProvisionObjects()
         {
             var template = new ProvisioningTemplate();
-
+            var roleDefinitionName = "UT_RoleDefinition";
 
             foreach (var user in admins)
             {
                 template.Security.AdditionalMembers.Add(new User() { Name = user.LoginName });
             }
-
-
+            template.Security.SiteSecurityPermissions.RoleDefinitions.Add(new Core.Framework.Provisioning.Model.RoleDefinition()
+            {
+                Name = roleDefinitionName
+            });
 
             using (var ctx = TestCommon.CreateClientContext())
             {
@@ -66,7 +68,9 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                 new ObjectSiteSecurity().ProvisionObjects(ctx.Web, template, parser, new ProvisioningTemplateApplyingInformation());
 
                 var memberGroup = ctx.Web.AssociatedMemberGroup;
+                var roleDefinitions = ctx.Web.RoleDefinitions;
                 ctx.Load(memberGroup, g => g.Users);
+                ctx.Load(roleDefinitions);
                 ctx.ExecuteQueryRetry();
                 foreach (var user in admins)
                 {
@@ -75,6 +79,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                     ctx.ExecuteQueryRetry();
                     Assert.IsNotNull(existingUser);
                 }
+                Assert.IsTrue(roleDefinitions.Any(rd => rd.Name == roleDefinitionName),"New role definition wasn't found after provisioning");
             }
         }
 

--- a/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/TokenParserTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/TokenParserTests.cs
@@ -34,6 +34,10 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                 var themesCatalog = ctx.Web.GetCatalog((int)ListTemplateType.ThemeCatalog);
                 ctx.Load(themesCatalog, t => t.RootFolder.ServerRelativeUrl);
 
+                var expectedRoleDefinitionId = 1073741826;
+                var roleDefinition = ctx.Web.RoleDefinitions.GetById(expectedRoleDefinitionId);
+                ctx.Load(roleDefinition);
+
                 ctx.ExecuteQueryRetry();
 
                 var currentUser = ctx.Web.EnsureProperty(w => w.CurrentUser);
@@ -70,6 +74,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                 var associatedVisitorGroupId = parser.ParseString("{groupid:associatedvisitorgroup}");
                 var groupId = parser.ParseString($"{{groupid:{ownerGroupName}}}");
                 var siteOwner = parser.ParseString("{siteowner}");
+                var roleDefinitionId = parser.ParseString($"{{roledefinitionid:{roleDefinition.Name}}}");
 
                 Assert.IsTrue(site1 == $"{ctx.Web.ServerRelativeUrl}/test");
                 Assert.IsTrue(site2 == $"{ctx.Web.ServerRelativeUrl}/test");
@@ -96,7 +101,8 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                 Assert.IsTrue(int.Parse(associatedVisitorGroupId) == ctx.Web.AssociatedVisitorGroup.Id);
                 Assert.IsTrue(associatedOwnerGroupId == groupId);
                 Assert.IsTrue(siteOwner == ctx.Site.Owner.LoginName);
-
+                
+                Assert.IsTrue(roleDefinitionId == expectedRoleDefinitionId.ToString(), $"Role Definition Id was not parsed correctly (expected:{expectedRoleDefinitionId};returned:{roleDefinitionId})");
             }
         }
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
@@ -203,8 +203,10 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                                 roleDefinitionCI.BasePermissions = basePermissions;
 
-                                web.RoleDefinitions.Add(roleDefinitionCI);
+                                var newRoleDefinition = web.RoleDefinitions.Add(roleDefinitionCI);
+                                web.Context.Load(newRoleDefinition, nrd => nrd.Name, nrd => nrd.Id);
                                 web.Context.ExecuteQueryRetry();
+                                parser.AddToken(new RoleDefinitionIdToken(web,newRoleDefinition.Name,newRoleDefinition.Id));
                             }
                             else
                             {

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/RoleDefinitionIdToken.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/RoleDefinitionIdToken.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.SharePoint.Client;
+using System.Text.RegularExpressions;
+
+namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitions
+{
+    internal class RoleDefinitionIdToken : TokenDefinition
+    {
+        private readonly int _roleDefinitionId = 0;
+        public RoleDefinitionIdToken(Web web, string name, int roleDefinitionId)
+            : base(web, $"{{roledefinitionid:{Regex.Escape(name)}}}")
+        {
+            _roleDefinitionId = roleDefinitionId;
+        }
+
+        public override string GetReplaceValue()
+        {
+            if (string.IsNullOrEmpty(CacheValue))
+            {
+                CacheValue = _roleDefinitionId.ToString();
+            }
+            return CacheValue;
+        }
+    }
+}

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
@@ -244,10 +244,14 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             }
 
             // OOTB Roledefs
-            web.EnsureProperty(w => w.RoleDefinitions.Include(r => r.RoleTypeKind));
+            web.EnsureProperty(w => w.RoleDefinitions.Include(r => r.RoleTypeKind,r => r.Name,r => r.Id));
             foreach (var roleDef in web.RoleDefinitions.AsEnumerable().Where(r => r.RoleTypeKind != RoleType.None))
             {
                 _tokens.Add(new RoleDefinitionToken(web, roleDef));
+            }
+            foreach(var roleDef in web.RoleDefinitions)
+            {
+                _tokens.Add(new RoleDefinitionIdToken(web, roleDef.Name, roleDef.Id));
             }
 
             // Groups
@@ -272,6 +276,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             {
                 _tokens.Add(new GroupIdToken(web, "associatedownergroup", web.AssociatedOwnerGroup.Id));
             }
+
             var sortedTokens = from t in _tokens
                                orderby t.GetTokenLength() descending
                                select t;

--- a/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
+++ b/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
@@ -418,6 +418,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>CoreResources.resx</DependentUpon>
     </Compile>
+    <Compile Include="Framework\Provisioning\ObjectHandlers\TokenDefinitions\RoleDefinitionIdToken.cs" />
     <Compile Include="Framework\Provisioning\Providers\Xml\Resolvers\TermSetFromModelToSchemaTypeResolver.cs" />
     <Compile Include="Framework\Provisioning\Providers\Xml\Resolvers\ExpressionTypeResolver.cs" />
     <Compile Include="Framework\Provisioning\Providers\Xml\Resolvers\ExpressionCollectionValueResolver.cs" />


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no 
| New feature?    | yes
| New sample?      | no
| Related issues?  | /

#### What's in this Pull Request?
Added a new token '{roledefinitionid:name_of_roledefinition}'
i.e.
{roledefinitionid:Read} will return the id of the roledefinition.

I use it to replace the value in a workflow I created so I spare the need to call REST-service to get this data each time the WF is running.

Unit tests have been extended to test the new token.