### PR TITLE
New Feature: Provision WikiPages into SubFolders of a Library

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/PageExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/PageExtensions.cs
@@ -1008,7 +1008,14 @@ namespace Microsoft.SharePoint.Client
             }
 
             var folderName = serverRelativePageUrl.Substring(0, serverRelativePageUrl.LastIndexOf("/", StringComparison.Ordinal));
-            var folder = web.GetFolderByServerRelativeUrl(folderName);
+            
+            //ensure that folderName does not contain the web's ServerRelativeUrl -> otherwise it will fail on SubSites
+            if (folderName.ToLower().StartsWith((web.ServerRelativeUrl.ToLower())))
+            {
+                folderName = folderName.Substring(web.ServerRelativeUrl.Length);
+            }
+            var folder = web.EnsureFolderPath(folderName);
+
             folder.Files.AddTemplateFile(serverRelativePageUrl, TemplateFileType.WikiPage);
 
             web.Context.ExecuteQueryRetry();


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no
| Related issues?  | none

#### What's in this Pull Request?
If you provide a path to a WikiPage, that contains a folder in the library, the Provisioning will fail.
e.g: /sitepages/SubFolderA/somePage.aspx

This change will ensure that the target folder (SubFolderA) is created, before the Wiki Page is uploaded.