### PR TITLE
Ensure that the value in file.ListItemAllFields.ServerObjectIsNull is…

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/FileFolderExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/FileFolderExtensions.cs
@@ -1274,6 +1274,10 @@ namespace Microsoft.SharePoint.Client
             {
                 var context = file.Context;
 
+                // Ensure that ListItemAllFields.ServerObjectIsNull is loaded
+                context.Load(file, f => f.ListItemAllFields);
+                context.ExecuteQueryRetry();
+
                 bool normalFile = !file.ListItemAllFields.ServerObjectIsNull ?? false; //normal files have listItemAllFields;
                 var checkOutRequired = false;
                 if (normalFile)


### PR DESCRIPTION
… loaded before checking it, otherwise it will always return null. Fixes issue with files deployed to Master Page Gallery end up as Draft, not Published.

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no 
| New sample?      | no 
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

A bug fix for uploading files to libraries. It was discovered when all files uploaded to Master Page Gallery ended up being just drafts, not Published as specified in template.xml. The fix just ensures that the value for file.ListItemAllFields is loaded before checking the ServerObjectIsNull property, so that the proper value is returned. Otherwise, ServerObjectIsNull will always be null, and the normalFile boolean will always be false, and thus no files will be published.
