### PR TITLE
Fix to preserve attributes on view fieldrefs

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -496,7 +496,13 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     viewCI.Title = Path.GetFileNameWithoutExtension(urlAttribute.Value);
                 }
 
+                var reader = viewElement.CreateReader();
+                reader.MoveToContent();
+                var viewInnerXml = reader.ReadInnerXml();
+
                 var createdView = createdList.Views.Add(viewCI);
+                createdView.ListViewXml = viewInnerXml;
+                createdView.Update();
                 createdView.EnsureProperties(v => v.Scope, v => v.JSLink, v => v.Title, v => v.Aggregations, v => v.MobileView, v => v.MobileDefaultView, v => v.ViewData);
                 web.Context.ExecuteQueryRetry();
 


### PR DESCRIPTION
Fixed to set ListViewXml to the inner xml of our view schema so that any additional attributes on FieldRefs that aren't directly settable through CSOM are properly set.

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
Currently, if you have a view fieldref like the following, the attributes aren't preserved on the view when provisioned:
`
<FieldRef Name="Role" listItemMenu="TRUE" linkToItem="TRUE" />
`

The easy fix for this is to set the ListViewXml property of the view to the inner XML of the view schema right after creating it. This will properly set the above attributes, allowing the user to specify that a field other than Title should be used as a link to open the list item and/or to display the menu for the list item.



