### PR TITLE
Update to allow different id from template field and real site field …

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
@@ -35,9 +35,10 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                 var existingFields = web.Fields;
 
-                web.Context.Load(existingFields, fs => fs.Include(f => f.Id));
+                web.Context.Load(existingFields, fs => fs.Include(f => f.Id, f => f.InternalName));
                 web.Context.ExecuteQueryRetry();
-                var existingFieldIds = existingFields.AsEnumerable<SPField>().Select(l => l.Id).ToList();
+                // Get list of all fields with Ids & Internal names to be able to match using Id or InternalName
+                var existingFieldIdsAndNames = existingFields.AsEnumerable<SPField>().ToDictionary(t => t.Id, t => t.InternalName);
                 var fields = template.SiteFields;
 
                 var currentFieldIndex = 0;
@@ -47,9 +48,55 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                     XElement templateFieldElement = XElement.Parse(parser.ParseXmlString(field.SchemaXml, "~sitecollection", "~site"));
                     var fieldId = templateFieldElement.Attribute("ID").Value;
-                    var fieldInternalName = templateFieldElement.Attribute("InternalName") != null ? templateFieldElement.Attribute("InternalName").Value : "";
-                    WriteMessage($"Field|{(!string.IsNullOrWhiteSpace(fieldInternalName) ? fieldInternalName : fieldId)}|{currentFieldIndex}|{fields.Count}", ProvisioningMessageType.Progress);
-                    if (!existingFieldIds.Contains(Guid.Parse(fieldId)))
+                
+                    WriteMessage($"Field|{fieldId}|{currentFieldIndex}|{fields.Count}", ProvisioningMessageType.Progress);
+
+                    bool isExistingField = false;
+                    if (!existingFieldIdsAndNames.ContainsKey(Guid.Parse(fieldId)))
+                    {
+                        // Try to get the internal name
+                        var fieldInternalName = templateFieldElement.Attribute("InternalName") != null ? templateFieldElement.Attribute("InternalName").Value : "";
+                        if (string.IsNullOrEmpty(fieldInternalName)) fieldInternalName = templateFieldElement.Attribute("StaticName") != null ? templateFieldElement.Attribute("StaticName").Value : "";
+                        if (string.IsNullOrEmpty(fieldInternalName)) fieldInternalName = templateFieldElement.Attribute("Name") != null ? templateFieldElement.Attribute("Name").Value : "";
+
+                        if (existingFieldIdsAndNames.ContainsValue(fieldInternalName))
+                        {
+                            Guid currentFieldId = existingFieldIdsAndNames.FirstOrDefault(e => e.Value == fieldInternalName).Key;
+
+                            // Switch field id to the real one
+                            Guid oldFieldId = new Guid(fieldId);
+                            fieldId = currentFieldId.ToString();
+                            templateFieldElement.Attribute("ID").Value = fieldId;
+
+                            // We need also to update related content types & lists
+                            if (template.ContentTypes != null)
+                            {
+                                foreach (var ct in template.ContentTypes)
+                                {
+                                    var ctFieldLink = ct.FieldRefs.FirstOrDefault(f => f.Id == oldFieldId);
+                                    if (ctFieldLink != null)
+                                    {
+                                        ctFieldLink.Id = currentFieldId;
+                                    }
+                                }
+                            }
+                            if (template.Lists != null)
+                            {
+                                foreach (var l in template.Lists)
+                                {
+                                    var lFieldLink = l.FieldRefs.FirstOrDefault(f => f.Id == oldFieldId);
+                                    if (lFieldLink != null)
+                                    {
+                                        lFieldLink.Id = currentFieldId;
+                                    }
+                                }
+                            }
+
+                            isExistingField = true;
+                        }
+                    }
+
+                    if (!isExistingField)
                     {
                         try
                         {
@@ -616,7 +663,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 _willExtract = true;
             }
             return _willExtract.Value;
-        }        
+        }
     }
 
     internal static class XElementStringExtensions

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
@@ -95,6 +95,10 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                             isExistingField = true;
                         }
                     }
+                    else
+                    {
+                        isExistingField = true;
+                    }
 
                     if (!isExistingField)
                     {

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # PnP Core Component #
-This is the Community Source Code location for PnP Core component. This is a "sub" repository for the PnP repository at [https://github.com/OfficeDev/PnP](https://github.com/SharePoint/PnP) which will contain PnP core component and related resources. See details around the PnP Core Component from the project [readme file](Core/README.md).
+This is the Community Source Code location for PnP Core component. This is a "sub" repository for the PnP repository at [https://github.com/OfficeDev/PnP](https://github.com/SharePoint/PnP) which will contain PnP core component and related resources. See details around the PnP Core Component from the project [readme file](Core/README.md). 
 
 ![SharePoint Patterns and Practices](https://devofficecdn.azureedge.net/media/Default/PnP/sppnp.png)
 


### PR DESCRIPTION
…if internal name matches.

This is a fix for when using provisioning with content types and fields coming from a content type hub for initial provisioning, and so Ids are always differents.

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | mentioned in #461

#### What's in this Pull Request?

In a case where the field ids declared in your template can be different from the provisioned site, we receive "A duplicate field name XXX was found" error. It can happen when your site has some fields provisioned by another system that doesn't preserve the internal id. With this modification, if - and only if - the field id from the template is not found in the existing site fields, it checks if a field with the same internal name exists (use Internal, StaticName then Name from the declaration). If it finds it, it will use it for the update, otherwise do as before.
2 modifications were required : one for the Field provisioning, the other Lookup Field as this is a specific process.