### PR TITLE
Fix webpart importation

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/Serializers/PagesSerializer.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/Serializers/PagesSerializer.cs
@@ -36,7 +36,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml.Serializers
                 expressions.Add(f => f.Security.RoleAssignments, new RoleAssigmentsFromSchemaToModelTypeResolver());
                 expressions.Add(f => f.WebParts[0].Row, new ExpressionValueResolver((s, v) => (uint)(int)v));
                 expressions.Add(f => f.WebParts[0].Column, new ExpressionValueResolver((s, v) => (uint)(int)v));
-                expressions.Add(f => f.WebParts[0].Contents, new ExpressionValueResolver((s, v) => v != null ? ((XmlElement)v).InnerXml : null));
+                expressions.Add(f => f.WebParts[0].Contents, new ExpressionValueResolver((s, v) => v != null ? ((XmlElement)v).OuterXml : null));
 
                 template.Pages.AddRange(
                     PnPObjectsMapper.MapObjects<Page>(pages,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |  yes
| New feature?    | no
| New sample?      | no 
| Related issues?  | fixes #869

#### What's in this Pull Request?

`LimitedWebPartManager.AddWebPart` method from the CSOM library requires to provide WebPart definition wrapped within a `<webParts>` node.

The custom serialization reads the `pnp:webPart/pnp:Contents/webParts` **InnerXml** value, which is actually the `<webPart>` node.

This leads to the namespace error mentioned in the issue.

Changing the serializer code to use **OuterXml** resolves the issue.

This also allow the usage of DWP webparts.

Hope that helped
