### PR TITLE
adding ToListId attribute as another attribute that can be replaced i…

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectWorkflows.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectWorkflows.cs
@@ -395,14 +395,22 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         {
             // Tokenize XAML to replace any ListId attribute with the corresponding token
             XElement xamlDocument = XElement.Parse(xaml);
-            var elements = (IEnumerable)xamlDocument.XPathEvaluate("//child::*[@ListId]");
+            string[] listIdAttributes = {"ListId", "ToListId"};
+            
+            var elements = (IEnumerable)xamlDocument.XPathEvaluate($"//child::*[@{listIdAttributes[0]}|@{listIdAttributes[1]}]");
 
-            if (elements != null)
+            if (elements != null) // always true, consider removing 
             {
                 foreach (var element in elements.Cast<XElement>())
                 {
-                    var listId = element.Attribute("ListId").Value;
-                    element.SetAttributeValue("ListId", TokenizeListIdProperty(listId, lists));
+                    foreach (var listIdAttribute in listIdAttributes)
+                    {
+                        if (element.Attribute(listIdAttribute) != null)
+                        {
+                            var listId = element.Attribute(listIdAttribute).Value;
+                            element.SetAttributeValue(listIdAttribute, TokenizeListIdProperty(listId, lists));
+                        }
+                    }
                 }
 
                 xaml = xamlDocument.ToString();


### PR DESCRIPTION
…n the exported xaml

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

When exporting workflows using pnp, the `ListId` attribute in the .xaml files is replaced with {listid: list title}. Any listid in ToListId attributes are left behind, causing us to either manually replace these with {listid: list title} or we have to fix these with sharepoint designer after a deploy

This PR adds token replacement to the `ToListId` attributes so we don't have to manually fix the xaml files after extracting them. 

I've attached a simple project with a workflow that you can try to deploy and extract before and after applying the fix.
[demo-wf1.zip](https://github.com/SharePoint/PnP-Sites-Core/files/1555020/demo-wf1.zip)

here is a fragment of xaml illustrating how the resulting ToListId and ListId elements should look

```
                <Sequence DisplayName="Then">
                  <local:CopyItem ItemId="{x:Null}" Overwrite="False" ToListId="{listid:Handoff library}">
                    <local:CopyItem.ItemGuid>
                      <InArgument x:TypeArguments="s:Guid">
                        <local:GetCurrentItemGuid />
                      </InArgument>
                    </local:CopyItem.ItemGuid>
                    <local:CopyItem.ListId>
                      <InArgument x:TypeArguments="s:Guid">
                        <local:GetCurrentListId />
                      </InArgument>
                    </local:CopyItem.ListId>
                  </local:CopyItem>
                  <local:UpdateListItem ItemId="{x:Null}" ListItemPropertiesDynamicValue="{x:Null}" ListId="{listid:Handoff library}">
                    <local:UpdateListItem.ItemGuid>
                      <InArgument x:TypeArguments="s:Guid">
                        <local:LookupSPListItemGuid ItemId="{x:Null}" ListId="{listid:Handoff library}" PropertyName="FileLeafRef">
                          <local:LookupSPListItemGuid.PropertyValue>
                            <InArgument x:TypeArguments="x:String">
                              <local:LookupSPListItemStringProperty ItemId="{x:Null}" PropertyName="FileLeafRef" Result="{x:Null}">
                                <local:LookupSPListItemStringProperty.ItemGuid>
                                  <InArgument x:TypeArguments="s:Guid">
                                    <local:GetCurrentItemGuid Result="{x:Null}" />
                                  </InArgument>
                                </local:LookupSPListItemStringProperty.ItemGuid>
                                <local:LookupSPListItemStringProperty.ListId>
                                  <InArgument x:TypeArguments="s:Guid">
                                    <local:GetCurrentListId Result="{x:Null}" />
                                  </InArgument>
                                </local:LookupSPListItemStringProperty.ListId>
                              </local:LookupSPListItemStringProperty>
                            </InArgument>
                          </local:LookupSPListItemGuid.PropertyValue>
                        </local:LookupSPListItemGuid>
                      </InArgument>
                    </local:UpdateListItem.ItemGuid>
                    <local:UpdateListItem.ListItemProperties>
                      <InArgument x:TypeArguments="scg:IDictionary(x:String, x:Object)">
                        <p:BuildDictionary x:TypeArguments="x:String, x:Object" Dictionary="{x:Null}">
                          <p:BuildDictionary.Values>
                            <InArgument x:TypeArguments="x:Object" x:Key="Source_x0020_library">
                              <Cast x:TypeArguments="x:String, x:Object">
                                <Cast.Operand>
                                  <InArgument x:TypeArguments="x:String">
                                    <p:FormatString Format="{}{0}" Result="{x:Null}">
                                      <p:FormatString.Arguments>
                                        <InArgument x:TypeArguments="x:String">
                                          <local:LookupWorkflowContextProperty PropertyName="ListName" />
                                        </InArgument>
                                      </p:FormatString.Arguments>
                                    </p:FormatString>
                                  </InArgument>
                                </Cast.Operand>
                                <Cast.Result>
                                  <OutArgument x:TypeArguments="x:Object" />
                                </Cast.Result>
                              </Cast>
                            </InArgument>
                          </p:BuildDictionary.Values>
                        </p:BuildDictionary>
                      </InArgument>
                    </local:UpdateListItem.ListItemProperties>
                  </local:UpdateListItem>
                  <local:SetField FieldValueDynamicValue="{x:Null}" FieldName="TPS_x0020_Status">
                    <local:SetField.FieldValue>
                      <InArgument x:TypeArguments="x:Object">
                        <Cast x:TypeArguments="x:String, x:Object" Operand="Done" />
                      </InArgument>
                    </local:SetField.FieldValue>
                  </local:SetField>
                </Sequence>
```
