### PR TITLE
Add site title token and proper implementation of site name token

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/Extensions/WebExtensionsTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Extensions/WebExtensionsTests.cs
@@ -11,6 +11,7 @@ using System.IO;
 using OfficeDevPnP.Core.Framework.Provisioning.Model;
 using OfficeDevPnP.Core;
 using OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers;
+using OfficeDevPnP.Core.Entities;
 
 namespace Microsoft.SharePoint.Client.Tests
 {
@@ -122,6 +123,22 @@ namespace Microsoft.SharePoint.Client.Tests
             if (ct != null)
             {
                 ct.DeleteObject();
+                clientContext.ExecuteQueryRetry();
+            }
+
+            bool dirty = false;
+            clientContext.Load(clientContext.Web.Webs, wc => wc.Include(w => w.Title, w => w.ServerRelativeUrl));
+            clientContext.ExecuteQueryRetry();
+            foreach (Web subWeb in clientContext.Web.Webs)
+            {
+                if (subWeb.Title.StartsWith("Test_") || subWeb.ServerRelativeUrl.Contains("Test_"))
+                {
+                    subWeb.DeleteObject();
+                    dirty = true;
+                }
+            }
+            if (dirty)
+            {
                 clientContext.ExecuteQueryRetry();
             }
 
@@ -736,5 +753,33 @@ namespace Microsoft.SharePoint.Client.Tests
         }
         #endregion
 
+        [TestMethod()]
+        public void CanGetWebNameOfRootWebTest()
+        {
+            using (var ctx = TestCommon.CreateClientContext())
+            {
+                string rootWebName = ctx.Web.GetName();
+                Assert.AreEqual(string.Empty, rootWebName);
+            }
+        }
+
+        [TestMethod()]
+        public void CanGetWebNameOfSubWebTest()
+        {
+            using (var ctx = TestCommon.CreateClientContext())
+            {
+                string subWebUrl = "Test_SubWebUrl";
+                SiteEntity subSiteInfo = new SiteEntity()
+                {
+                    Title = "Test_Site Title",
+                    Url = subWebUrl,
+                    Template = "STS#0"
+                };
+                Web subSite = ctx.Web.CreateWeb(subSiteInfo);
+                
+                string subWebName = subSite.GetName();
+                Assert.AreEqual(subWebUrl, subWebName);
+            }
+        }
     }
 }

--- a/Core/OfficeDevPnP.Core/Extensions/WebExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/WebExtensions.cs
@@ -1312,6 +1312,40 @@ namespace Microsoft.SharePoint.Client
 #endif
         #endregion
 
+        /// <summary>
+        /// Gets the name of the Web site.
+        /// </summary>
+        /// <param name="web">The Web to process</param>
+        /// <returns>A string that contains the name</returns>
+        public static string GetName(this Web web)
+        {
+            web.Context.Load(web, w => w.ParentWeb.ServerRelativeUrl);
+            web.Context.Load(web, w => w.ServerRelativeUrl);
+            web.Context.ExecuteQueryRetry();
+            string webName;
+            string parentWebUrl = null;
+
+            //web.ParentWeb.ServerObjectIsNull will be null if a parent web exists.
+            //ClientObjectExtensions.ServerObjectIsNull() seems to have a problem when 
+            //ClientObject.ServerObjectIsNull == null
+            //ServerObjectIsNull is then undefined but ClientObjectExtensions.ServerObjectIsNull()
+            //incorrectly returns true.
+            if (web.ParentWeb.ServerObjectIsNull == null || !web.ParentWeb.ServerObjectIsNull.Value)
+            {
+                parentWebUrl = web.ParentWeb.ServerRelativeUrl;
+            }
+
+            if (parentWebUrl == null)
+            {
+                webName = string.Empty;
+            }
+            else
+            {
+                webName = UrlUtility.ConvertToServiceRelUrl(web.ServerRelativeUrl, parentWebUrl);
+            }
+            return webName;
+        }
+
 #if !ONPREMISES
         #region ClientSide Package Deployment
         /// <summary>
