### PR TITLE
Calculated field formula language issue

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
@@ -225,10 +225,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
             if (formulaElement != null)
             {
-                field.EnsureProperty(f => f.Formula);
-
-                var formulastring = field.Formula;
-
+                var formulastring = formulaElement.Value;
                 if (formulastring != null)
                 {
                     var fieldRefs = schemaElement.Descendants("FieldRef");
@@ -616,7 +613,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 _willExtract = true;
             }
             return _willExtract.Value;
-        }        
+        }
     }
 
     internal static class XElementStringExtensions


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | YES
| New feature?    | NO
| New sample?      | NO
| Related issues?  | https://github.com/SharePoint/PnP-Sites-Core/issues/1236

#### What's in this Pull Request?

When fetching the formula of a calculated field using the Formula property the language would that of the lcid it was created with. When fetching the formula from the SchemaXml property we get the English/US version which will allow us to provision the formula when using ApplyProvisioningTemplate. See issue https://github.com/SharePoint/PnP-Sites-Core/issues/1236 for more information.

Update:
Do not merge this pull, it's not correct. I'm looking futher into this.