### PR TITLE
Get Owners and Members of a Unified Group.

### DIFF
--- a/Core/OfficeDevPnP.Core/Entities/UnifiedGroupUser.cs
+++ b/Core/OfficeDevPnP.Core/Entities/UnifiedGroupUser.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OfficeDevPnP.Core.Entities
+{
+    /// <summary>
+    /// Defines a Unified Group user
+    /// </summary>
+    public class UnifiedGroupUser
+    {
+        /// <summary>
+        /// Unified group user principal name
+        /// </summary>
+        public String UserPrincipalName { get; set; }
+        /// <summary>
+        /// Unified group user display name
+        /// </summary>
+        public String DisplayName { get; set; }
+        
+    }
+}

--- a/Core/OfficeDevPnP.Core/Entities/UnifiedGroupUser.cs
+++ b/Core/OfficeDevPnP.Core/Entities/UnifiedGroupUser.cs
@@ -12,11 +12,11 @@ namespace OfficeDevPnP.Core.Entities
     public class UnifiedGroupUser
     {
         /// <summary>
-        /// Unified group user principal name
+        /// Unified group user's user principal name
         /// </summary>
         public String UserPrincipalName { get; set; }
         /// <summary>
-        /// Unified group user display name
+        /// Unified group user's display name
         /// </summary>
         public String DisplayName { get; set; }
         

--- a/Core/OfficeDevPnP.Core/Framework/Graph/UnifiedGroupsUtility.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Graph/UnifiedGroupsUtility.cs
@@ -717,5 +717,164 @@ namespace OfficeDevPnP.Core.Framework.Graph
             }
             return (result);
         }
