### PR TITLE
Fixed issue where PersistFile is replacing already set Container

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Connectors/AzureStorageConnector.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Connectors/AzureStorageConnector.cs
@@ -351,15 +351,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
         /// <returns>Returns filename without path</returns>
         public override string GetFilenamePart(string fileName)
         {
-            if (fileName.IndexOf(@"/") != -1)
-            {
-                var parts = fileName.Split(new[] { @"/" }, StringSplitOptions.RemoveEmptyEntries);
-                return parts.LastOrDefault();
-            }
-            else
-            {
-                return fileName;
-            }
+            return Path.GetFileName(fileName);
         }
 
         #endregion

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Connectors/FileSystemConnector.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Connectors/FileSystemConnector.cs
@@ -131,15 +131,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
         /// <returns>Returns filename without path</returns>
         public override string GetFilenamePart(string fileName)
         {
-            if (fileName.IndexOf(@"\") != -1)
-            {
-                var parts = fileName.Split(new []{@"\"}, StringSplitOptions.RemoveEmptyEntries);
-                return parts.LastOrDefault();
-            }
-            else
-            {
-                return fileName;
-            }
+            return Path.GetFileName(fileName);
         }
 
         /// <summary>

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Connectors/OpenXMLConnector.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Connectors/OpenXMLConnector.cs
@@ -179,14 +179,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
         /// <returns>Returns a filename without a path</returns>
         public override string GetFilenamePart(string fileName)
         {
-            fileName = fileName.Replace(@"/", @"\");
-
-            if (fileName.Contains(@"\"))
-            {
-                var parts = fileName.Split(new[] { @"\" }, StringSplitOptions.RemoveEmptyEntries);
-                return parts.LastOrDefault();
-            }
-            return fileName;
+            return Path.GetFileName(fileName);
         }
 
         /// <summary>

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Connectors/SharePointConnector.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Connectors/SharePointConnector.cs
@@ -373,16 +373,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
         /// <returns>Returns a filename without a path</returns>
         public override string GetFilenamePart(string fileName)
         {
-            fileName = fileName.Replace('\\', '/');
-            if (fileName.IndexOf(@"/") != -1)
-            {
-                var parts = fileName.Split(new[] { @"/" }, StringSplitOptions.RemoveEmptyEntries);
-                return parts.LastOrDefault();
-            }
-            else
-            {
-                return fileName;
-            }
+            return Path.GetFileName(fileName);
         }
 
         #endregion

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentHandlerBase.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentHandlerBase.cs
@@ -168,9 +168,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         {
             if (creationInfo.FileConnector != null)
             {
+                var fileConnector = creationInfo.FileConnector;
                 SharePointConnector connector = new SharePointConnector(web.Context, web.Url, "dummy");
-
-                
                 Uri u = new Uri(web.Url);
 
                 if (u.PathAndQuery != "/")
@@ -183,6 +182,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                 String container = folderPath.Trim('/').Replace("%20", " ").Replace("/", "\\");
                 String persistenceFileName = (decodeFileName ? HttpUtility.UrlDecode(fileName) : fileName).Replace("%20", " ");
+
+                if (fileConnector.Parameters.ContainsKey(FileConnectorBase.CONTAINER))
+                {
+                    container = string.Concat(fileConnector.GetContainer(), container);
+                }
 
                 using (Stream s = connector.GetFileStream(fileName, folderPath))
                 {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | N/A

#### What's in this Pull Request?

If a FileConnector with a Container is set to eg. /Templates/SubFolder and PersistBrandingFiles is True,
the FileConnector container is replaced when persisting a page in the PageContents Objecthandler.

Let's say that the SiteAssets/default.aspx page should be persisted.
Then the Container will be /SiteAssets instead of  /Templates/SubFolder/SiteAssets which will in my case result in a bad server request as I'm using the AzureStorageConnector.

This change will check for an already set Container and concatenate it.
