### PR TITLE
Fixed an Issue in ClientContextExtensions - the compareToVersion obje…

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/ClientContextExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/ClientContextExtensions.cs
@@ -288,7 +288,7 @@ namespace Microsoft.SharePoint.Client
                         string version = reader.ReadToEnd().Split('|')[2].Trim();
 
                         // Only compare the first three digits
-                        var compareToVersion = new Version(minimallyRequiredVersion.Major, minimallyRequiredVersion.MajorRevision, minimallyRequiredVersion.Minor, 0);
+                        var compareToVersion = new Version(minimallyRequiredVersion.Major, minimallyRequiredVersion.Minor, minimallyRequiredVersion.Build, 0);
                         hasMinimalVersion = new Version(version.Split('.')[0].ToInt32(), 0, version.Split('.')[3].ToInt32(), 0).CompareTo(compareToVersion) >= 0;
                     }
                 }


### PR DESCRIPTION
…ct was initialized incorrect. Now it uses:

minimallyRequiredVersion.Major
minimallyRequiredVersion.Minor
minimallyRequiredVersion.Build
0

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | none

#### What's in this Pull Request?

The method HasMinimalServerLibraryVersion in ClientContextExtensions.cs used a wrong parameter in the constructor of the compareToVersion object. This leads to potential issues if the Method in the Servers Version is not yet implemented but this check returns a false positive

| Constructor  Param | Prior | fixed
| --------------- | --- | ---------
| Major | minimallyRequiredVersion.Major | minimallyRequiredVersion.Major
| Minor | minimallyRequiredVersion.MajorRevision | minimallyRequiredVersion.Minor
| Build | minimallyRequiredVersion.Minor| minimallyRequiredVersion.Build
| Revision | 0 | 0 
