### PR TITLE
Support token replacement in the file name

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
@@ -52,6 +52,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 var currentFileIndex = 0;
                 foreach (var file in filesToProcess)
                 {
+                    file.Src = parser.ParseString(file.Src);
                     var targetFileName = !String.IsNullOrEmpty(file.TargetFileName) ? file.TargetFileName : file.Src;
 
                     currentFileIndex++;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| New feature?    | yes

#### What's in this Pull Request?

Support token replacement in the filename. Useful if you based on some external parameter want to upload a different file to a specific file name. All files could be stored in the package, but only one will be uploaded.