### PR TITLE
Changed control index to float

### DIFF
--- a/Core/OfficeDevPnP.Core/Pages/ClientSidePageControls.cs
+++ b/Core/OfficeDevPnP.Core/Pages/ClientSidePageControls.cs
@@ -149,7 +149,7 @@ namespace OfficeDevPnP.Core.Pages
         /// </summary>
         /// <param name="controlIndex">The sequence of the control inside the section</param>
         /// <returns>Html representation of a control</returns>
-        public abstract string ToHtml(int controlIndex);
+        public abstract string ToHtml(float controlIndex);
 
         /// <summary>
         /// Removes the control from the page
@@ -330,7 +330,7 @@ namespace OfficeDevPnP.Core.Pages
         /// </summary>
         /// <param name="controlIndex">The sequence of the control inside the section</param>
         /// <returns>Html representation of this <see cref="ClientSideText"/> control</returns>
-        public override string ToHtml(int controlIndex)
+        public override string ToHtml(float controlIndex)
         {
             // Can this control be hosted in this section type?
             if (this.Section.Type == CanvasSectionTemplate.OneColumnFullWidth)
@@ -629,7 +629,7 @@ namespace OfficeDevPnP.Core.Pages
         /// </summary>
         /// <param name="controlIndex">The sequence of the control inside the section</param>
         /// <returns>HTML representation of the client side web part</returns>
-        public override string ToHtml(int controlIndex)
+        public override string ToHtml(float controlIndex)
         {
             // Can this control be hosted in this section type?
             if (this.Section.Type == CanvasSectionTemplate.OneColumnFullWidth)

--- a/Core/OfficeDevPnP.Core/Pages/ClientSidePagesControlData.cs
+++ b/Core/OfficeDevPnP.Core/Pages/ClientSidePagesControlData.cs
@@ -38,7 +38,7 @@ namespace OfficeDevPnP.Core.Pages
         /// Gets or sets JsonProperty "controlIndex"
         /// </summary>
         [JsonProperty(PropertyName = "controlIndex")]
-        public int ControlIndex { get; set; }
+        public float ControlIndex { get; set; }
     }
 
     /// <summary>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes

#### What's in this Pull Request?
When exporting a client page as a template with a custom web part I noticed I got a `controlIndex` of 0.5. Changed from int to float to allow this.

![image](https://user-images.githubusercontent.com/51104/30696676-cc99a530-9edc-11e7-917f-7aa5f138b682.png)