### PR TITLE
Fix Event item provisioning

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
@@ -246,9 +246,10 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                                         listitem[parser.ParseString(dataValue.Key)] = fieldValue;
                                                         break;
                                                 }
-                                                listitem.Update();
                                             }
                                         }
+
+                                        listitem.Update();
                                         web.Context.ExecuteQueryRetry(); // TODO: Run in batches?
 
                                         if (dataRow.Security != null && (dataRow.Security.ClearSubscopes == true || dataRow.Security.CopyRoleAssignments == true || dataRow.Security.RoleAssignments.Count > 0))


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #1586 

#### What's in this Pull Request?

Calling listItem.update() per field value causes an exception when creating an Event item via a template. Moving this out and calling it once per item resolves this issue, although this could have side effects.
