### PR TITLE
Fix for #357: Support both forward and backward slashes in AzureStorage- and FileSystemConnectors

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/Framework/Connectors/ConnectorFileSystemTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/Connectors/ConnectorFileSystemTests.cs
@@ -15,7 +15,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.Connectors
     public class ConnectorFileSystemTests
     {
 
-        #region Test initialize and cleanup
+        #region Test initialize and cleanup    
         [ClassInitialize()]
         public static void ClassInit(TestContext context)
         {
@@ -261,6 +261,45 @@ namespace OfficeDevPnP.Core.Tests.Framework.Connectors
 
             // file will be deleted at end of test 
         }
+
+        /// <summary>
+        /// Containers using forward slash (/) as path separator should be supported
+        /// </summary>
+        [TestMethod]
+        public void FileConnectorForwardslashSupportTest()
+        {
+            // Path with forwardslash separator
+            var filename = "separator.png";
+            var containerWithForwardSlash = @"Resources/Templates/newfolder";
+
+            // Constructor replaces folder delimiter
+            FileSystemConnector fileSystemConnector = new FileSystemConnector(".", containerWithForwardSlash);
+            Assert.AreEqual(@"Resources\Templates\newfolder", fileSystemConnector.GetContainer());
+
+            // Save a file
+            long byteCount = 0;
+            using (var fileStream = System.IO.File.OpenRead(@".\resources\office365.png"))
+            {
+                byteCount = fileStream.Length;
+                fileSystemConnector.SaveFileStream(filename, containerWithForwardSlash, fileStream);
+            }
+
+            // List files
+            var files = fileSystemConnector.GetFiles(containerWithForwardSlash);
+            Assert.IsTrue(files.Contains(filename));
+
+            // Read the file
+            using (var bytes = fileSystemConnector.GetFileStream(filename, containerWithForwardSlash))
+            {
+                Assert.IsTrue(byteCount == bytes.Length);
+            }
+
+            // Delete the file 
+            fileSystemConnector.DeleteFile(filename, containerWithForwardSlash);
+
+            // Folder will be deleted in cleanup
+        }
+
         #endregion
     }
 }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Connectors/AzureStorageConnector.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Connectors/AzureStorageConnector.cs
@@ -45,7 +45,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
             {
                 throw new ArgumentException("container");
             }
-
+            container = container.Replace('\\', '/');
+            
             this.AddParameterAsString(CONNECTIONSTRING, connectionString);
             this.AddParameterAsString(CONTAINER, container);
         }
@@ -72,7 +73,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
             {
                 throw new ArgumentException("container");
             }
-
+            container = container.Replace('\\', '/');
+            
             if (!initialized)
             {
                 Initialize();
@@ -119,7 +121,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
             {
                 throw new ArgumentException("container");
             }
-
+            container = container.Replace('\\', '/');
+            
             if (!initialized)
             {
                 Initialize();
@@ -173,6 +176,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
             {
                 throw new ArgumentException("container");
             }
+            container = container.Replace('\\', '/');            
 
             string result = null;
             MemoryStream stream = null;
@@ -225,6 +229,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
             {
                 throw new ArgumentException("container");
             }
+            container = container.Replace('\\', '/');            
 
             return GetFileFromStorage(fileName, container);
         }
@@ -256,6 +261,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
             {
                 throw new ArgumentException(nameof(container));
             }
+            container = container.Replace('\\', '/');            
 
             if (stream == null)
             {
@@ -316,6 +322,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
             {
                 throw new ArgumentException("container");
             }
+            container = container.Replace('\\', '/');            
 
             if (!initialized)
             {

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Connectors/FileSystemConnector.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Connectors/FileSystemConnector.cs
@@ -40,6 +40,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
             {
                 container = "";
             }
+            container = container.Replace('/', '\\');
 
             this.AddParameterAsString(CONNECTIONSTRING, connectionString);
             this.AddParameterAsString(CONTAINER, container);
@@ -68,6 +69,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
             {
                 container = "";
             }
+            container = container.Replace('/', '\\');
 
             List<string> result = new List<string>();
 
@@ -101,6 +103,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
             {
                 container = "";
             }
+            container = container.Replace('/', '\\');
 
             List<string> result = new List<string>();
 
@@ -151,6 +154,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
             {
                 container = "";
             }
+            container = container.Replace('/', '\\');
 
             string result = null;
             MemoryStream stream = null;
@@ -203,6 +207,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
             {
                 container = "";
             }
+            container = container.Replace('/', '\\');
 
             return GetFileFromStorage(fileName, container);
         }
@@ -234,6 +239,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
             {
                 container = "";
             }
+            container = container.Replace('/', '\\');
 
             if (stream == null)
             {
@@ -287,6 +293,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
             {
                 container = "";
             }
+            container = container.Replace('/', '\\');
 
             try
             {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no 
| New feature?    |  yes
| New sample?      | no
| Related issues?  | fixes #357

#### What's in this Pull Request?

This PR adds support for both backward (```\```) and forward slashes (```/```) as path delimiters for Provisioning Engine's ```FileSystemConnector``` and ```AzureStorageConnector``` thus making it possible to use same provisioning templates across all different connectors.

The support for both delimiters was already implemented for the ```SharePointConnector``` and ```OpenXMLConnector```, so now all of the connectors should be able to use both '\' and '/' as the path separator.

The supprort for the ```SharePointConnector``` was added in PR #807 in 10/2016 and this current PR is implemented using similar approach.
