### PR TITLE
Add support for setting taxonomy field data in provisioning template …

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectListInstanceTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectListInstanceTests.cs
@@ -6,6 +6,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OfficeDevPnP.Core.Framework.Provisioning.Model;
 using OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers;
 using System.Xml.Linq;
+using Microsoft.SharePoint.Client.Taxonomy;
 
 namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
 {
@@ -14,6 +15,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
     {
         private const string ElementSchema = @"<Field xmlns=""http://schemas.microsoft.com/sharepoint/v3"" Name=""DemoField"" StaticName=""DemoField"" DisplayName=""Test Field"" Type=""Text"" ID=""{7E5E53E4-86C2-4A64-9F2E-FDFECE6219E0}"" Group=""PnP"" Required=""true""/>";
         private Guid fieldId = Guid.Parse("{7E5E53E4-86C2-4A64-9F2E-FDFECE6219E0}");
+        private Guid termGroupId = Guid.Empty;
 
         private const string CalculatedFieldElementSchema = @"<Field Name=""CalculatedField"" StaticName=""CalculatedField"" DisplayName=""Test Calculated Field"" Type=""Calculated"" ResultType=""Text"" ID=""{D1A33456-9FEB-4D8E-AFFA-177EACCE4B70}"" Group=""PnP"" ReadOnly=""TRUE"" ><Formula>=DemoField&amp;""DemoField""</Formula><FieldRefs><FieldRef Name=""DemoField"" ID=""{7E5E53E4-86C2-4A64-9F2E-FDFECE6219E0}"" /></FieldRefs></Field>";
         private const string TokenizedCalculatedFieldElementSchema = @"<Field Name=""CalculatedField"" StaticName=""CalculatedField"" DisplayName=""Test Calculated Field"" Type=""Calculated"" ResultType=""Text"" ID=""{D1A33456-9FEB-4D8E-AFFA-177EACCE4B70}"" Group=""PnP"" ReadOnly=""TRUE"" ><Formula>=[{fieldtitle:DemoField}]&amp;""DemoField""</Formula></Field>";
@@ -62,6 +64,27 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                     isDirty = true;
                 }
 
+                // Clean up Taxonomy
+                if (!Guid.Empty.Equals(termGroupId))
+                {
+                    var taxSession = TaxonomySession.GetTaxonomySession(ctx);
+                    var termStore = taxSession.GetDefaultSiteCollectionTermStore();
+                    var termGroup = termStore.GetGroup(termGroupId);
+                    ctx.ExecuteQueryRetry();
+                    isDirty = false;
+                    if (!termGroup.ServerObjectIsNull.Value)
+                    {
+                        var termSets = termGroup.TermSets;
+                        ctx.Load(termSets);
+                        ctx.ExecuteQueryRetry();                        
+                        foreach (var termSet in termSets)
+                        {
+                            termSet.DeleteObject();
+                        }
+                        termGroup.DeleteObject();
+                        isDirty = true;
+                    }
+                }
                 if (isDirty)
                 {
                     ctx.ExecuteQueryRetry();
@@ -93,17 +116,37 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
             listInstance.Url = string.Format("lists/{0}", listName);
             listInstance.Title = listName;
             listInstance.TemplateType = (int)ListTemplateType.GenericList;
-
-            Dictionary<string, string> dataValues = new Dictionary<string, string>();
-            dataValues.Add("Title", "Test");
-            DataRow dataRow = new DataRow(dataValues);
-
-            listInstance.DataRows.Add(dataRow);
-
-            template.Lists.Add(listInstance);
+            listInstance.FieldRefs.Add(new FieldRef() { Id = new Guid("23f27201-bee3-471e-b2e7-b64fd8b7ca38") });
 
             using (var ctx = TestCommon.CreateClientContext())
             {
+                //Create term
+                var taxSession = TaxonomySession.GetTaxonomySession(ctx);
+                var termStore = taxSession.GetDefaultSiteCollectionTermStore();
+
+                // Termgroup
+                termGroupId = Guid.NewGuid();
+                var termGroup = termStore.CreateGroup("Test_Group_" + DateTime.Now.ToFileTime(), termGroupId);
+                ctx.Load(termGroup);
+
+                var termSet = termGroup.CreateTermSet("Test_Termset_" + DateTime.Now.ToFileTime(), Guid.NewGuid(), 1033);
+                ctx.Load(termSet);
+
+                Guid termId = Guid.NewGuid();
+                string termName = "Test_Term_" + DateTime.Now.ToFileTime();
+
+                termSet.CreateTerm(termName, 1033, termId);
+
+                Dictionary<string, string> dataValues = new Dictionary<string, string>();
+                dataValues.Add("Title", "Test");
+                dataValues.Add("TaxKeyword", $"{termName}|{termId.ToString()}");
+                DataRow dataRow = new DataRow(dataValues);
+
+                listInstance.DataRows.Add(dataRow);
+
+                template.Lists.Add(listInstance);
+
+
                 var parser = new TokenParser(ctx.Web, template);
 
                 // Create the List
@@ -116,11 +159,19 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                 Assert.IsNotNull(list);
 
                 var items = list.GetItems(CamlQuery.CreateAllItemsQuery());
-                ctx.Load(items, itms => itms.Include(item => item["Title"]));
+                ctx.Load(items, itms => itms.Include(item => item["Title"], i => i["TaxKeyword"]));
                 ctx.ExecuteQueryRetry();
 
                 Assert.IsTrue(items.Count == 1);
                 Assert.IsTrue(items[0]["Title"].ToString() == "Test");
+
+                //Validate taxonomy field data
+                var value = items[0]["TaxKeyword"] as TaxonomyFieldValueCollection;
+                Assert.IsNotNull(value);
+                Assert.IsTrue(value[0].WssId > 0, "Term WSS ID not set correctly");
+                Assert.AreEqual(termName, value[0].Label, "Term label not set correctly");
+                Assert.AreEqual(termId.ToString(), value[0].TermGuid, "Term GUID not set correctly");
+
             }
         }
 

--- a/Core/OfficeDevPnP.Core/Extensions/TaxonomyExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/TaxonomyExtensions.cs
@@ -1565,7 +1565,7 @@ namespace Microsoft.SharePoint.Client
         }
 
         /// <summary>
