### PR TITLE
Make TokenHelper public

### DIFF
--- a/Core/OfficeDevPnP.Core/Utilities/TokenHelper.cs
+++ b/Core/OfficeDevPnP.Core/Utilities/TokenHelper.cs
@@ -26,7 +26,7 @@ using X509SigningCredentials = Microsoft.IdentityModel.SecurityTokenService.X509
 
 namespace OfficeDevPnP.Core.Utilities
 {
-    internal static class TokenHelper
+    public static class TokenHelper
     {
         #region public fields
 


### PR DESCRIPTION


| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?

Trying to use Azure Functions to create/maintain SharePoint WebHooks. To call the Rest API, we need an access token (app only). This is not exposed via the public AuthenticationManager class. 

Either need to make class public or wrap GetAppOnlyAccessToken somewhere.
