### PR TITLE
Navigation and page serializers fixes + tests

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/Framework/Providers/XMLProvidersTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/Providers/XMLProvidersTests.cs
@@ -987,7 +987,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.Providers
             Assert.AreEqual((uint)1, webpart.Order);
             Assert.AreEqual("Main", webpart.Zone);
             Assert.IsNotNull(webpart.Contents);
-            Assert.AreEqual("<webPart>[!<![CDATA[web part definition goes here]]></webPart>", webpart.Contents.Trim());
+            Assert.AreEqual("<webParts><webPart>[!<![CDATA[web part definition goes here]]></webPart></webParts>", webpart.Contents.Trim());
 
             Assert.IsNotNull(file.WebParts);
             webpart = file.WebParts.FirstOrDefault(wp => wp.Title == "My Editor");
@@ -995,7 +995,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.Providers
             Assert.AreEqual((uint)10, webpart.Order);
             Assert.AreEqual("Left", webpart.Zone);
             Assert.IsNotNull(webpart.Contents);
-            Assert.AreEqual("<webPart>[!<![CDATA[web part definition goes here]]></webPart>", webpart.Contents.Trim());
+            Assert.AreEqual("<webParts><webPart>[!<![CDATA[web part definition goes here]]></webPart></webParts>", webpart.Contents.Trim());
 
             file = result.Files.FirstOrDefault(f => f.Src == "/Resources/Files/SAMPLE.js");
             Assert.IsNotNull(file);
@@ -1315,7 +1315,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.Providers
             Assert.AreEqual((uint)1, webpart.Row);
             Assert.AreEqual((uint)2, webpart.Column);
             Assert.IsNotNull(webpart.Contents);
-            Assert.AreEqual("<webPart>[!<![CDATA[web part definition goes here]]></webPart>", webpart.Contents);
+            Assert.AreEqual("<webParts><webPart>[!<![CDATA[web part definition goes here]]></webPart></webParts>", webpart.Contents);
 
             Assert.IsNotNull(page.WebParts);
             webpart = page.WebParts.FirstOrDefault(wp => wp.Title == "My Editor");
@@ -1323,7 +1323,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.Providers
             Assert.AreEqual((uint)2, webpart.Row);
             Assert.AreEqual((uint)1, webpart.Column);
             Assert.IsNotNull(webpart.Contents);
-            Assert.AreEqual("<webPart>[!<![CDATA[web part definition goes here]]></webPart>", webpart.Contents);
+            Assert.AreEqual("<webParts><webPart>[!<![CDATA[web part definition goes here]]></webPart></webParts>", webpart.Contents);
 
             Assert.IsNotNull(page.Fields);
             Assert.AreEqual(4, page.Fields.Count() );
@@ -1549,7 +1549,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.Providers
             Assert.AreEqual("Term2Set1Group1", tm.Name);
             Assert.AreEqual("Term2 Set1 Group1", tm.Description);
             Assert.AreEqual(102, tm.CustomSortOrder);
-            Assert.AreEqual(0, tm.Language);
+            Assert.IsNull(tm.Language);
             Assert.AreEqual("term1owner@term2owner", tm.Owner);
             Assert.AreEqual(Guid.Empty, tm.SourceTermId);
             Assert.IsFalse(tm.IsAvailableForTagging);

