### PR TITLE
Added pageUrl argument encoding

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/PageExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/PageExtensions.cs
@@ -18,6 +18,7 @@ using System.Text;
 using System.Web.Configuration;
 using WebPart = OfficeDevPnP.Core.Framework.Provisioning.Model.WebPart;
 using OfficeDevPnP.Core.Pages;
+using Microsoft.SharePoint.Client.Utilities;
 
 namespace Microsoft.SharePoint.Client
 {
@@ -311,7 +312,7 @@ namespace Microsoft.SharePoint.Client
             xd.PreserveWhitespace = true;
             xd.LoadXml(wikiField);
 
-            // Sometimes the wikifield content seems to be surrounded by an additional div? 
+            // Sometimes the wikifield content seems to be surrounded by an additional div?
             var layoutsTable = xd.SelectSingleNode("div/div/table") as XmlElement ??
                                xd.SelectSingleNode("div/table") as XmlElement;
 
@@ -394,7 +395,7 @@ namespace Microsoft.SharePoint.Client
                 var serverRelativeUrl = web.EnsureProperty(w => w.ServerRelativeUrl);
                 var webUrl = $"{uri.Scheme}://{uri.Host}:{uri.Port}{serverRelativeUrl}";
                 var pageUrl = $"{uri.Scheme}://{uri.Host}:{uri.Port}{serverRelativePageUrl}";
-                var request = (HttpWebRequest)WebRequest.Create($"{webUrl}/_vti_bin/exportwp.aspx?pageurl={pageUrl}&guidstring={id}");
+                var request = (HttpWebRequest)WebRequest.Create($"{webUrl}/_vti_bin/exportwp.aspx?pageurl={HttpUtility.UrlKeyValueEncode(pageUrl)}&guidstring={id}");
 
                 if (web.Context.Credentials != null)
                 {
@@ -756,7 +757,7 @@ namespace Microsoft.SharePoint.Client
             xd.PreserveWhitespace = true;
             xd.LoadXml(wikiField);
 
-            // Sometimes the wikifield content seems to be surrounded by an additional div? 
+            // Sometimes the wikifield content seems to be surrounded by an additional div?
             var layoutsTable = xd.SelectSingleNode("div/div/table") as XmlElement;
             if (layoutsTable == null)
             {
@@ -890,7 +891,7 @@ namespace Microsoft.SharePoint.Client
         }
 
         /// <summary>
-        /// Loads a client side "modern" page 
+        /// Loads a client side "modern" page
         /// </summary>
         /// <param name="web">Web to load the page from</param>
         /// <param name="pageName">Name (e.g. demo.aspx) of the page to be loaded</param>
@@ -1015,7 +1016,7 @@ namespace Microsoft.SharePoint.Client
             }
 
             var folderName = serverRelativePageUrl.Substring(0, serverRelativePageUrl.LastIndexOf("/", StringComparison.Ordinal));
-            
+
             //ensure that folderName does not contain the web's ServerRelativeUrl -> otherwise it will fail on SubSites
             if (folderName.ToLower().StartsWith((web.ServerRelativeUrl.ToLower())))
             {
@@ -1085,7 +1086,7 @@ namespace Microsoft.SharePoint.Client
             var wpdNew = limitedWebPartManager.AddWebPart(oWebPartDefinition.WebPart, zoneId, zoneIndex);
             webPartPage.Context.Load(wpdNew);
             webPartPage.Context.ExecuteQueryRetry();
-            
+
             var webPartPostProcessor = WebPartPostProcessorFactory.Resolve(webPart.WebPartXml);
 
             var currentContext = ((ClientContext) webPartPage.Context);
@@ -1273,6 +1274,6 @@ namespace Microsoft.SharePoint.Client
             return (friendlyUrl.Value);
         }
 
-       
+
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no 
| New sample?      | no 
| Related issues?  | fixes #1452 

#### What's in this Pull Request?

This PR fix #1452.

After delving into the code, I noticed that the engine builds an url like this to get the XML:

`http://server:80/sites/somepublishingsite/_vti_bin/exportwp.aspx?pageurl=http://server:80/sites/somepublishingsite/Pages/default.aspx&guidstring=df28b8a4-cad2-4652-97f1-5d57d8010232`

Precisely:

` var request = (HttpWebRequest)WebRequest.Create($"{webUrl}/_vti_bin/exportwp.aspx?pageurl={pageUrl}&guidstring={id}");`

The pageURl argument is passed as is.

Adding an Url encoding solved the issue:

`var request = (HttpWebRequest)WebRequest.Create($"{webUrl}/_vti_bin/exportwp.aspx?pageurl={HttpUtility.UrlKeyValueEncode(pageUrl)}&guidstring={id}");`

The Url became:

`http://server:80/sites/somepublishingsite/_vti_bin/exportwp.aspx?pageurl=http%3A%2F%2Fserver%3A80%2Fsites%2Fsomepublishingsite%2FPages%2Fdefault%2Easpx&guidstring=df28b8a4-cad2-4652-97f1-5d57d8010232`


Hope that helped