### PR TITLE
Avoid duplicate image renditions if provisioned multiple times

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectImageRenditions.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectImageRenditions.cs
@@ -73,7 +73,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         rendition.Height = r.Height;
                         rendition.Width = r.Width;
 
-                        if (!renditions.Contains(rendition))
+                        if (!renditions.Any(rd => rd.Name == rendition.Name && rd.Height == rendition.Height && rd.Width == rendition.Width))
                         {
                             renditions.Add(rendition);
                         }


### PR DESCRIPTION
…me name, width & height)

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?

Define a template with an Image Rendition, and provision it twice for the same site : the rendition will be present 2 times. This is because of the "Contains" test that is not relevant for this kind of object. I'm using a LINQ query to test if there is an existing image rendition (same name, width & height) in order to avoid provisionning multiple times the same image rendition.