### PR TITLE
Fixed cookieLifeTime in UsernameMixed() to use lifeTime.TotalMinutes

### DIFF
--- a/Core/OfficeDevPnP.Core/IdentityModel/TokenProviders/ADFS/UsernameMixed.cs
+++ b/Core/OfficeDevPnP.Core/IdentityModel/TokenProviders/ADFS/UsernameMixed.cs
@@ -36,7 +36,7 @@ namespace OfficeDevPnP.Core.IdentityModel.TokenProviders.ADFS
                 lifeTime = new TimeSpan(0, 60, 0);
             }
 
-            int cookieLifeTime = Math.Min((lifeTime.Hours * 60 + lifeTime.Minutes), logonTokenCacheExpirationWindow);
+            int cookieLifeTime = Math.Min((int)lifeTime.TotalMinutes, logonTokenCacheExpirationWindow);
             DateTime expiresOn = DateTime.Now.AddMinutes(cookieLifeTime);
 
             CookieContainer cc = null;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #1455

#### What's in this Pull Request?

Fixed UsernameMixed.GetFedAuthCookie() to work if cookie-lifetime is in days (like 1.00:00:00, without hours and minutes) #1455