### PR TITLE
Fixed to properly detokenize xml strings containing xml escaped token…

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/TokenParserTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/TokenParserTests.cs
@@ -132,6 +132,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                 var termSetId = Guid.NewGuid();
                 var termStoreId = Guid.NewGuid();
 
+                var resolvedTermGroupName = parser.ParseString("{sitecollectiontermgroupname}");
 
                 // Use fake data
                 parser.AddToken(new ContentTypeIdToken(web, contentTypeName, contentTypeId));
@@ -139,6 +140,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                 parser.AddToken(new ListUrlToken(web, listTitle, listUrl));
                 parser.AddToken(new WebPartIdToken(web, webPartTitle, webPartId));
                 parser.AddToken(new TermSetIdToken(web, termGroupName, termSetName, termSetId));
+                parser.AddToken(new TermSetIdToken(web, resolvedTermGroupName, termSetName, termSetId));
                 parser.AddToken(new TermStoreIdToken(web, termStoreName, termStoreId));
 
                 var resolvedContentTypeId = parser.ParseString($"{{contenttypeid:{contentTypeName}}}");
@@ -150,6 +152,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                 var parameterTest2 = parser.ParseString("abc{$test(T)}/test");
                 var resolvedWebpartId = parser.ParseString($"{{webpartid:{webPartTitle}}}");
                 var resolvedTermSetId = parser.ParseString($"{{termsetid:{termGroupName}:{termSetName}}}");
+                var resolvedTermSetId2 = parser.ParseString($"{{termsetid:{{sitecollectiontermgroupname}}:{termSetName}}}");
                 var resolvedTermStoreId = parser.ParseString($"{{termstoreid:{termStoreName}}}");
 
 
@@ -161,6 +164,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                 Assert.IsTrue(parameterTest2 == parameterExpectedResult);
                 Assert.IsTrue(Guid.TryParse(resolvedWebpartId, out outGuid));
                 Assert.IsTrue(Guid.TryParse(resolvedTermSetId, out outGuid));
+                Assert.IsTrue(Guid.TryParse(resolvedTermSetId2, out outGuid));
                 Assert.IsTrue(Guid.TryParse(resolvedTermStoreId, out outGuid));
 
             }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
@@ -45,7 +45,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 {
                     currentFieldIndex++;
 
-                    XElement templateFieldElement = XElement.Parse(parser.ParseString(field.SchemaXml, "~sitecollection", "~site"));
+                    XElement templateFieldElement = XElement.Parse(parser.ParseXmlString(field.SchemaXml, "~sitecollection", "~site"));
                     var fieldId = templateFieldElement.Attribute("ID").Value;
                     var fieldInternalName = templateFieldElement.Attribute("InternalName") != null ? templateFieldElement.Attribute("InternalName").Value : "";
                     WriteMessage($"Field|{(!string.IsNullOrWhiteSpace(fieldInternalName) ? fieldInternalName : fieldId)}|{currentFieldIndex}|{fields.Count}", ProvisioningMessageType.Progress);
@@ -101,7 +101,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         templateFieldElement.Attribute("List").Remove();
                     }
 
