### PR TITLE
Partial fix of issue #1353 related to local fields

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -783,7 +783,10 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             var fieldXml = parser.ParseXmlString(fieldElement.ToString(), "~sitecollection", "~site");
             if (IsFieldXmlValid(parser.ParseXmlString(originalFieldXml), parser, context))
             {
-                field = listInfo.SiteList.Fields.AddFieldAsXml(fieldXml, false, AddFieldOptions.AddFieldInternalNameHint | AddFieldOptions.AddToNoContentType);
+                var addOptions = listInfo.TemplateList.ContentTypesEnabled
+                    ? AddFieldOptions.AddFieldInternalNameHint | AddFieldOptions.AddToNoContentType
+                    : AddFieldOptions.AddFieldInternalNameHint | AddFieldOptions.AddToDefaultContentType;
+                field = listInfo.SiteList.Fields.AddFieldAsXml(fieldXml, false, addOptions);
                 listInfo.SiteList.Context.Load(field);
                 listInfo.SiteList.Context.ExecuteQueryRetry();
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |  yes
| New feature?    | no 
| New sample?      | no 
| Related issues?  | partially #1353 and #1457 

#### What's in this Pull Request?

This PR partially fixes local field regression.

Here is the status of what's working or not (in scenarios where PnP engine is use to "clone" site, by exporting the template and applying it):

[X] List with content types not enabled are cloned properly (site fields and local fields)
[ ] List with content types enabled : 
    [X] site fields referenced in the site content types are cloned properly
    [ ] all list local fields are cloned, but are not bound to content types
    [ ] all site fields are cloned, but are not bound to content types if the reference is in the list content type

I choose to still submit the PR as it solve the first case below, as it is widely used. Unfortunately, the other cases can't be fixed unless the schema is also extended.

