### PR TITLE
Fix to decode a JWT token with System.IdentityModel.Tokens.Jwt v.4.0.0 instead of v.5.1.5

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/ClientContextExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/ClientContextExtensions.cs
@@ -12,7 +12,7 @@ using System.Configuration;
 using System.Threading.Tasks;
 using System.Net.Http;
 using Newtonsoft.Json;
-using System.IdentityModel.Tokens.Jwt;
+using System.IdentityModel.Tokens;
 
 #if !ONPREMISES
 using OfficeDevPnP.Core.Sites;
@@ -248,17 +248,13 @@ namespace Microsoft.SharePoint.Client
             if (!String.IsNullOrEmpty(accessToken))
             {
                 // Try to decode the access token
-                JwtSecurityTokenHandler jwtHandler = new JwtSecurityTokenHandler();
-                if (jwtHandler.CanReadToken(accessToken))
-                {
-                    var token = jwtHandler.ReadToken(accessToken) as JwtSecurityToken;
+                var token = new JwtSecurityToken(accessToken);
 
-                    // Search for the UPN claim, to see if we have user's delegation
-                    var upn = token.Claims.FirstOrDefault(claim => claim.Type == "upn")?.Value;
-                    if (String.IsNullOrEmpty(upn))
-                    {
-                        result = true;
-                    }
+                // Search for the UPN claim, to see if we have user's delegation
+                var upn = token.Claims.FirstOrDefault(claim => claim.Type == "upn")?.Value;
+                if (String.IsNullOrEmpty(upn))
+                {
+                    result = true;
                 }
             }
             else if (clientContext.Credentials == null)

--- a/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
+++ b/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
@@ -349,8 +349,8 @@
     <Reference Include="System.EnterpriseServices" />
     <Reference Include="System.IdentityModel" />
     <Reference Include="System.IdentityModel.Selectors" />
-    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=5.1.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.5.1.5\lib\net45\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.4.0.0\lib\net45\System.IdentityModel.Tokens.Jwt.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/Core/OfficeDevPnP.Core/packages.config
+++ b/Core/OfficeDevPnP.Core/packages.config
@@ -22,7 +22,7 @@
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net45" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net45" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net45" />
-  <package id="System.IdentityModel.Tokens.Jwt" version="5.1.5" targetFramework="net45" />
+  <package id="System.IdentityModel.Tokens.Jwt" version="4.0.0" targetFramework="net45" />
   <package id="System.Linq" version="4.1.0" targetFramework="net45" />
   <package id="System.Linq.Expressions" version="4.1.0" targetFramework="net45" />
   <package id="System.Reflection" version="4.1.0" targetFramework="net45" />


### PR DESCRIPTION
Fix to decode a JWT token with System.IdentityModel.Tokens.Jwt v.4.0.0 instead of v.5.1.5