### PR TITLE
Do not set  VersionLimits on SP2013

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -1826,8 +1826,10 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         l => l.OnQuickLaunch,
                         l => l.RootFolder.ServerRelativeUrl,
                         l => l.UserCustomActions,
+#if !SP2013
                         l => l.MajorVersionLimit,
                         l => l.MajorWithMinorVersionsLimit,
+#endif
                         l => l.DraftVersionVisibility,
                         l => l.DefaultDisplayFormUrl,
                         l => l.DefaultEditFormUrl,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #1152, affects #1116 

#### What's in this Pull Request?

Fixes the problem that the engine is trying to set MajorVersionlimit on SharePoint 2013. Problem is, that this property is not exposed at the API of SharePoint 2013. To be consistent with the other parts of ObjectListInstance, the property will be ignored on SharePoint 2013.

Resubmitting #1291 to DevBranch as discussed with @VesaJuvonen 