-                    if (IsFieldXmlValid(parser.ParseString(originalFieldXml), parser, web.Context))
+                    if (IsFieldXmlValid(parser.ParseXmlString(originalFieldXml), parser, web.Context))
                     {
                         foreach (var attribute in templateFieldElement.Attributes())
                         {
@@ -136,7 +136,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         {
                             existingFieldElement.Attributes("Version").Remove();
                         }
-                        existingField.SchemaXml = parser.ParseString(existingFieldElement.ToString(), "~sitecollection", "~site");
+                        existingField.SchemaXml = parser.ParseXmlString(existingFieldElement.ToString(), "~sitecollection", "~site");
                         existingField.UpdateAndPushChanges(true);
                         web.Context.Load(existingField, f => f.TypeAsString, f => f.DefaultValue);
                         try
@@ -289,7 +289,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 templateFieldElement.Attribute("List").Remove();
             }
 
-            var fieldXml = parser.ParseString(templateFieldElement.ToString(), "~sitecollection", "~site");
+            var fieldXml = parser.ParseXmlString(templateFieldElement.ToString(), "~sitecollection", "~site");
 
             if (IsFieldXmlValid(fieldXml, parser, web.Context))
             {

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
@@ -126,7 +126,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                     scope.LogDebug(CoreResources.Provisioning_ObjectHandlers_Files_Adding_webpart___0___to_page, webPart.Title);
                                     var wpEntity = new WebPartEntity();
                                     wpEntity.WebPartTitle = parser.ParseString(webPart.Title);
-                                    wpEntity.WebPartXml = parser.ParseString(webPart.Contents).Trim(new[] { '\n', ' ' });
+                                    wpEntity.WebPartXml = parser.ParseXmlString(webPart.Contents).Trim(new[] { '\n', ' ' });
                                     wpEntity.WebPartZone = webPart.Zone;
                                     wpEntity.WebPartIndex = (int)webPart.Order;
                                     var wpd = web.AddWebPartToWebPartPage(targetFile.ServerRelativeUrl, wpEntity);

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -220,7 +220,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                             foreach (var field in listInfo.TemplateList.Fields)
                             {
 
-                                var fieldElement = XElement.Parse(parser.ParseString(field.SchemaXml, "~sitecollection", "~site"));
+                                var fieldElement = XElement.Parse(parser.ParseXmlString(field.SchemaXml, "~sitecollection", "~site"));
                                 if (fieldElement.Attribute("ID") == null)
                                 {
                                     scope.LogError(CoreResources.Provisioning_ObjectHandlers_ListInstances_Field_schema_has_no_ID_attribute___0_, field.SchemaXml);
@@ -721,8 +721,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             Field field = null;
             fieldElement = PrepareField(fieldElement);
 
-            var fieldXml = parser.ParseString(fieldElement.ToString(), "~sitecollection", "~site");
-            if (IsFieldXmlValid(parser.ParseString(originalFieldXml), parser, context))
+            var fieldXml = parser.ParseXmlString(fieldElement.ToString(), "~sitecollection", "~site");
+            if (IsFieldXmlValid(parser.ParseXmlString(originalFieldXml), parser, context))
             {
                 field = listInfo.SiteList.Fields.AddFieldAsXml(fieldXml, false, AddFieldOptions.AddFieldInternalNameHint);
                 listInfo.SiteList.Context.Load(field);
@@ -784,7 +784,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 if (existingFieldElement.Attribute("Type").Value == templateFieldElement.Attribute("Type").Value)
                 {
                     templateFieldElement = PrepareField(templateFieldElement);
-                    if (IsFieldXmlValid(parser.ParseString(templateFieldElement.ToString()), parser, web.Context))
+                    if (IsFieldXmlValid(parser.ParseXmlString(templateFieldElement.ToString()), parser, web.Context))
                     {
                         foreach (var attribute in templateFieldElement.Attributes())
                         {
@@ -819,7 +819,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         {
                             existingFieldElement.Attributes("Version").Remove();
                         }
-                        existingField.SchemaXml = parser.ParseString(existingFieldElement.ToString(), "~sitecollection", "~site");
+                        existingField.SchemaXml = parser.ParseXmlString(existingFieldElement.ToString(), "~sitecollection", "~site");
                         existingField.UpdateAndPushChanges(true);
                         web.Context.ExecuteQueryRetry();
                         bool isDirty = false;

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPages.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPages.cs
@@ -130,7 +130,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                 {
                                     WebPartEntity wpEntity = new WebPartEntity();
                                     wpEntity.WebPartTitle = parser.ParseString(webPart.Title);
-                                    wpEntity.WebPartXml = parser.ParseString(webPart.Contents.Trim(new[] { '\n', ' ' }),"~sitecollection", "~site");
+                                    wpEntity.WebPartXml = parser.ParseXmlString(webPart.Contents.Trim(new[] { '\n', ' ' }), "~sitecollection", "~site");
                                     var wpd = web.AddWebPartToWikiPage(url, wpEntity, (int)webPart.Row, (int)webPart.Column, false);
 #if !SP2013
                                     if (webPart.Title.ContainsResourceToken())
@@ -144,10 +144,10 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 #endif
                                         webPart.Order = (uint)wpd.WebPart.ZoneIndex;
                                         webPartsNeedLocalization = true;
-                                   }
-#endif
                                     }
+#endif
                                 }
+                            }
                             var allWebParts = web.GetWebParts(url);
                             foreach (var webpart in allWebParts)
                             {

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectWorkflows.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectWorkflows.cs
@@ -223,7 +223,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                         RequiresInitiationForm = templateDefinition.RequiresInitiationForm,
                                         RestrictToScope = parser.ParseString(templateDefinition.RestrictToScope),
                                         RestrictToType = templateDefinition.RestrictToType != "Universal" ? templateDefinition.RestrictToType : null,
-                                        Xaml = parser.ParseString(xaml.ToString()),
+                                        Xaml = parser.ParseXmlString(xaml.ToString()),
                                     };
 
                                 //foreach (var p in definition.Properties)

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
@@ -355,21 +355,27 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         /// <returns>Returns parsed string</returns>
         public string ParseString(string input, params string[] tokensToSkip)
         {
-            if (string.IsNullOrEmpty(input) || input.IndexOfAny(new []{'{','~'}) == -1) return input;
+            var tokenChars = new[] { '{', '~' };
+            if (string.IsNullOrEmpty(input) || input.IndexOfAny(tokenChars) == -1) return input;
 
             var tokensToSkipList = tokensToSkip?.ToList() ?? new List<string>();
+            string origInput;
 
-            foreach (var token in _tokens)
+            do
             {
-                foreach (var filteredToken in token.GetTokens().Except(tokensToSkipList, StringComparer.InvariantCultureIgnoreCase))
+                origInput = input;
+                foreach (var token in _tokens)
                 {
-                    var regex = token.GetRegexForToken(filteredToken);
-                    if (regex.IsMatch(input))
+                    foreach (var filteredToken in token.GetTokens().Except(tokensToSkipList, StringComparer.InvariantCultureIgnoreCase))
                     {
-                        input = regex.Replace(input, ParseString(token.GetReplaceValue(), tokensToSkipList.Concat(new[] { filteredToken }).ToArray()));
+                        var regex = token.GetRegexForToken(filteredToken);
+                        if (regex.IsMatch(input))
+                        {
+                            input = regex.Replace(input, ParseString(token.GetReplaceValue(), tokensToSkipList.Concat(new[] { filteredToken }).ToArray()));
+                        }
                     }
                 }
-            }
+            } while (origInput != input && input.IndexOfAny(tokenChars) >= 0);
 
             return input;
         }


### PR DESCRIPTION
Fixed to properly detokenize xml strings containing xml escaped tokens.

Updated TokenParser.ParseString to be simpler, more performant, and safer (now prevents infinite loops in nested parameters).

Added simple unit test for testing nested parameters.

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | https://github.com/SharePoint/PnP-Sites-Core/pull/1231

#### What's in this Pull Request?

The TokenParser.ParseString method did not properly handle XML strings containing XML escaped tokens. The token regexes would not match a token that had been XML escaped. I've added a new method that converts the XML string into an XmlDocument, then searches through attributes and element text values, replacing tokens as necessary, then returns back the full XML string.

I've also Updated TokenParser.ParseString to be simpler, more performant, and safer (now prevents infinite loops in nested parameters). Previously, one could cause an infinite loop by using nested params where param A contains a token for param B which contains a token for param C which contains a token for param A. I also added a short-circuiting condition to skip searching a string for tokens if the string doesn't contain a { or ~ character so that we're not needlessly running hundreds of regex searches against a string that doesn't contain any tokens. I don't see a hard requirement for tokens to begin with one of those two characters, but it seems to be the convention for all the tokens currently constructed in this project. If that's not the case, feel free to remove that condition from the initial if statement in the ParseString method.