--- a/Core/OfficeDevPnP.Core.Tests/Resources/Templates/ProvisioningTemplate-2016-05-Sample-03-OUT-ct.xml
+++ b/Core/OfficeDevPnP.Core.Tests/Resources/Templates/ProvisioningTemplate-2016-05-Sample-03-OUT-ct.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<pnp:Provisioning xmlns:pnp="http://schemas.dev.office.com/PnP/2016/05/ProvisioningSchema">
+  <pnp:Preferences Generator="OfficeDevPnP.Core, Version=2.20.1711.0, Culture=neutral, PublicKeyToken=null" />
+  <pnp:Templates ID="CONTAINER-ProvisioningTemplate-2016-05-Sample-03-OUT-ct">
+    <pnp:ProvisioningTemplate ID="ProvisioningTemplate-2016-05-Sample-03-OUT-ct" Version="0">
+      <pnp:ContentTypes>
+        <pnp:ContentType ID="0x01005D4F34E4BE7F4B6892AEBE088EDD215E" Name="General Project Document" Description="General Project Document Content Type" Group="Base Foundation Content Types" Hidden="true" Sealed="true" ReadOnly="true" Overwrite="true" NewFormUrl="/Forms/NewForm.aspx" EditFormUrl="/Forms/EditForm.aspx" DisplayFormUrl="/Forms/DisplayForm.aspx">
+          <pnp:FieldRefs>
+            <pnp:FieldRef ID="23203e97-3bfe-40cb-afb4-07aa2b86bf45" Name="TestField" Required="true" Hidden="true" />
+            <pnp:FieldRef ID="00000000-0000-0000-0000-000000000000" Name="TestField1" />
+            <pnp:FieldRef ID="00000000-0000-0000-0000-000000000000" Name="TestField2" />
+            <pnp:FieldRef ID="00000000-0000-0000-0000-000000000000" Name="TestField3" />
+          </pnp:FieldRefs>
+          <pnp:DocumentTemplate TargetName="DocumentTemplate.dotx" />
+          <pnp:DocumentSetTemplate WelcomePage="home.aspx">
+            <pnp:AllowedContentTypes>
+              <pnp:AllowedContentType ContentTypeID="0x01005D4F34E4BE7F4B6892AEBE088EDD215E002" />
+            </pnp:AllowedContentTypes>
+            <pnp:DefaultDocuments>
+              <pnp:DefaultDocument Name="DefaultDocument" ContentTypeID="0x01005D4F34E4BE7F4B6892AEBE088EDD215E001" FileSourcePath="document.dotx" />
+            </pnp:DefaultDocuments>
+            <pnp:SharedFields>
+              <pnp:SharedField ID="f6e7bdd5-bdcb-4c72-9f18-2bd8c27003d3" />
+              <pnp:SharedField ID="a8df65ec-0d06-4df1-8edf-55d48b3936dc" />
+            </pnp:SharedFields>
+            <pnp:WelcomePageFields>
+              <pnp:WelcomePageField ID="c69d2ffc-0c86-474a-9cc7-dcd7774da531" />
+              <pnp:WelcomePageField ID="b9132b30-2b9e-47d4-b0fc-1ac34a61506f" />
+            </pnp:WelcomePageFields>
+          </pnp:DocumentSetTemplate>
+        </pnp:ContentType>
+      </pnp:ContentTypes>
+    </pnp:ProvisioningTemplate>
+  </pnp:Templates>
+</pnp:Provisioning>

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/Resolvers/NavigationFromSchemaToModelTypeResolver.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/Resolvers/NavigationFromSchemaToModelTypeResolver.cs
@@ -43,63 +43,66 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml.Resolvers
                     break;
             }
 
