### PR TITLE
Refresh Token bug fix in WebAPI Helper

### DIFF
--- a/Core/OfficeDevPnP.Core/WebAPI/WebAPIHelper.cs
+++ b/Core/OfficeDevPnP.Core/WebAPI/WebAPIHelper.cs
@@ -85,7 +85,7 @@ namespace OfficeDevPnP.Core.WebAPI
                 WebAPIContexCacheItem cacheItem = WebAPIContextCache.Instance.Get(cacheKey);
 
                 //request a new access token from ACS whenever our current access token will expire in less than 1 hour
-                if (cacheItem.AccessToken.ExpiresOn < (DateTime.Now.AddHours(-1)))
+                if (cacheItem.AccessToken.ExpiresOn.ToUniversalTime() < (DateTime.Now.ToUniversalTime().AddHours(1)))
                 {
                     Uri targetUri = new Uri(cacheItem.SharePointServiceContext.HostWebUrl);
                     OAuth2AccessTokenResponse accessToken = TokenHelper.GetAccessToken(cacheItem.RefreshToken, TokenHelper.SharePointPrincipal, targetUri.Authority, TokenHelper.GetRealmFromTargetUrl(targetUri));

--- a/Core/OfficeDevPnP.Core/WebAPI/WebAPIHelper.cs
+++ b/Core/OfficeDevPnP.Core/WebAPI/WebAPIHelper.cs
@@ -85,7 +85,7 @@ namespace OfficeDevPnP.Core.WebAPI
                 WebAPIContexCacheItem cacheItem = WebAPIContextCache.Instance.Get(cacheKey);
 
                 //request a new access token from ACS whenever our current access token will expire in less than 1 hour
-                if (cacheItem.AccessToken.ExpiresOn.ToUniversalTime() < (DateTime.Now.ToUniversalTime().AddHours(1)))
+                if (cacheItem.AccessToken.ExpiresOn.ToUniversalTime() < (DateTime.UtcNow.AddHours(1)))
                 {
                     Uri targetUri = new Uri(cacheItem.SharePointServiceContext.HostWebUrl);
                     OAuth2AccessTokenResponse accessToken = TokenHelper.GetAccessToken(cacheItem.RefreshToken, TokenHelper.SharePointPrincipal, targetUri.Authority, TokenHelper.GetRealmFromTargetUrl(targetUri));


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no


#### What's in this Pull Request?
Fixes the condition to refresh the access token in the WebAPI Helper
The Token was refreshed only after expiration+ one hour