### PR TITLE
Fix errors when publishing non-list-based files.

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/FileFolderExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/FileFolderExtensions.cs
@@ -1277,6 +1277,7 @@ namespace Microsoft.SharePoint.Client
             {
                 var context = file.Context;
 
+                bool normalFile = true;
                 // Ensure that ListItemAllFields.ServerObjectIsNull is loaded
                 try
                 {
@@ -1285,9 +1286,12 @@ namespace Microsoft.SharePoint.Client
                 catch
                 {
                     // Catch all errors...there's a valid scenario for this failing when this is not a file associated to a listitem
+                    normalFile = false;
                 }
 
-                bool normalFile = !file.ListItemAllFields.ServerObjectIsNull ?? false; //normal files have listItemAllFields;
+                // Only access ListItemAllFields if the above load succeeded. If it didn't, accessing it will throw it back in the context, and the next
+                // ExecuteQueryRetry will throw a 'The object specified does not belong to a list.' error.
+                normalFile = normalFile && (!file.ListItemAllFields.ServerObjectIsNull ?? false); //normal files have listItemAllFields;
                 var checkOutRequired = false;
                 if (normalFile)
                 {


### PR DESCRIPTION
Fixed to avoid trying to access file.ListItemAllFields when the file isn't associated with a list item, causing a later, spurious 'The object specified does not belong to a list' error the next time the context is executed.


| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no - yes?
| New sample?      | no - yes?
| Related issues?  | partially fixes #1340 

#### What's in this Pull Request?

This code was accessing file.ListItemAllFields to check if it's a normal file or non-list-based file, but was doing so even if the call to file.EnsureProperty(f => f.ListItemAllFields) threw an exception (indicating the file's not associated with a list). Doing so throws the retrieval back in the context, and the next time that ExecuteQueryRetry is called (which could end up being in an entirely different object handler), it will throw a 'The object specified does not belong to a list.' error.