### PR TITLE
Illegal chars set for folders and files

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/FileFolderExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/FileFolderExtensions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.SharePoint.Client
     public static partial class FileFolderExtensions
     {
 #if !ONPREMISES
-        const string REGEX_INVALID_FILE_NAME_CHARS = @"[""#%*:<>?/\|.\t\r\n]";
+        const string REGEX_INVALID_FILE_NAME_CHARS = @"[""#%*:<>?/\|\t\r\n]";
         const string REGEX_INVALID_FOLDER_NAME_CHARS = REGEX_INVALID_FILE_NAME_CHARS;
 #else
         const string REGEX_INVALID_FILE_NAME_CHARS = @"[~#%&*{}\:<>?/|""\t\r\n]";

--- a/Core/OfficeDevPnP.Core/Extensions/FileFolderExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/FileFolderExtensions.cs
@@ -20,8 +20,10 @@ namespace Microsoft.SharePoint.Client
     {
 #if !ONPREMISES
         const string REGEX_INVALID_FILE_NAME_CHARS = @"[""#%*:<>?/\|.\t\r\n]";
+        const string REGEX_INVALID_FOLDER_NAME_CHARS = REGEX_INVALID_FILE_NAME_CHARS;
 #else
         const string REGEX_INVALID_FILE_NAME_CHARS = @"[~#%&*{}\:<>?/|""\t\r\n]";
+        const string REGEX_INVALID_FOLDER_NAME_CHARS = REGEX_INVALID_FILE_NAME_CHARS;
 #endif
         /// <summary>
         /// Approves a file
@@ -220,7 +222,7 @@ namespace Microsoft.SharePoint.Client
         /// </remarks>
         public static Folder CreateFolder(this Web web, string folderName)
         {
-            if (folderName.ContainsInvalidUrlChars())
+            if (Regex.IsMatch(folderName, REGEX_INVALID_FOLDER_NAME_CHARS))
             {
                 throw new ArgumentException(CoreResources.FileFolderExtensions_CreateFolder_The_argument_must_be_a_single_folder_name_and_cannot_contain_path_characters_, nameof(folderName));
             }
@@ -246,7 +248,7 @@ namespace Microsoft.SharePoint.Client
         /// </remarks>
         public static Folder CreateFolder(this Folder parentFolder, string folderName)
         {
-            if (folderName.ContainsInvalidUrlChars())
+            if (Regex.IsMatch(folderName, REGEX_INVALID_FOLDER_NAME_CHARS))
             {
                 throw new ArgumentException(CoreResources.FileFolderExtensions_CreateFolder_The_argument_must_be_a_single_folder_name_and_cannot_contain_path_characters_, nameof(folderName));
             }
@@ -384,7 +386,7 @@ namespace Microsoft.SharePoint.Client
         /// </remarks>
         public static Folder EnsureFolder(this Web web, string folderName, params Expression<Func<Folder, object>>[] expressions)
         {
-            if (folderName.ContainsInvalidUrlChars())
+            if (Regex.IsMatch(folderName, REGEX_INVALID_FOLDER_NAME_CHARS))
             {
                 throw new ArgumentException(CoreResources.FileFolderExtensions_CreateFolder_The_argument_must_be_a_single_folder_name_and_cannot_contain_path_characters_, nameof(folderName));
             }
@@ -408,7 +410,7 @@ namespace Microsoft.SharePoint.Client
         /// </remarks>
         public static Folder EnsureFolder(this Folder parentFolder, string folderName, params Expression<Func<Folder, object>>[] expressions)
         {
-            if (folderName.ContainsInvalidUrlChars())
+            if (Regex.IsMatch(folderName, REGEX_INVALID_FOLDER_NAME_CHARS))
             {
                 throw new ArgumentException(CoreResources.FileFolderExtensions_CreateFolder_The_argument_must_be_a_single_folder_name_and_cannot_contain_path_characters_, nameof(folderName));
             }
@@ -688,7 +690,7 @@ namespace Microsoft.SharePoint.Client
                 throw new ArgumentNullException(nameof(folderName));
             }
 
-            if (folderName.ContainsInvalidUrlChars())
+            if (Regex.IsMatch(folderName, REGEX_INVALID_FOLDER_NAME_CHARS))
             {
                 throw new ArgumentException(CoreResources.FileFolderExtensions_CreateFolder_The_argument_must_be_a_single_folder_name_and_cannot_contain_path_characters_, nameof(folderName));
             }

--- a/Core/OfficeDevPnP.Core/Extensions/FileFolderExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/FileFolderExtensions.cs
@@ -18,8 +18,11 @@ namespace Microsoft.SharePoint.Client
     /// </summary>
     public static partial class FileFolderExtensions
     {
-        const string REGEX_INVALID_FILE_NAME_CHARS = @"[<>:;*?/\\|""&%\t\r\n]";
-
+#if !ONPREMISES
+        const string REGEX_INVALID_FILE_NAME_CHARS = @"[""#%*:<>?/\|.\t\r\n]";
+#else
+        const string REGEX_INVALID_FILE_NAME_CHARS = @"[~#%&*{}\:<>?/|""\t\r\n]";
+#endif
         /// <summary>
         /// Approves a file
         /// </summary>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no 
| New sample?      | no
| Related issues?  | Solves this issue - https://github.com/SharePoint/PnP-Sites-Core/issues/1161

#### What's in this Pull Request?

- Updates illegal characters set for SharePoint Online according to current limitations . For on-premises I used this article https://support.microsoft.com/lo-la/help/905231/information-about-the-characters-that-you-cannot-use-in-site-names--fo
- Applies new char set for folder creating, checking and file upload methods