-            var navigationType = navigation.GetPublicInstancePropertyValue("NavigationType");
-            switch (navigationType.ToString())
+            if (navigation != null)
             {
-                case "Managed":
-                    targetNavigation = new Model.ManagedNavigation();
+                var navigationType = navigation.GetPublicInstancePropertyValue("NavigationType");
+                switch (navigationType.ToString())
+                {
+                    case "Managed":
+                        targetNavigation = new Model.ManagedNavigation();
 
-                    var managedNavigation = navigation.GetPublicInstancePropertyValue("ManagedNavigation");
-                    PnPObjectsMapper.MapProperties(managedNavigation, targetNavigation, resolvers, true);
+                        var managedNavigation = navigation.GetPublicInstancePropertyValue("ManagedNavigation");
+                        PnPObjectsMapper.MapProperties(managedNavigation, targetNavigation, resolvers, true);
 
-                    if (targetIsGlobal)
-                    {
-                        target = new Model.GlobalNavigation(Model.GlobalNavigationType.Managed, null, (Model.ManagedNavigation)targetNavigation);
-                    }
-                    else
-                    {
-                        target = new Model.CurrentNavigation(Model.CurrentNavigationType.Managed, null, (Model.ManagedNavigation)targetNavigation);
-                    }
+                        if (targetIsGlobal)
+                        {
+                            target = new Model.GlobalNavigation(Model.GlobalNavigationType.Managed, null, (Model.ManagedNavigation)targetNavigation);
+                        }
+                        else
+                        {
+                            target = new Model.CurrentNavigation(Model.CurrentNavigationType.Managed, null, (Model.ManagedNavigation)targetNavigation);
+                        }
 
-                    break;
-                case "Structural":
-                case "StructuralLocal":
-                    targetNavigation = new Model.StructuralNavigation();
-                    var structuralNavigation = navigation.GetPublicInstancePropertyValue("StructuralNavigation");
-                    var structuralNavigationNodes = structuralNavigation.GetPublicInstancePropertyValue("NavigationNode");
+                        break;
+                    case "Structural":
+                    case "StructuralLocal":
+                        targetNavigation = new Model.StructuralNavigation();
+                        var structuralNavigation = navigation.GetPublicInstancePropertyValue("StructuralNavigation");
+                        var structuralNavigationNodes = structuralNavigation.GetPublicInstancePropertyValue("NavigationNode");
 
-                    if (!resolvers.ContainsKey($"{targetNavigation.GetType().FullName}.NavigationNodes"))
-                    {
-                        resolvers.Add($"{targetNavigation.GetType().FullName}.NavigationNodes", new NavigationNodeFromSchemaToModelTypeResolver());
-                    }
+                        if (!resolvers.ContainsKey($"{targetNavigation.GetType().FullName}.NavigationNodes"))
+                        {
+                            resolvers.Add($"{targetNavigation.GetType().FullName}.NavigationNodes", new NavigationNodeFromSchemaToModelTypeResolver());
+                        }
 
-                    PnPObjectsMapper.MapProperties(structuralNavigation, targetNavigation, resolvers, true);
+                        PnPObjectsMapper.MapProperties(structuralNavigation, targetNavigation, resolvers, true);
 
-                    if (targetIsGlobal)
-                    {
-                        target = new Model.GlobalNavigation(Model.GlobalNavigationType.Structural, (Model.StructuralNavigation)targetNavigation, null);
-                    }
-                    else
-                    {
-                        target = new Model.CurrentNavigation(
-                            navigationType.ToString() == "Structural" ? Model.CurrentNavigationType.Structural : Model.CurrentNavigationType.StructuralLocal,
-                            (Model.StructuralNavigation)targetNavigation, null);
-                    }
+                        if (targetIsGlobal)
+                        {
+                            target = new Model.GlobalNavigation(Model.GlobalNavigationType.Structural, (Model.StructuralNavigation)targetNavigation, null);
+                        }
+                        else
+                        {
+                            target = new Model.CurrentNavigation(
+                                navigationType.ToString() == "Structural" ? Model.CurrentNavigationType.Structural : Model.CurrentNavigationType.StructuralLocal,
+                                (Model.StructuralNavigation)targetNavigation, null);
+                        }
 
-                    break;
-                case "Inherit":
-                    if (targetIsGlobal)
-                    {
-                        target = new Model.GlobalNavigation(Model.GlobalNavigationType.Inherit, null, null);
-                    }
-                    else
-                    {
-                        target = new Model.CurrentNavigation(Model.CurrentNavigationType.Inherit, null, null);
-                    }
-                    break;
+                        break;
+                    case "Inherit":
+                        if (targetIsGlobal)
+                        {
+                            target = new Model.GlobalNavigation(Model.GlobalNavigationType.Inherit, null, null);
+                        }
+                        else
+                        {
+                            target = new Model.CurrentNavigation(Model.CurrentNavigationType.Inherit, null, null);
+                        }
+                        break;
+                }
+                return (target);
             }
-
-            return (target);
+            return null;
         }
     }
 }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/Serializers/PagesSerializer.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/Serializers/PagesSerializer.cs
@@ -37,7 +37,17 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml.Serializers
                 expressions.Add(f => f.Security.RoleAssignments, new RoleAssigmentsFromSchemaToModelTypeResolver());
                 expressions.Add(f => f.WebParts[0].Row, new ExpressionValueResolver((s, v) => (uint)(int)v));
                 expressions.Add(f => f.WebParts[0].Column, new ExpressionValueResolver((s, v) => (uint)(int)v));
-                expressions.Add(f => f.WebParts[0].Contents, new ExpressionValueResolver((s, v) => v != null ? XElement.Parse(((XmlElement)v).InnerXml)?.Element("webPart")?.ToString() : null));
+                //Contents is deserialized to persistence differently base on schema version. 
+                //Deserialization of older schemas include <Contents> elements, newer do not. 
+                //Deserialized model should not contain <Contents> element, so skip it if present
+                expressions.Add(f => f.WebParts[0].Contents, new ExpressionValueResolver((s, v) => {
+                    if (v != null)
+                    {
+                        var xml = (XmlElement)v;
+                        return xml.Name == "Contents" ? xml.InnerXml : xml.OuterXml;
+                    }
+                    return null;
+                }));
 
                 template.Pages.AddRange(
                     PnPObjectsMapper.MapObjects<Page>(pages,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
Fixes for Navigation and Pages XML serializers.
Navigation serializer throw NullReference when only one of two navigation is specified (e.g. only Global)
Pages serializer does not deserialize WebParts correctly for latest schema resulting in web part contents loss.
Also updated teasts.