### PR TITLE
Use nameof instead of literal parameter name

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/TimerJobs/TimerJob.cs
+++ b/Core/OfficeDevPnP.Core/Framework/TimerJobs/TimerJob.cs
@@ -717,7 +717,7 @@ namespace OfficeDevPnP.Core.Framework.TimerJobs
         {
             if (String.IsNullOrEmpty(samAccountName))
             {
-                throw new ArgumentNullException("userName");
+                throw new ArgumentNullException(nameof(samAccountName));
             }
 
             if (password == null || password.Length == 0)


### PR DESCRIPTION
missed one exception in d3a6d77bdd1a4d985ad00481f9b0350e1caa53ee :)

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 