-        /// Sets a value of a taxonomy field
+        /// Sets a value of a taxonomy field. To set an empty value set label to an empty string and termGuid to an empty GUID.
         /// </summary>
         /// <param name="item">The item to process</param>
         /// <param name="fieldId">The ID of the field to set</param>
@@ -1575,32 +1575,18 @@ namespace Microsoft.SharePoint.Client
         {
             ClientContext clientContext = item.Context as ClientContext;
 
-            List list = item.ParentList;
-
-            clientContext.Load(list);
+            var field = item.ParentList.Fields.GetById(fieldId);
+            TaxonomyField taxField = clientContext.CastTo<TaxonomyField>(field);
             clientContext.ExecuteQueryRetry();
 
-            IEnumerable<Field> fieldQuery = clientContext.LoadQuery(
-              list.Fields
-              .Include(
-                fieldArg => fieldArg.TypeAsString,
-                fieldArg => fieldArg.Id,
-                fieldArg => fieldArg.InternalName
-              )
-            ).Where(fieldArg => fieldArg.Id == fieldId);
-
-            clientContext.ExecuteQueryRetry();
-
-            TaxonomyField taxField = fieldQuery.Cast<TaxonomyField>().FirstOrDefault();
-
-            clientContext.Load(taxField);
-            clientContext.ExecuteQueryRetry();
-
-            TaxonomyFieldValue fieldValue = new TaxonomyFieldValue();
-            fieldValue.Label = label;
-            fieldValue.TermGuid = termGuid.ToString();
-            fieldValue.WssId = -1;
-            taxField.SetFieldValueByValue(item, fieldValue);
+            if (string.IsNullOrEmpty(label) && termGuid.Equals(Guid.Empty))
+            {
+                taxField.SetFieldValue(item, string.Empty);
+            }
+            else
+            {
+                taxField.SetFieldValue(item, $"{label}|{termGuid.ToString()}");
+            }
             item.Update();
             clientContext.ExecuteQueryRetry();
         }