+
+        /// <summary>
+        /// Returns all the Members of an Office 365 group.
+        /// </summary>
+        /// <param name="group">The Office 365 group object of type UnifiedGroupEntity</param>
+        /// <param name="accessToken">The OAuth 2.0 Access Token to use for invoking the Microsoft Graph</param>
+        /// <param name="retryCount">Number of times to retry the request in case of throttling</param>
+        /// <param name="delay">Milliseconds to wait before retrying the request. The delay will be increased (doubled) every retry</param>
+        /// <returns>Members of an Office 365 group as a list of UnifiedGroupUser entity</returns>
+        public static List<UnifiedGroupUser> GetUnifiedGroupMembers(UnifiedGroupEntity group, string accessToken, int retryCount = 10, int delay = 500)
+        {
+            List<UnifiedGroupUser> unifiedGroupUsers = null;
+            List<User> unifiedGroupGraphUsers = null;
+            IGroupMembersCollectionWithReferencesPage groupUsers = null;
+
+            if (String.IsNullOrEmpty(accessToken))
+            {
+                throw new ArgumentNullException(nameof(accessToken));
+            }
+            if (group == null)
+            {
+                throw new ArgumentNullException(nameof(group));
+            }
+
+            try
+            {
+                var result = Task.Run(async () =>
+                {
+                    var graphClient = CreateGraphClient(accessToken, retryCount, delay);
+
+                    // Get the members of an Office 365 group.
+                    groupUsers = await graphClient.Groups[group.GroupId].Members.Request().GetAsync();
+                    if (groupUsers.CurrentPage != null && groupUsers.CurrentPage.Count > 0)
+                    {
+                        unifiedGroupGraphUsers = new List<User>();
+
+                        GenerateGraphUserCollection(groupUsers.CurrentPage,unifiedGroupGraphUsers);
+                    }
+
+                    // Retrieve users when the results are paged.
+                    while (groupUsers.NextPageRequest != null)
+                    {
+                        groupUsers = groupUsers.NextPageRequest.GetAsync().GetAwaiter().GetResult();
+                        if (groupUsers.CurrentPage != null && groupUsers.CurrentPage.Count > 0)
+                        {
+                            GenerateGraphUserCollection(groupUsers.CurrentPage, unifiedGroupGraphUsers);
+                        }
+                    }
+
+                    // Create the collection of type OfficeDevPnP 'UnifiedGroupUser' after all users are retrieved, including paged data.
+                    if (unifiedGroupGraphUsers != null && unifiedGroupGraphUsers.Count > 0)
+                    {
+                        unifiedGroupUsers = new List<UnifiedGroupUser>();
+                        foreach (User usr in unifiedGroupGraphUsers)
+                        {
+                            UnifiedGroupUser groupUser = new UnifiedGroupUser();
+                            groupUser.UserPrincipalName = usr.UserPrincipalName != null ? usr.UserPrincipalName : string.Empty;
+                            groupUser.DisplayName = usr.DisplayName != null ? usr.DisplayName : string.Empty;
+                            unifiedGroupUsers.Add(groupUser);
+                        }
+                    }
+                    return unifiedGroupUsers;
+
+                }).GetAwaiter().GetResult();
+            }
+            catch (ServiceException ex)
+            {
+                Log.Error(Constants.LOGGING_SOURCE, CoreResources.GraphExtensions_ErrorOccured, ex.Error.Message);
+                throw;
+            }
+            return unifiedGroupUsers;
+        }
+
+        /// <summary>
+        /// Returns all the Owners of an Office 365 group.
+        /// </summary>
+        /// <param name="group">The Office 365 group object of type UnifiedGroupEntity</param>
+        /// <param name="accessToken">The OAuth 2.0 Access Token to use for invoking the Microsoft Graph</param>
+        /// <param name="retryCount">Number of times to retry the request in case of throttling</param>
+        /// <param name="delay">Milliseconds to wait before retrying the request. The delay will be increased (doubled) every retry</param>
+        /// <returns>Owners of an Office 365 group as a list of UnifiedGroupUser entity</returns>
+        public static List<UnifiedGroupUser> GetUnifiedGroupOwners(UnifiedGroupEntity group, string accessToken, int retryCount = 10, int delay = 500)
+        {
+            List<UnifiedGroupUser> unifiedGroupUsers = null;
+            List<User> unifiedGroupGraphUsers = null;
+            IGroupOwnersCollectionWithReferencesPage groupUsers = null;
+
+            if (String.IsNullOrEmpty(accessToken))
+            {
+                throw new ArgumentNullException(nameof(accessToken));
+            }
+
+            try
+            {
+                var result = Task.Run(async () =>
+                {
+                    var graphClient = CreateGraphClient(accessToken, retryCount, delay);
+
+                    // Get the owners of an Office 365 group.
+                    groupUsers = await graphClient.Groups[group.GroupId].Owners.Request().GetAsync();
+                    if (groupUsers.CurrentPage != null && groupUsers.CurrentPage.Count > 0)
+                    {
+                        unifiedGroupGraphUsers = new List<User>();
+                        GenerateGraphUserCollection(groupUsers.CurrentPage, unifiedGroupGraphUsers);
+                    }
+
+                    // Retrieve users when the results are paged.
+                    while (groupUsers.NextPageRequest != null)
+                    {
+                        groupUsers = groupUsers.NextPageRequest.GetAsync().GetAwaiter().GetResult();
+                        if (groupUsers.CurrentPage != null && groupUsers.CurrentPage.Count > 0)
+                        {
+                            GenerateGraphUserCollection(groupUsers.CurrentPage, unifiedGroupGraphUsers);
+                        }
+                    }
+
+                    // Create the collection of type OfficeDevPnP 'UnifiedGroupUser' after all users are retrieved, including paged data.
+                    if (unifiedGroupGraphUsers != null && unifiedGroupGraphUsers.Count > 0)
+                    {
+                        unifiedGroupUsers = new List<UnifiedGroupUser>();
+                        foreach (User usr in unifiedGroupGraphUsers)
+                        {
+                            UnifiedGroupUser groupUser = new UnifiedGroupUser();
+                            groupUser.UserPrincipalName = usr.UserPrincipalName != null ? usr.UserPrincipalName : string.Empty;
+                            groupUser.DisplayName = usr.DisplayName != null ? usr.DisplayName : string.Empty;
+                            unifiedGroupUsers.Add(groupUser);
+                        }
+                    }
+                    return unifiedGroupUsers;
+
+                }).GetAwaiter().GetResult();
+            }
+            catch (ServiceException ex)
+            {
+                Log.Error(Constants.LOGGING_SOURCE, CoreResources.GraphExtensions_ErrorOccured, ex.Error.Message);
+                throw;
+            }
+            return unifiedGroupUsers;
+        }
+
+        /// <summary>
+        /// Helper method. Generates a collection of Microsoft.Graph.User entity from directory objects.
+        /// </summary>
+        /// <param name="page"></param>
+        /// <param name="unifiedGroupGraphUsers"></param>
+        /// <returns>Returns a collection of Microsoft.Graph.User entity</returns>
+        private static List<User> GenerateGraphUserCollection(IList<DirectoryObject> page, List<User> unifiedGroupGraphUsers)
+        {
+            // Create a collection of Microsoft.Graph.User type
+            foreach (User usr in page)
+            {
+                if (usr != null)
+                {
+                    unifiedGroupGraphUsers.Add(usr);
+                }
+            }
+
+            return unifiedGroupGraphUsers;
+        }
     }
 }

--- a/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
+++ b/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
@@ -378,6 +378,7 @@
   <ItemGroup>
     <Compile Include="ALM\AppManager.cs" />
     <Compile Include="ALM\AppMetadata.cs" />
+    <Compile Include="Entities\UnifiedGroupUser.cs" />
     <Compile Include="Entities\WebhookNotification.cs" />
     <Compile Include="Entities\WebhookSubscription.cs" />
     <Compile Include="Extensions\ClientContextExtensions.cs" />
@@ -909,6 +910,7 @@
     <EmbeddedResource Include="CoreResources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>CoreResources.Designer.cs</LastGenOutput>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | 
| New feature?    | yes
| New sample?      | 
| Related issues?  |

#### What's in this Pull Request?

New functionality to retrieve Owners and Members of a particular Unified group.


#### Guidance
Currently there is no functionality in PnP-Sites-Core Graph utility to retrieve Owners and Members of a particular Unified group. This can be useful in creating new commands in PnP-Powershell to fetch members and owners. The changes consists of following

- Methods GetUnifiedGroupMembers, GetUnifiedGroupOwners and a helper method GenerateGraphUserCollection(to reduce repeatitive code) added to UnifiedGroupsUtiity class. 

- New entity UnifiedGroupUser added with the properties User principal name and display name. This entity represents a user in a Unified group.
