### PR TITLE
Using TokenParser on CustomAction.RegistrationId

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectCustomActions.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectCustomActions.cs
@@ -95,7 +95,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         ImageUrl = parser.ParseString(customAction.ImageUrl),
                         Location = customAction.Location,
                         Name = customAction.Name,
-                        RegistrationId = customAction.RegistrationId,
+                        RegistrationId = parser.ParseString(customAction.RegistrationId),
                         RegistrationType = customAction.RegistrationType,
                         Remove = customAction.Remove,
                         Rights = customAction.Rights,
@@ -244,10 +244,10 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 existingCustomAction.Location = customAction.Location;
                 isDirty = true;
             }
-            if (existingCustomAction.RegistrationId != customAction.RegistrationId)
+            if (existingCustomAction.RegistrationId != parser.ParseString(customAction.RegistrationId))
             {
                 scope.LogPropertyUpdate("RegistrationId");
-                existingCustomAction.RegistrationId = customAction.RegistrationId;
+                existingCustomAction.RegistrationId = parser.ParseString(customAction.RegistrationId);
                 isDirty = true;
             }
             if (existingCustomAction.RegistrationType != customAction.RegistrationType)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no

#### What's in this Pull Request?

This PR includes code to use the TokenParser on CustomAction.RegistrationId, as it makes sense to resolve tokens there (as List ID, specially useful for registering spfx extensions, as RegistrationType=ContenType is not yet supported, so we need to specify a ListID if we want to use the extension with a specific List).