### PR TITLE
Allow site columns to be provisioned to subwebs when ProvisionContentTypesToSubWebs flag is set

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/FieldAndContentTypeExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/FieldAndContentTypeExtensions.cs
@@ -998,9 +998,12 @@ namespace Microsoft.SharePoint.Client
             var flink = contentType.FieldLinks.FirstOrDefault(fld => fld.Id == field.Id);
             if (flink == null)
             {
-                XElement fieldElement = XElement.Parse(field.SchemaXmlWithResourceTokens);
-                fieldElement.SetAttributeValue("AllowDeletion", "TRUE"); // Default behavior when adding a field to a CT from the UI.
-                field.SchemaXml = fieldElement.ToString();
+                if (!web.IsSubSite())
+                {
+                    XElement fieldElement = XElement.Parse(field.SchemaXmlWithResourceTokens);
+                    fieldElement.SetAttributeValue("AllowDeletion", "TRUE"); // Default behavior when adding a field to a CT from the UI.
+                    field.SchemaXml = fieldElement.ToString();
+                }
                 var fldInfo = new FieldLinkCreationInformation();
                 fldInfo.Field = field;
                 contentType.FieldLinks.Add(fldInfo);

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
@@ -27,7 +27,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             using (var scope = new PnPMonitoredScope(this.Name))
             {
                 // if this is a sub site then we're not provisioning fields. Technically this can be done but it's not a recommended practice
-                if (web.IsSubSite())
+                if (web.IsSubSite() && !applyingInformation.ProvisionContentTypesToSubWebs)
                 {
                     scope.LogDebug(CoreResources.Provisioning_ObjectHandlers_Fields_Context_web_is_subweb__skipping_site_columns);
                     return parser;

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectLookupFields.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectLookupFields.cs
@@ -64,16 +64,16 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     var relationshipDeleteBehavior = fieldElement.Attribute("RelationshipDeleteBehavior") != null ? fieldElement.Attribute("RelationshipDeleteBehavior").Value : string.Empty;
                     var webId = string.Empty;
 
-                    var field = rootWeb.Fields.GetById(fieldId);
-                    rootWeb.Context.Load(field, f => f.SchemaXmlWithResourceTokens);
-                    rootWeb.Context.ExecuteQueryRetry();
+                    var field = web.AvailableFields.GetById(fieldId);
+                    web.Context.Load(field, f => f.SchemaXmlWithResourceTokens);
+                    web.Context.ExecuteQueryRetry();
 
                     List sourceList = FindSourceList(listIdentifier, web, rootWeb);
 
                     if (sourceList != null)
                     {
-                        rootWeb.Context.Load(sourceList.ParentWeb);
-                        rootWeb.Context.ExecuteQueryRetry();
+                        web.Context.Load(sourceList.ParentWeb);
+                        web.Context.ExecuteQueryRetry();
 
                         webId = sourceList.ParentWeb.Id.ToString();
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
If the ProvisionContentTypesToSubWebs flag is set, the engine should allow provisioning of site columns to the subweb as well. Alternatively, if this needs to be more explicitly enabled, a new ProvisionSiteColumnsToSubWebs flag could be added. Although it's not a best practice to provision site columns or content types to a subweb, there's one key use case where it's very important to be able to do so - creating a lookup site column referencing a list in the subweb. Open to suggestions / modifications if there's a better alternative to this approach.
