### PR TITLE
Fixing data rows key column and overwrite behaviour

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
@@ -94,7 +94,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                         // if it is empty, skip the check
                                         if (dataRowValues.Any())
                                         {
-                                            var query = $@"<View><Query><Where><Eq><FieldRef Name=""{parsedKeyColumn}""/><Value Type=""{keyColumnType}"">{dataRowValue.FirstOrDefault().Value}</Value></Eq></Where></Query><RowLimit>1</RowLimit></View>";
+                                            var query = $@"<View><Query><Where><Eq><FieldRef Name=""{parsedKeyColumn}""/><Value Type=""{keyColumnType}"">{dataRowValues.FirstOrDefault().Value}</Value></Eq></Where></Query><RowLimit>1</RowLimit></View>";
                                             var camlQuery = new CamlQuery()
                                             {
                                                 ViewXml = query

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
@@ -88,10 +88,13 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                     ListItem listitem = null;
                                     if (!string.IsNullOrEmpty(listInstance.DataRows.KeyColumn))
                                     {
+                                        // Get value from key column
+                                        var dataRowValues = dataRow.Values.Where(v => v.Key == listInstance.DataRows.KeyColumn);
+
                                         // if it is empty, skip the check
-                                        if (!string.IsNullOrEmpty(dataRow.Key))
+                                        if (dataRowValue.Any())
                                         {
-                                            var query = $@"<View><Query><Where><Eq><FieldRef Name=""{parsedKeyColumn}""/><Value Type=""{keyColumnType}"">{parser.ParseString(dataRow.Key)}</Value></Eq></Where></Query><RowLimit>1</RowLimit></View>";
+                                            var query = $@"<View><Query><Where><Eq><FieldRef Name=""{parsedKeyColumn}""/><Value Type=""{keyColumnType}"">{dataRowValue.FirstOrDefault().Value}</Value></Eq></Where></Query><RowLimit>1</RowLimit></View>";
                                             var camlQuery = new CamlQuery()
                                             {
                                                 ViewXml = query

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
@@ -92,7 +92,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                         var dataRowValues = dataRow.Values.Where(v => v.Key == listInstance.DataRows.KeyColumn);
 
                                         // if it is empty, skip the check
-                                        if (dataRowValue.Any())
+                                        if (dataRowValues.Any())
                                         {
                                             var query = $@"<View><Query><Where><Eq><FieldRef Name=""{parsedKeyColumn}""/><Value Type=""{keyColumnType}"">{dataRowValue.FirstOrDefault().Value}</Value></Eq></Where></Query><RowLimit>1</RowLimit></View>";
                                             var camlQuery = new CamlQuery()


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | X
| Related issues?  | 
https://github.com/SharePoint/PnP-Provisioning-Schema/issues/259
https://github.com/SharePoint/PnP-Provisioning-Schema/issues/236

#### What's in this Pull Request?

This pull request contains a fix for the data rows xml element. When defining the key column and update behaviour a new list item is always created.
The problem is that we're looking at the wrong key when iterating through each data row and verifying if dataRow.Key is null (which will always be null). In order to get the right value we need to look at the values inside the dataRow.Values and get the value where key == listInstance.DataRows.KeyColumn.

Example:
If we're updating items based on the column 'Title', we will have to iterate through each data row, get its values and grab the key/value pair correspondent to 'Title'. Once we have this pair, we can then build the Caml query using the value to get items where 'Title' matches the rows we're going to insert.