### PR TITLE
Corrected links for additional documentation

### DIFF
--- a/Core/README.md
+++ b/Core/README.md
@@ -39,9 +39,9 @@ Core component solution structure follows the generic structure like all PnP pro
 ## Additional documentation ##
 Additional PnP Core component documentation.  
 - [Class and method documentation](Documentation.md)
-- [SAML support](SAML authentication.md)
+- [SAML support](SAML%20authentication.md)
 - [PnP Core nuget package](nuget.md)
-- [Timer job framework](TimerJob Framework.md)
+- [Timer job framework](TimerJob%20Framework.md)
 
 ## AppModelExtensions ##
 [Extension methods](http://msdn.microsoft.com/en-us/library/bb383977.aspx) are a .Net construct that allow to extend an existing type with additional methods. This approach is extensively used in the core library. Below you'll see a method that extends the SharePoint.Client.Web type with a method named CreateContentType:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no 
| New sample?      | no 
| Related issues?  | none

Two Additional documentation links were missing escape characters for spaces. Corrected links to SAML support and Timer job framework.