### PR TITLE
Missing default groups

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
@@ -66,14 +66,14 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 for (int i = siteSecurity.SiteGroups.Count - 1; i >= 0; i--)
                 {
                     var currentGroup = siteSecurity.SiteGroups[i];
-                    string currentGroupOwner = parser.ParseString(currentGroup.Owner);
+                    string currentGroupOwner = currentGroup.Owner;
                     string currentGroupTitle = parser.ParseString(currentGroup.Title);
 
                     if (currentGroupOwner != "SHAREPOINT\\system" && currentGroupOwner != currentGroupTitle && !(currentGroupOwner.StartsWith("{{associated") && currentGroupOwner.EndsWith("group}}")))
                     {
                         for (int j = 0; j < i; j++)
                         {
-                            if (parser.ParseString(siteSecurity.SiteGroups[j].Owner) == currentGroupTitle)
+                            if (siteSecurity.SiteGroups[j].Owner == currentGroupTitle)
                             {
                                 siteSecurity.SiteGroups.RemoveAt(i);
                                 siteSecurity.SiteGroups.Insert(j, currentGroup);

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/AssociatedGroupToken.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/AssociatedGroupToken.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using Microsoft.SharePoint.Client;
+using OfficeDevPnP.Core.Entities;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitions
 {
@@ -20,26 +22,56 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitio
                 this.Web.EnsureProperty(w => w.Url);
                 using (ClientContext context = this.Web.Context.Clone(this.Web.Url))
                 {
-                    context.Load(context.Web, w => w.AssociatedOwnerGroup.Title, w => w.AssociatedMemberGroup.Title, w => w.AssociatedVisitorGroup.Title);
-                    context.ExecuteQueryRetry();
-                    switch (_groupType)
+
+                    int i = 0;
+                    do
                     {
-                        case AssociatedGroupType.owners:
+
+                        context.Load(context.Web, w => w.AssociatedOwnerGroup.Title, w => w.AssociatedMemberGroup.Title, w => w.AssociatedVisitorGroup.Title, w => w.HasUniqueRoleAssignments, w => w.Title);
+                        context.ExecuteQueryRetry();
+
+                        switch (_groupType)
+                        {
+                            case AssociatedGroupType.owners:
                             {
-                                CacheValue = context.Web.AssociatedOwnerGroup.Title;
+                                if (!context.Web.AssociatedOwnerGroup.ServerObjectIsNull())
+                                    CacheValue = context.Web.AssociatedOwnerGroup.Title;
                                 break;
                             }
-                        case AssociatedGroupType.members:
+                            case AssociatedGroupType.members:
                             {
-                                CacheValue = context.Web.AssociatedMemberGroup.Title;
+                                if (!context.Web.AssociatedMemberGroup.ServerObjectIsNull())
+                                    CacheValue = context.Web.AssociatedMemberGroup.Title;
                                 break;
                             }
-                        case AssociatedGroupType.visitors:
+                            case AssociatedGroupType.visitors:
                             {
-                                CacheValue = context.Web.AssociatedVisitorGroup.Title;
+                                if (!context.Web.AssociatedVisitorGroup.ServerObjectIsNull())
+                                    CacheValue = context.Web.AssociatedVisitorGroup.Title;
                                 break;
                             }
-                    }
+                        }
+
+                        if (string.IsNullOrEmpty(CacheValue) && context.Web.HasUniqueRoleAssignments && i==0)
+                        {
+                            var web = context.Web;
+                            List<UserEntity> adminList = web.GetAdministrators();
+
+                            web.Context.Load(web.CurrentUser, u => u.LoginName);
+
+                            web.Context.ExecuteQueryRetry();
+
+                            string secondaryLoginName = web.CurrentUser.LoginName;
+
+                            web.CreateDefaultAssociatedGroups(
+                                (adminList != null && adminList.Count > 0)
+                                    ? adminList[0].LoginName
+                                    : secondaryLoginName, secondaryLoginName, web.Title);
+
+                            web.Context.ExecuteQueryRetry();
+                        }
+                        i++;
+                    } while (string.IsNullOrEmpty(CacheValue) && i<2);
                 }
             }
             return CacheValue;

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/AssociatedGroupToken.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/AssociatedGroupToken.cs
@@ -52,6 +52,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitio
                             }
                         }
 
+                        //when referenced associated group is not found, let's try to create them and then one more attempt to get them again
                         if (string.IsNullOrEmpty(CacheValue) && context.Web.HasUniqueRoleAssignments && i==0)
                         {
                             var web = context.Web;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |  yes
| Related issues?  | fixes #1395

#### What's in this Pull Request?

The purpose of this PR is to fix the situation when there's a reference in template to default site groups like Owners, Members or Visitors and these groups do not exist on target web (e. g. they were deleted). The reference could be the part of site groups collection (Owner property) or in role assignments list. Prior this update provisioning process fails. Now these groups are provisioned (if the target web HasUniqueRoleAssignments enabled) by standard web method CreateDefaultAssociatedGroups to increase the chance that provisioning process will finish successfully.