@@ -1432,7 +1466,7 @@ namespace Microsoft.SharePoint.Client
                 return sppkgFile.ListItemAllFields;
             }
         }
-    #endregion
+        #endregion
 #endif
 
     }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/SiteNameToken.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/SiteNameToken.cs
@@ -13,13 +13,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitio
         {
             if (CacheValue == null)
             {
-                this.Web.EnsureProperty(w => w.Url);
-                using (ClientContext context = this.Web.Context.Clone(this.Web.Url))
-                {
-                    context.Load(context.Web, w => w.Title);
-                    context.ExecuteQueryRetry();
-                    CacheValue = context.Web.Title;
-                }
+                CacheValue = this.Web.GetName();
             }
             return CacheValue;
         }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/SiteNameToken.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/SiteNameToken.cs
@@ -5,7 +5,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitio
     internal class SiteNameToken : TokenDefinition
     {
         public SiteNameToken(Web web)
-            : base(web, "~sitename", "{sitename}")
+            //Due to backwardscompatibility issues this token can not use the intended sitename token value
+            //This is because SiteTitleToken historically was created with sitename token value and incorrectly returned the site title.
+            //If possible this should be changed to sitename in the future.
+            //: base(web, "~sitename", "{sitename}")
+            : base(web, "~webname", "{webname}")
         {
         }
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/SiteNameToken.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/SiteNameToken.cs
@@ -5,8 +5,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitio
     internal class SiteNameToken : TokenDefinition
     {
         public SiteNameToken(Web web)
-            //Due to backwardscompatibility issues this token can not use the intended sitename token value
-            //This is because SiteTitleToken historically was created with sitename token value and incorrectly returned the site title.
+            //Due to backwardscompatibility issues this token can not use the intended sitename token
+            //This is because SiteTitleToken historically was created with sitename token and incorrectly returned the site title.
             //If possible this should be changed to sitename in the future.
             //: base(web, "~sitename", "{sitename}")
             : base(web, "~webname", "{webname}")

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/SiteTitleToken.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/SiteTitleToken.cs
@@ -5,7 +5,10 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitio
     internal class SiteTitleToken : TokenDefinition
     {
         public SiteTitleToken(Web web)
-            : base(web, "~sitetitle", "{sitetitle}")
+            //sitename token value has been added for backwards compatibility
+            //This is because SiteTitleToken historically was created with sitename token value and incorrectly returned the site title.
+            //If possible this should be removed annd moved to SiteNameToken in the future.
+            : base(web, "~sitetitle", "{sitetitle}", "~sitename", "{sitename}")
         {
         }
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/SiteTitleToken.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/SiteTitleToken.cs
@@ -5,9 +5,9 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitio
     internal class SiteTitleToken : TokenDefinition
     {
         public SiteTitleToken(Web web)
-            //sitename token value has been added for backwards compatibility
-            //This is because SiteTitleToken historically was created with sitename token value and incorrectly returned the site title.
-            //If possible this should be removed annd moved to SiteNameToken in the future.
+            //sitename token has been added for backwards compatibility
+            //This is because SiteTitleToken historically was created with sitename token and incorrectly returned the site title.
+            //If possible this should be removed and moved to SiteNameToken in the future.
             : base(web, "~sitetitle", "{sitetitle}", "~sitename", "{sitename}")
         {
         }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/SiteTitleToken.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/SiteTitleToken.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.SharePoint.Client;
+
+namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitions
+{
+    internal class SiteTitleToken : TokenDefinition
+    {
+        public SiteTitleToken(Web web)
+            : base(web, "~sitetitle", "{sitetitle}")
+        {
+        }
+
+        public override string GetReplaceValue()
+        {
+            if (CacheValue == null)
+            {
+                this.Web.EnsureProperty(w => w.Url);
+                using (ClientContext context = this.Web.Context.Clone(this.Web.Url))
+                {
+                    context.Load(context.Web, w => w.Title);
+                    context.ExecuteQueryRetry();
+                    CacheValue = context.Web.Title;
+                }
+            }
+            return CacheValue;
+        }
+    }
+}

--- a/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
+++ b/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
@@ -465,6 +465,7 @@
     <Compile Include="Framework\Provisioning\ObjectHandlers\TokenDefinitions\SiteCollectionConnectedOffice365GroupId.cs" />
     <Compile Include="Framework\Provisioning\ObjectHandlers\TokenDefinitions\SiteCollectionIdEncodedToken.cs" />
     <Compile Include="Framework\Provisioning\ObjectHandlers\TokenDefinitions\SiteIdEncodedToken.cs" />
+    <Compile Include="Framework\Provisioning\ObjectHandlers\TokenDefinitions\SiteTitleToken.cs" />
     <Compile Include="Framework\Provisioning\ObjectHandlers\Utilities\ClientSidePageContentsHelper.cs" />
     <Compile Include="Framework\Provisioning\ObjectHandlers\TokenDefinitions\AppPackageIdToken.cs" />
     <Compile Include="Framework\Provisioning\ObjectHandlers\TokenDefinitions\FileUniqueIdToken.cs" />

--- a/Core/OfficeDevPnP.Core/Utilities/UrlUtility.cs
+++ b/Core/OfficeDevPnP.Core/Utilities/UrlUtility.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Text.RegularExpressions;
 
 namespace OfficeDevPnP.Core.Utilities
@@ -151,5 +152,50 @@ namespace OfficeDevPnP.Core.Utilities
             return Regex.IsMatch(url, IIS_MAPPED_PATHS_REGEX, RegexOptions.IgnoreCase);
         }
 
+        /// <summary>
+        /// Taken from Microsoft.SharePoint.Utilities.SPUtility
+        /// </summary>
+        /// <param name="strUrl"></param>
+        /// <param name="strBaseUrl"></param>
+        /// <returns></returns>
+        internal static string ConvertToServiceRelUrl(string strUrl, string strBaseUrl)
+        {
+            if (((strBaseUrl == null) || !StsStartsWith(strBaseUrl, "/")) || ((strUrl == null) || !StsStartsWith(strUrl, "/")))
+            {
+                throw new ArgumentException();
+            }
+            if ((strUrl.Length > 1) && (strUrl[strUrl.Length - 1] == '/'))
+            {
+                strUrl = strUrl.Substring(0, strUrl.Length - 1);
+            }
+            if ((strBaseUrl.Length > 1) && (strBaseUrl[strBaseUrl.Length - 1] == '/'))
+            {
+                strBaseUrl = strBaseUrl.Substring(0, strBaseUrl.Length - 1);
+            }
+            if (!StsStartsWith(strUrl, strBaseUrl))
+            {
+                throw new ArgumentException();
+            }
+            if (strBaseUrl == "/")
+            {
+                return strUrl.Substring(1);
+            }
+            if (strUrl.Length == strBaseUrl.Length)
+            {
+                return "";
+            }
+            return strUrl.Substring(strBaseUrl.Length + 1);
+        }
+
+        /// <summary>
+        /// Taken from Microsoft.SharePoint.Utilities.SPUtility
+        /// </summary>
+        /// <param name="strMain"></param>
+        /// <param name="strBegining"></param>
+        /// <returns></returns>
+        internal static bool StsStartsWith(string strMain, string strBegining)
+        {
+            return CultureInfo.InvariantCulture.CompareInfo.IsPrefix(strMain, strBegining, CompareOptions.IgnoreCase);
+        }
     }
 }


### PR DESCRIPTION

| Q               | A
| --------------- | ---
| Bug fix?        | (yes)
| New feature?    | yes
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
Site name token is incorrectly implemented and returns title. This has been fixed by adding a new site title token that returns the site title. The site name token has been modified to return the site name.
An extension method has been made available on the web to get the site name.

This change will unfortunately change value that the site name token used to return. It's unfortunate that this token was introduced with this oversight in the first place. I see no good naming scheme for the correct implementation of site name token and simultaneously retain backwards compatibility.

I leave it up to the PnP team to decide what approach to go for. Feel free to rename the token value as required. The important thing is to have a site name token and a site title token that returns expected values.