### PR TITLE
Retrieve principal Id when principal already exists in the groups coll…

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Extensions/SecurableObjectExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Extensions/SecurableObjectExtensions.cs
@@ -57,8 +57,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Extensions
                     if (principal == null)
                     {
                         principal = context.Web.EnsureUser(roleAssignmentPrincipal);
-                        principal.EnsureProperty(p => p.Id);
                     }
+                    principal.EnsureProperty(p => p.Id);
 
                     if (principal != null)
                     {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
Applying a provisioning template with files that break role inheritance and removes specific role assignments might fail with the errormessage: 
Apply-PnPProvisioningTemplate : The property or field 'Id' has not been initialized. It has not been requested or the request has not been executed. It may need to be explicitly requested.

` <pnp:Files>
  <pnp:File Src="Home.aspx" Folder="SitePages" Overwrite="true" Level="Published">
   <pnp:Security>
    <pnp:BreakRoleInheritance ClearSubscopes="true" CopyRoleAssignments="true">
     <pnp:RoleAssignment Principal="{associatedmembergroup}" RoleDefinition="{roledefinition:Editor}" Remove="true" />
     <pnp:RoleAssignment Principal="{associatedmembergroup}" RoleDefinition="{roledefinition:Reader}" />
    </pnp:BreakRoleInheritance>
   </pnp:Security>
  </pnp:File>
`

The code does not retrieve the principal Id property if the principal already exists in the groups collection.
The line has therefore been moved outside the if statement block so that it's always run.

  