### PR TITLE
Fix for the Responsive UI when going to mobile view and back to desktop view

### DIFF
--- a/Core/OfficeDevPnP.Core/Resources/SP-Responsive-UI.js
+++ b/Core/OfficeDevPnP.Core/Resources/SP-Responsive-UI.js
@@ -132,7 +132,7 @@ PnPResponsiveApp.Main = (function () {
                 // let sharepoint do its thing
                 originalResizeFunction();
                 // fix the body container width
-                document.getElementById('s4-bodyContainer').style.width = document.getElementById('s4-workspace').offsetWidth;
+                document.getElementById('s4-bodyContainer').style.width = document.getElementById('s4-workspace').clientWidth + "px";   
             };
         },
         /**


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #1272

#### What's in this Pull Request?

A fix for #1272 by changing how we set the width of the 's4-bodyContainer' element in the 'FixRibbonAndWorkspaceDimensions' function.
