### PR TITLE
Fix prolem creating pnp:DataRow when User type field is the last one

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
@@ -177,9 +177,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                                     listitem[parser.ParseString(dataValue.Key)] = fieldValue;
                                                     break;
                                             }
+                                            
+                                            listitem.Update();
                                         }
                                     }
-                                    listitem.Update();
+                                    
                                     web.Context.ExecuteQueryRetry(); // TODO: Run in batches?
 
                                     if (dataRow.Security != null && (dataRow.Security.ClearSubscopes == true || dataRow.Security.CopyRoleAssignments == true || dataRow.Security.RoleAssignments.Count > 0))


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes

#### What's in this Pull Request?
- Fix problem creating pnp:DataRows, when User field is the last one.

#### My Scenario
I was trying to create DataRow with Title, LinkField and UserField. Eventually onle UserField was updated.
          <pnp:DataRows>
            <pnp:DataRow>
              <pnp:DataValue FieldName="Title">Title</pnp:DataValue>
              <pnp:DataValue FieldName="LinkField">link</pnp:DataValue>
              <pnp:DataValue FieldName="UserField">Me</pnp:DataValue>
            </pnp:DataRow>
          </pnp:DataRows>
