### PR TITLE
Ensure view fieldrefs use correct internal name

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
@@ -47,7 +47,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                     XElement templateFieldElement = XElement.Parse(parser.ParseXmlString(field.SchemaXml, "~sitecollection", "~site"));
                     var fieldId = templateFieldElement.Attribute("ID").Value;
-                    var fieldInternalName = templateFieldElement.Attribute("InternalName") != null ? templateFieldElement.Attribute("InternalName").Value : "";
+                    var fieldInternalName = templateFieldElement.Attribute("Name") != null ? templateFieldElement.Attribute("Name").Value : "";
                     WriteMessage($"Field|{(!string.IsNullOrWhiteSpace(fieldInternalName) ? fieldInternalName : fieldId)}|{currentFieldIndex}|{fields.Count}", ProvisioningMessageType.Progress);
                     if (!existingFieldIds.Contains(Guid.Parse(fieldId)))
                     {

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -227,7 +227,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                     throw new Exception(string.Format(CoreResources.Provisioning_ObjectHandlers_ListInstances_Field_schema_has_no_ID_attribute___0_, field.SchemaXml));
                                 }
                                 var id = fieldElement.Attribute("ID").Value;
-                                var internalName = fieldElement.Attribute("InternalName")?.Value;
+                                var internalName = fieldElement.Attribute("Name")?.Value;
 
                                 WriteMessage($"List Columns for list {listInfo.TemplateList.Title}|{internalName ?? id}|{currentFieldIndex}|{total}", ProvisioningMessageType.Progress);
                                 Guid fieldGuid;

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -289,27 +289,30 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                             listInfo.SiteList.Update();
                             web.Context.ExecuteQueryRetry();
 
-                            // Ensure that the internal names in view fieldrefs match the actual internal names of the fields.
-                            foreach (var view in listInfo.TemplateList.Views)
+                            if (internalNamesToUpdate.Count > 0)
                             {
-                                var xmlDoc = new System.Xml.XmlDocument();
-                                xmlDoc.LoadXml(view.SchemaXml);
-
-                                // Swap out field ref internal names.
-                                var nodes = xmlDoc.SelectNodes("//FieldRef");
-                                if (nodes != null)
+                                // Ensure that the internal names in view fieldrefs match the actual internal names of the fields.
+                                foreach (var view in listInfo.TemplateList.Views)
                                 {
-                                    foreach (var node in nodes.OfType<System.Xml.XmlElement>().Where(n => n.HasAttributes))
+                                    var xmlDoc = new System.Xml.XmlDocument();
+                                    xmlDoc.LoadXml(view.SchemaXml);
+
+                                    // Swap out field ref internal names.
+                                    var nodes = xmlDoc.SelectNodes("//FieldRef");
+                                    if (nodes != null)
                                     {
-                                        var attribute = node.Attributes.GetNamedItem("Name");
-                                        if (attribute != null && internalNamesToUpdate.ContainsKey(attribute.Value))
+                                        foreach (var node in nodes.OfType<System.Xml.XmlElement>().Where(n => n.HasAttributes))
                                         {
-                                            attribute.Value = internalNamesToUpdate[attribute.Value];
+                                            var attribute = node.Attributes.GetNamedItem("Name");
+                                            if (attribute != null && internalNamesToUpdate.ContainsKey(attribute.Value))
+                                            {
+                                                attribute.Value = internalNamesToUpdate[attribute.Value];
+                                            }
                                         }
                                     }
-                                }
 
-                                view.SchemaXml = xmlDoc.OuterXml;
+                                    view.SchemaXml = xmlDoc.OuterXml;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?

This fixes a (very, very) edge case where a list view can become invalid if an existing field on a list has a different internal name than a field defined in the template, but has the same ID. In this case, the fieldrefs on the list view still have the internal names defined in the template instead of the actual internal names. If the view's orderby condition contains one of these bad internal names, the view will break as soon as you add an item to the list.

This can be reproduced by defining a site content type (ContentTypeA) and a site column (ColumnA), including the site column in the content type. Then, in the list definition, include that content type, and also include a definition for the field with the same ID, but a different internal name (ColumnANew). Add a view to the list definition that includes a fieldref to that field and also orders by it, using the internal name defined in the template (ColumnANew). When the list is provisioned using current code, it appears to provision fine, but as soon as you add an item, the view breaks, as it attempts to order by ColumnANew, which doesn't exist, as the existing site column was added via the content type, so the field's internal name is actually ColumnA.

In the real world, you could run into this if you had an existing template that defined fields directly on the list, but later, someone decided to create site columns based on those same definitions, using the same ID, but tweaking the internal names. I know. Very edge case. Doesn't hurt to catch though.

The fix is to keep track of any instances where an existing field's internal name doesn't match the field name specified in the template list definition, then iterate through the fieldrefs of all views, looking for attributes whose values match the defined internal names and swapping them out with the actual internal names.

Also fixed two spots where the code wasn't pulling internal name from the definition properly - was using the wrong attribute name. In both cases, the variable was only being used for logging, and was falling back to the field id, so it wasn't obvious that it wasn't being pulled correctly.

