### PR TITLE
Fixed so that webparts with the same title can be successfully added …

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPages.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPages.cs
@@ -144,10 +144,15 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 #endif
                                         webPart.Order = (uint)wpd.WebPart.ZoneIndex;
                                         webPartsNeedLocalization = true;
-                                   }
-#endif
                                     }
+#endif
                                 }
+                            }
+
+                            // Remove any existing WebPartIdToken tokens in the parser that were added by other pages. They won't apply to this page,
+                            // and they'll cause issues if this page contains web parts with the same name as web parts on other pages.
+                            parser.Tokens.RemoveAll(t => t is WebPartIdToken);
+
                             var allWebParts = web.GetWebParts(url);
                             foreach (var webpart in allWebParts)
                             {


### PR DESCRIPTION
…to multiple pages with a custom layout. Previously, if two pages had a webpart with the same name, the token parser would end up replacing webpartid tokens in the WikiField field of both pages with the ID of whichever webpart was processed first.

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?

Currently, if you have two pages in your template using custom layouts, and both have a webpart with the same name (for example, if I've added the 'Documents' library as a web part to both pages), the web part will only be correctly added to the first page. This is because the WikiField field for the pages will both contain a token for the web part ( {webpartid:Documents} ), and the token parser will replace it with the ID of whichever webpart was processed and added to the parser first. The token parser should be cleared of any existing WebPartIdTokens before adding the tokens for the current page's web parts and processing the page's fields.

