### PR TITLE
Null handling for bing map control property

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectClientSidePages.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectClientSidePages.cs
@@ -300,8 +300,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         page.PromoteAsNewsArticle();
                     }
 
-                    page.Publish();
-
                 }
             }
             return parser;

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectClientSidePages.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectClientSidePages.cs
@@ -247,7 +247,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                         }
 
                                         // set using property collection
-                                        if (control.ControlProperties.Any())
+                                        if (control.ControlProperties != null && control.ControlProperties.Any())
                                         {
                                             // grab the "default" properties so we can deduct their types, needed to correctly apply the set properties
                                             var controlManifest = JObject.Parse(baseControl.Manifest);

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectClientSidePages.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectClientSidePages.cs
@@ -126,7 +126,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                 if (control.Type == WebPartType.Text)
                                 {
                                     Pages.ClientSideText textControl = new Pages.ClientSideText();
-                                    if (control.ControlProperties.Any())
+                                    if (control.ControlProperties != null && control.ControlProperties.Any())
                                     {
                                         var textProperty = control.ControlProperties.First();
                                         textControl.Text = textProperty.Value;
@@ -299,6 +299,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     {
                         page.PromoteAsNewsArticle();
                     }
+
+                    page.Publish();
 
                 }
             }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |  yes
| New feature?    | no
| New sample?      | no


#### What's in this Pull Request?

PnP Provisioning template throws error when template has bing map or people webpart because they dont have control property.

So, have added null handling to fix this bug.

Issue - 

1) Create a modern page

2) Add highlighted content webpart, bing map and people webpart in that order

3) Extract the site's template using the Get-ProvisioningTemplate method of CSOM C#

4) Apply the template.

5) It throws value should not be null error.

Fix:

Have added a fix to handle null value of control properties.


