### PR TITLE
List validationformula fix

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -1464,6 +1464,14 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     existingList.ValidationMessage = parser.ParseString(templateList.ValidationMessage);
                     isDirty = true;
                 }
+
+                if (isDirty)
+                {
+                    existingList.Update();
+                    web.Context.ExecuteQueryRetry();
+                    isDirty = false;
+                }
+
                 if (templateList.Security != null)
                 {
                     existingList.SetSecurity(parser, templateList.Security);
@@ -1784,11 +1792,14 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             if (!string.IsNullOrEmpty(parser.ParseString(list.ValidationFormula)))
             {
                 createdList.ValidationFormula = parser.ParseString(list.ValidationFormula);
+                createdList.Update();
             }
             if (!string.IsNullOrEmpty(parser.ParseString(list.ValidationMessage)))
             {
                 createdList.ValidationMessage = parser.ParseString(list.ValidationMessage);
+                createdList.Update();
             }
+            web.Context.ExecuteQueryRetry();
 
             // Add any custom action
             if (list.UserCustomActions.Any())

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -1094,17 +1094,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     isDirty = true;
                 }
 #endif
-                if (templateList.ValidationFormula != null && existingList.ValidationFormula != parser.ParseString(templateList.ValidationFormula))
-                {
-                    existingList.ValidationFormula = parser.ParseString(templateList.ValidationFormula);
-                    isDirty = true;
-                }
-                if (templateList.ValidationMessage != null && existingList.ValidationMessage != parser.ParseString(templateList.ValidationMessage))
-                {
-                    existingList.ValidationMessage = parser.ParseString(templateList.ValidationMessage);
-                    isDirty = true;
-                }
-
                 if (existingList.IrmExpire != templateList.IrmExpire)
                 {
                     existingList.IrmExpire = templateList.IrmExpire;
@@ -1463,6 +1452,18 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         }
                     }
                 }
+                // A validation formula may reference columns specified in a contenttype. We
+                // have to apply the validation formula after contenttypes have been added/removed
+                if (templateList.ValidationFormula != null && existingList.ValidationFormula != parser.ParseString(templateList.ValidationFormula))
+                {
+                    existingList.ValidationFormula = parser.ParseString(templateList.ValidationFormula);
+                    isDirty = true;
+                }
+                if (templateList.ValidationMessage != null && existingList.ValidationMessage != parser.ParseString(templateList.ValidationMessage))
+                {
+                    existingList.ValidationMessage = parser.ParseString(templateList.ValidationMessage);
+                    isDirty = true;
+                }
                 if (templateList.Security != null)
                 {
                     existingList.SetSecurity(parser, templateList.Security);
@@ -1607,14 +1608,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 createdList.ReadSecurity = list.ReadSecurity;
             }
 #endif
-            if (!string.IsNullOrEmpty(parser.ParseString(list.ValidationFormula)))
-            {
-                createdList.ValidationFormula = parser.ParseString(list.ValidationFormula);
-            }
-            if (!string.IsNullOrEmpty(parser.ParseString(list.ValidationMessage)))
-            {
-                createdList.ValidationMessage = parser.ParseString(list.ValidationMessage);
-            }
             if (createdList.BaseTemplate != (int)ListTemplateType.PictureLibrary && list.IRMSettings != null)
             {
                 createdList.IrmEnabled = list.IRMSettings.Enabled;
@@ -1785,6 +1778,16 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         web.Context.ExecuteQueryRetry();
                     }
                 }
+            }
+            // A list validation formula may reference columns specified in a contenttype. We
+            // have to apply the validation formula after contenttypes have been added/removed
+            if (!string.IsNullOrEmpty(parser.ParseString(list.ValidationFormula)))
+            {
+                createdList.ValidationFormula = parser.ParseString(list.ValidationFormula);
+            }
+            if (!string.IsNullOrEmpty(parser.ParseString(list.ValidationMessage)))
+            {
+                createdList.ValidationMessage = parser.ParseString(list.ValidationMessage);
             }
 
             // Add any custom action


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no

#### What's in this Pull Request?

ValidationFormulas added to lists usually will reference different fields coming from content types added to the list. In the current implementation validationformula is added _before_ content types. This will cause a validation formula to fail during deployment if it references anything other than Title. 

In this PR i have moved ValidationFormula and ValidationMessage after content type operations. 