### PR TITLE
ViewData property for View schema in ListInstance element

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -583,7 +583,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     }
                 }
 
-
                 createdList.Update();
                 web.Context.ExecuteQueryRetry();
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -457,7 +457,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 }
 
                 var createdView = createdList.Views.Add(viewCI);
-                createdView.EnsureProperties(v => v.Scope, v => v.JSLink, v => v.Title, v => v.Aggregations, v => v.MobileView, v => v.MobileDefaultView);
+                createdView.EnsureProperties(v => v.Scope, v => v.JSLink, v => v.Title, v => v.Aggregations, v => v.MobileView, v => v.MobileDefaultView, v => v.ViewData);
                 web.Context.ExecuteQueryRetry();
 
                 if (urlHasValue)
@@ -562,7 +562,27 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         }
                     }
                 }
-                
+
+                // View Data
+                var viewDataElement = viewElement.Descendants("ViewData").FirstOrDefault();
+                if (viewDataElement != null)
+                {
+                    if (viewDataElement.HasElements)
+                    {
+                        var fieldRefString = "";
+                        var fieldRefs = viewDataElement.Descendants("FieldRef");
+                        foreach (var fieldRef in fieldRefs)
+                        {
+                            fieldRefString += fieldRef.ToString();
+                        }
+                        if (createdView.ViewData != fieldRefString)
+                        {
+                            createdView.ViewData = fieldRefString;
+                            createdView.Update();
+                        }
+                    }
+                }
+
 
                 createdList.Update();
                 web.Context.ExecuteQueryRetry();


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no
| Related issues?  | no

#### What's in this Pull Request?
`ListInstance` element of provisioning template allows to create views using `View` schema. This pull requests allows to include `ViewData` property in the view. This property is used when creating views for tasks or calendar lists types to specify additional settings for timeline, Gantt chart, tasks strike-through, etc.

Sample of ViewData element inside schema:
```
<View Name="....">
....
    <ViewData>
        <FieldRef Name="PercentComplete" Type="StrikeThroughPercentComplete"></FieldRef>                
    </ViewData> 
</View>
```