@@ -1615,46 +1601,91 @@ namespace Microsoft.SharePoint.Client
         {
             ClientContext clientContext = item.Context as ClientContext;
 
-            List list = item.ParentList;
-
-            clientContext.Load(list);
-            clientContext.ExecuteQueryRetry();
-
-            IEnumerable<Field> fieldQuery = clientContext.LoadQuery(
-              list.Fields
-              .Include(
-                fieldArg => fieldArg.TypeAsString,
-                fieldArg => fieldArg.Id,
-                fieldArg => fieldArg.InternalName
-              )
-            ).Where(fieldArg => fieldArg.Id == fieldId);
-
-            clientContext.ExecuteQueryRetry();
-
-            TaxonomyField taxField = fieldQuery.Cast<TaxonomyField>().FirstOrDefault();
-
-            clientContext.Load(taxField);
+            var field = item.ParentList.Fields.GetById(fieldId);
+            TaxonomyField taxField = clientContext.CastTo<TaxonomyField>(field);
+            clientContext.Load(taxField, tf => tf.AllowMultipleValues);
             clientContext.ExecuteQueryRetry();
 
             if (taxField.AllowMultipleValues)
             {
-                var termValuesString = String.Empty;
+                StringBuilder termValuesStringbuilder = new StringBuilder();
+                bool skipSeperator = true;
                 foreach (var term in termValues)
                 {
-                    termValuesString += "-1;#" + term.Value + "|" + term.Key.ToString("D") + ";#";
+                    if (skipSeperator)
+                    {
+                        skipSeperator = false;
+                    }
+                    else
+                    {
+                        termValuesStringbuilder.Append(';');
+                    }
+                    termValuesStringbuilder.Append(term.Value + "|" + term.Key.ToString());
                 }
 
-                termValuesString = termValuesString.Substring(0, termValuesString.Length - 2);
-
-                var newTaxFieldValue = new TaxonomyFieldValueCollection(clientContext, termValuesString, taxField);
-                taxField.SetFieldValueByValueCollection(item, newTaxFieldValue);
-
+                taxField.SetFieldValue(item, termValuesStringbuilder.ToString());
                 item.Update();
                 clientContext.ExecuteQueryRetry();
             }
             else
             {
                 throw new ArgumentException(CoreResources.TaxonomyExtensions_Field_Is_Not_Multivalues, taxField.StaticName);
+            }
+        }
+
+        /// <summary>
+        /// Sets a value of a taxonomy field.
+        /// Value parameter is one or more label GUID pairs:
+        /// Single value field (TaxonomyFieldType) - term label|term GUID
+        /// Multi value field (TaxonomyFieldTypeMulti) - term label|term GUID;term label|term GUID;term label|term GUID...
+        /// </summary>
+        /// <param name="taxonomyField">The field to set</param>
+        /// <param name="item">The item to process</param>
+        /// <param name="value">The value to set on the taxonomy field</param>
+        public static void SetFieldValue(this TaxonomyField taxonomyField, ListItem item, string value)
+        {
+            taxonomyField.EnsureProperties(f => f.TypeAsString, f => f.TextField, f => f.AllowMultipleValues);
+
+            //TaxonomyFieldValue.PopulateFromLabelGuidPairs(string) has not been exposed to CSOM.
+            //This trick uses TaxonomyFieldValueCollection to get the same result for single value taxonomy fields.
+            TaxonomyFieldValueCollection taxonomyValues = new TaxonomyFieldValueCollection(item.Context, null, taxonomyField);
+            taxonomyValues.PopulateFromLabelGuidPairs(value);
+
+            if (taxonomyField.AllowMultipleValues)
+            {
+                taxonomyField.SetFieldValueByValueCollection(item, taxonomyValues);
+            }
+            else
+            {
+                item.Context.Load(taxonomyValues);
+                item.Context.ExecuteQueryRetry();
+                if (taxonomyValues.Count > 0)
+                {
+                    taxonomyField.SetFieldValueByValue(item, taxonomyValues[0]);
+                }
+                else
+                {
+                    //Empty single value taxonomy value specified. Clear out existing value.
+                    //It's not possible to clear out the value using an empty TaxonomyFieldValue directly.
+                    //This is due to the fact that SetFieldValueByValue requires TermGuid or creatingField to be set on server side.
+                    //It is not possible to set creatingField, so the only possible workaround is to use the predefined Guid with all 1's.
+                    //This will leave data in the hidden field that must be cleared in the same query on the server.
+                    //This approach is necessary to maintain data in TaxCatchAll field for other taxonomy fields in the list item.
+
+                    Field hiddenField = item.ParentList.Fields.GetById(taxonomyField.TextField);
+                    item.Context.Load(hiddenField,
+                        tf => tf.InternalName
+                        );
+                    item.Context.ExecuteQueryRetry();
+
+                    TaxonomyFieldValue taxonomyValue = new TaxonomyFieldValue();
+                    taxonomyValue.Label = string.Empty;
+                    taxonomyValue.TermGuid = "11111111-1111-1111-1111-111111111111";
+                    taxonomyValue.WssId = -1;
+                    taxonomyField.SetFieldValueByValue(item, taxonomyValue);
+
+                    item[hiddenField.InternalName] = string.Empty;
+                }
             }
         }
 

--- a/Core/OfficeDevPnP.Core/Extensions/TaxonomyExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/TaxonomyExtensions.cs
@@ -1581,11 +1581,11 @@ namespace Microsoft.SharePoint.Client
 
             if (string.IsNullOrEmpty(label) && termGuid.Equals(Guid.Empty))
             {
-                taxField.SetFieldValue(item, string.Empty);
+                taxField.SetFieldValueByLabelGuidPair(item, string.Empty);
             }
             else
             {
-                taxField.SetFieldValue(item, $"{label}|{termGuid.ToString()}");
+                taxField.SetFieldValueByLabelGuidPair(item, $"{label}|{termGuid.ToString()}");
             }
             item.Update();
             clientContext.ExecuteQueryRetry();
