### PR TITLE
Added support to get an app by its title

### DIFF
--- a/Core/OfficeDevPnP.Core/ALM/AppManager.cs
+++ b/Core/OfficeDevPnP.Core/ALM/AppManager.cs
@@ -6,6 +6,7 @@ using OfficeDevPnP.Core.Utilities;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
@@ -457,9 +458,25 @@ namespace OfficeDevPnP.Core.ALM
         /// <summary>
         /// Returns an available app
         /// </summary>
-        /// <param name="id">The unique id of the app. Notice that this is not the product id as listed in the app catalog.</param>
+        /// <param name="title">The title of the app.</param>
         /// <returns></returns>
-        private async Task<dynamic> BaseGetAvailableAsync(Guid id)
+        public AppMetadata GetAvailable(string title)
+        {
+            return BaseGetAvailableAsync(Guid.Empty, title).GetAwaiter().GetResult();
+        }
+
+        public async Task<AppMetadata> GetAvailableAsync(string title)
+        {
+            return await BaseGetAvailableAsync(Guid.Empty, title);
+        }
+
+        /// <summary>
+        /// Returns an available app
+        /// </summary>
+        /// <param name="id">The unique id of the app. Notice that this is not the product id as listed in the app catalog.</param>
+        /// <param name="title">The title of the app.</param>
+        /// <returns></returns>
+        private async Task<dynamic> BaseGetAvailableAsync(Guid id = default(Guid),string title = "")
         {
             dynamic addins = null;
 
@@ -501,12 +518,20 @@ namespace OfficeDevPnP.Core.ALM
                         {
                             try
                             {
-                                if (Guid.Empty == id)
+                                if (Guid.Empty == id && string.IsNullOrEmpty(title))
                                 {
                                     var responseJson = JObject.Parse(responseString);
                                     var returnedAddins = responseJson["d"]["results"] as JArray;
 
                                     addins = JsonConvert.DeserializeObject<List<AppMetadata>>(returnedAddins.ToString());
+                                }                                
+                                else if(!string.IsNullOrEmpty(title))
+                                {
+                                    var responseJson = JObject.Parse(responseString);
+                                    var returnedAddins = responseJson["d"]["results"] as JArray;
+
+                                    var listAddins = JsonConvert.DeserializeObject<List<AppMetadata>>(returnedAddins.ToString());
+                                    addins = listAddins.Where(a => a.Title == title).FirstOrDefault();                                    
                                 }
                                 else
                                 {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no 
| New feature?    | yes
| New sample?      | no
| Related issues?  | NA

#### What's in this Pull Request?

Currently you can either get all available apps or get an app by its ID. (due to API "limitation")
So, have kinda "added support" to get an app by its title.

In the future, if and when we get API support to get an app by title, we can simply replace some code in the BaseGetAvailableAsync method without impacting the implementation outside.

PS - Would be great if we also have API support (some time in the future)  to get an app by its title, something along the lines of 
`/_api/web/tenantappcatalog/AvailableApps/GetByTitle` 