### PR TITLE
Fix displaying the custom outcome buttons in a Workflow ContentType t…

### DIFF
--- a/Core/OfficeDevPnP.Core/BuiltInContentTypeId.cs
+++ b/Core/OfficeDevPnP.Core/BuiltInContentTypeId.cs
@@ -68,6 +68,7 @@ namespace OfficeDevPnP.Core
         public const string WikiDocument = "0x010108";
         public const string WorkflowHistory = "0x0109";
         public const string WorkflowTask = "0x010801";
+        public const string Workflow2013Task = "0x0108003365C4474CAE8C42BCE396314E88E51F";
         public const string XMLDocument = "0x010101";
         public const string XSLStyle = "0x010100734778F2B7DF462491FC91844AE431CF";
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
@@ -455,6 +455,29 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 documentSetTemplate.Update(true);
                 web.Context.ExecuteQueryRetry();
             }
+            else if (templateContentType.Id.StartsWith(BuiltInContentTypeId.Workflow2013Task + "00"))
+            {
+                // If the Workflow Task (SP2013) contains more than one outcomeChoice, the Form UI will not show
+                // the buttons associated each to choices, but fallback to classic Save and Cancel buttons.
+                // +"00" is used to target only inherited content types and not alter OOB
+                var outcomeFields = createdCT.Context.LoadQuery(
+                    createdCT.Fields.Where(f => f.TypeAsString == "OutcomeChoice"));
+                createdCT.Context.ExecuteQueryRetry();
+
+                if (outcomeFields.Count() > 1)
+                {
+                    // 2 OutcomeChoice specified means the user has certainly push its own.
+                    // Let's remove the default outcome field
+                    var field = outcomeFields.FirstOrDefault(f => f.StaticName == "TaskOutcome");
+                    if (field != null)
+                    {
+                        var fl = createdCT.FieldLinks.GetById(field.Id);
+                        fl.DeleteObject();
+                        createdCT.Update(true);
+                        createdCT.Context.ExecuteQueryRetry();
+                    }
+                }
+            }
 
             web.Context.Load(createdCT);
             web.Context.ExecuteQueryRetry();


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| New sample?      | no
| Related issues?  | fixes #363 and #283

#### What's in this Pull Request?
- Bug Fix to the Workflow Task content Type (SP2013) with a custom OutcomeChoice field. The UI fails to display the outcome choice buttons and fallback to classic Save and Cancel buttons.
Please note this is well documented on this [Andrew Connell post](http://www.andrewconnell.com/blog/SP2013-Workflow-Custom-Task-Outcomes).
- UnitTest for this behavior in the ObjectHandlers\ContentTypes
