### PR TITLE
Enable token use in ListInstance.Description

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectListInstanceTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectListInstanceTests.cs
@@ -127,6 +127,59 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
         }
 
         [TestMethod]
+        public void CanTokensBeUsedInListInstance()
+        {
+            using (var ctx = TestCommon.CreateClientContext())
+            {
+                // Create list instance
+                var template = new ProvisioningTemplate();
+
+                var listUrl = string.Format("lists/{0}", listName);
+                var listTitle = listName + "_Title";
+                var listDesc = listName + "_Description";
+                template.Parameters.Add("listTitle", listTitle);
+                template.Parameters.Add("listDesc", listDesc);
+
+                template.Lists.Add(new Core.Framework.Provisioning.Model.ListInstance
+                {
+                    Url = listUrl,
+                    Title = "{parameter:listTitle}",
+                    Description = "{parameter:listDesc}",
+                    TemplateType = (int)ListTemplateType.GenericList
+                });
+
+                ctx.Web.ApplyProvisioningTemplate(template);
+
+                var list = ctx.Web.GetListByUrl(listUrl, l => l.Title, l => l.Description);
+                Assert.IsNotNull(list);
+                Assert.AreEqual(listTitle, list.Title);
+                Assert.AreEqual(listDesc, list.Description);
+
+                // Update list instance
+                var updatedTemplate = new ProvisioningTemplate();
+
+                var updatedTitle = listName + "_UpdatedTitle";
+                var updatedDesc = listName + "_UpdatedDescription";
+                updatedTemplate.Parameters.Add("listTitle", updatedTitle);
+                updatedTemplate.Parameters.Add("listDesc", updatedDesc);
+
+                updatedTemplate.Lists.Add(new Core.Framework.Provisioning.Model.ListInstance
+                {
+                    Url = listUrl,
+                    Title = "{parameter:listTitle}",
+                    Description = "{parameter:listDesc}",
+                    TemplateType = (int)ListTemplateType.GenericList
+                });
+
+                ctx.Web.ApplyProvisioningTemplate(updatedTemplate);
+
+                var updatedList = ctx.Web.GetListByUrl(listUrl, l => l.Title, l => l.Description);
+                Assert.AreEqual(updatedTitle, updatedList.Title);
+                Assert.AreEqual(updatedDesc, updatedList.Description);
+            }
+        }
+
+        [TestMethod]
         public void FolderContentTypeShouldNotBeRemovedFromProvisionedDocumentLibraries()
         {
             using (var ctx = TestCommon.CreateClientContext())

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -997,9 +997,9 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         isDirty = true;
                     }
                 }
-                if (!string.IsNullOrEmpty(templateList.Description) && templateList.Description != existingList.Description)
+                if (!string.IsNullOrEmpty(templateList.Description) && parser.ParseString(templateList.Description) != existingList.Description)
                 {
-                    existingList.Description = templateList.Description;
+                    existingList.Description = parser.ParseString(templateList.Description);
                     isDirty = true;
                 }
                 if (templateList.Hidden != existingList.Hidden)
@@ -1500,10 +1500,10 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             else
             {
                 var listCreate = new ListCreationInformation();
-                listCreate.Description = list.Description;
+                listCreate.Description = parser.ParseString(list.Description);
                 listCreate.TemplateType = list.TemplateType;
                 listCreate.Title = parser.ParseString(list.Title);
-
+                
                 // the line of code below doesn't add the list to QuickLaunch
                 // the OnQuickLaunch property is re-set on the Created List object
                 listCreate.QuickLaunchOption = list.OnQuickLaunch ? QuickLaunchOptions.On : QuickLaunchOptions.Off;

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -1503,7 +1503,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 listCreate.Description = parser.ParseString(list.Description);
                 listCreate.TemplateType = list.TemplateType;
                 listCreate.Title = parser.ParseString(list.Title);
-                
+
                 // the line of code below doesn't add the list to QuickLaunch
                 // the OnQuickLaunch property is re-set on the Created List object
                 listCreate.QuickLaunchOption = list.OnQuickLaunch ? QuickLaunchOptions.On : QuickLaunchOptions.Off;

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -1205,6 +1205,14 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         isDirty = true;
                     }
                 }
+
+                if (templateList.Description.ContainsResourceToken())
+                {
+                    if (existingList.DescriptionResource.SetUserResourceValue(templateList.Description, parser))
+                    {
+                        isDirty = true;
+                    }
+                }
 #endif
                 if (existingList.EnableModeration != templateList.EnableModeration)
                 {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| New sample?      | no
| Related issues?  | none
#### What's in this Pull Request?

This PR changed provisioning engine so that tokens (e.g. {parameter:aaaa}) can be used in ListInstance -> Description attribute. 