### PR TITLE
Fix to align extension method behavior with the SharePoint UI default behavior

### DIFF
--- a/Core/OfficeDevPnP.Core/Sites/SiteCollection.cs
+++ b/Core/OfficeDevPnP.Core/Sites/SiteCollection.cs
@@ -102,7 +102,10 @@ namespace OfficeDevPnP.Core.Sites
                                     throw new Exception(responseString);
                                 }
                             }
-                            catch { }
+                            catch (Exception)
+                            {
+                                throw;
+                            }
                         }
                     }
                     else

--- a/Core/OfficeDevPnP.Core/Sites/SiteCollectionCreationInformation.cs
+++ b/Core/OfficeDevPnP.Core/Sites/SiteCollectionCreationInformation.cs
@@ -83,9 +83,9 @@ namespace OfficeDevPnP.Core.Sites
         public string DisplayName { get; set; }
 
         /// <summary>
-        /// The owner of the site. Reserved for future use.
+        /// Defines whether the Office 365 Group will be public (default), or private.
         /// </summary>
-        public bool IsPublic { get; set; }
+        public bool IsPublic { get; set; } = true;
 
         /// <summary>
         /// The Guid of the site design to be used. If specified will override the SiteDesign property


### PR DESCRIPTION
By default, the SharePoint Online UI creates a Public Office 365 Group. The extension method should do the same thing, for consistency, IMHO.