@@ -1623,7 +1623,7 @@ namespace Microsoft.SharePoint.Client
                     termValuesStringbuilder.Append(term.Value + "|" + term.Key.ToString());
                 }
 
-                taxField.SetFieldValue(item, termValuesStringbuilder.ToString());
+                taxField.SetFieldValueByLabelGuidPair(item, termValuesStringbuilder.ToString());
                 item.Update();
                 clientContext.ExecuteQueryRetry();
             }
@@ -1642,9 +1642,9 @@ namespace Microsoft.SharePoint.Client
         /// <param name="taxonomyField">The field to set</param>
         /// <param name="item">The item to process</param>
         /// <param name="value">The value to set on the taxonomy field</param>
-        public static void SetFieldValue(this TaxonomyField taxonomyField, ListItem item, string value)
+        public static void SetFieldValueByLabelGuidPair(this TaxonomyField taxonomyField, ListItem item, string value)
         {
-            taxonomyField.EnsureProperties(f => f.TypeAsString, f => f.TextField, f => f.AllowMultipleValues);
+            taxonomyField.EnsureProperties(f => f.TextField, f => f.AllowMultipleValues);
 
             //TaxonomyFieldValue.PopulateFromLabelGuidPairs(string) has not been exposed to CSOM.
             //This trick uses TaxonomyFieldValueCollection to get the same result for single value taxonomy fields.

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
@@ -252,7 +252,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                                                 // Multi value field - Expected format: term label|term GUID;term label|term GUID;term label|term GUID...
 
                                                                 TaxonomyField taxonomyField = web.Context.CastTo<TaxonomyField>(dataField);
-                                                                taxonomyField.SetFieldValueByLabelGuidPair(listitem, dataValue.Value);
+                                                                taxonomyField.SetFieldValueByLabelGuidPair(listitem, fieldValue);
                                                                 break;
                                                         }
                                                         break;

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
@@ -6,6 +6,7 @@ using OfficeDevPnP.Core.Framework.Provisioning.Model;
 using Field = Microsoft.SharePoint.Client.Field;
 using OfficeDevPnP.Core.Diagnostics;
 using OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Extensions;
+using Microsoft.SharePoint.Client.Taxonomy;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 {
@@ -242,6 +243,20 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                                             listitem[parser.ParseString(dataValue.Key)] = dateTime;
                                                         }
                                                         break;
+                                                    case FieldType.Invalid:
+                                                        switch (dataField.TypeAsString)
+                                                        {
+                                                            case "TaxonomyFieldType":
+                                                                // Single value field - Expected format: term label|term GUID
+                                                            case "TaxonomyFieldTypeMulti":
+                                                                // Multi value field - Expected format: term label|term GUID;term label|term GUID;term label|term GUID...
+
+                                                                TaxonomyField taxonomyField = web.Context.CastTo<TaxonomyField>(dataField);
+                                                                taxonomyField.SetFieldValue(listitem, dataValue.Value);
+                                                                break;
+                                                        }
+                                                        break;
+
                                                     default:
                                                         listitem[parser.ParseString(dataValue.Key)] = fieldValue;
                                                         break;

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
@@ -252,7 +252,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                                                 // Multi value field - Expected format: term label|term GUID;term label|term GUID;term label|term GUID...
 
                                                                 TaxonomyField taxonomyField = web.Context.CastTo<TaxonomyField>(dataField);
-                                                                taxonomyField.SetFieldValue(listitem, dataValue.Value);
+                                                                taxonomyField.SetFieldValueByLabelGuidPair(listitem, dataValue.Value);
                                                                 break;
                                                         }
                                                         break;


### PR DESCRIPTION
…data rows.

Fix bug when specifying an empty collection of termValues in SetTaxonomyFieldValues()
Add support for setting empty taxonomy field value.
Add method for setting taxonomy field value based on label GUID pair that also does not call item.Update() in order to support multiple field updates by method caller.
Change hardcoded GUIDs for term, term group, and term to generated GUIDs as hardcoded GUIDs created unwanted sidefects when running tests.

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?

Added support for specifying taxonomy field values in the provisioning template datarows section
This is specified in the format:
Single value field: "term label|term GUID"
Multi value field: "term label|term GUID;term label|term GUID;term label|term GUID"

Added method that can set the taxonomy field value with the same format. This method does not call item.Update() so that the caller can update multiple fields and update as needed. (this follows the implementation of SPTaxonomyField.SetFieldValue() methods that also is exposed through CSOM).

Fixed a bug in SetTaxonomyFieldValues() that would throw an exception if an empty collection for termValues is specified.

Added support for setting a taxonomy field value to a blank value (empty value). This requires some workarounds to be able to do. Doing this incorrectly will lead to an incorrect value in the TaxCatchAll field. In SP On-Prem you would get an error in the ULS log stating that not all taxonomy fields were processed and that the TaxCatchAll field might not have the correct value.