### PR TITLE
Fix group description update during site security provisioning

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectSiteSecurityTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectSiteSecurityTests.cs
@@ -146,6 +146,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
             string htmlGroupName = string.Format("Test_HTML_{0}", DateTime.Now.Ticks);
             string plainTextDescription = "Testing plain text";
             string richHtmlDescription = "Testing HTML with link to <a href=\"/\">Root Site</a>";
+            string richHtmlDescriptionPlainTextVersion = "Testing HTML with link to Root Site";
 
             var template = new ProvisioningTemplate();
 
@@ -183,7 +184,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                 Assert.AreEqual(plainTextDescription, plainTextGroup.Description);
                 Assert.AreEqual(plainTextDescription, plainTextGroupItem["Notes"]);
 
-                Assert.AreEqual(PnPHttpUtility.ConvertSimpleHtmlToText(richHtmlDescription, int.MaxValue), htmlGroup.Description);
+                Assert.AreEqual(richHtmlDescriptionPlainTextVersion, htmlGroup.Description);
                 Assert.AreEqual(richHtmlDescription, htmlGroupItem["Notes"]);
             }
         }

--- a/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectSiteSecurityTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectSiteSecurityTests.cs
@@ -1,10 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.SharePoint.Client;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OfficeDevPnP.Core.Entities;
 using OfficeDevPnP.Core.Framework.Provisioning.Model;
 using OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers;
+using OfficeDevPnP.Core.Utilities;
 using User = OfficeDevPnP.Core.Framework.Provisioning.Model.User;
 
 namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
@@ -43,6 +45,27 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                     {
 
                     }
+                }
+
+                var siteGroups = ctx.Web.SiteGroups;
+                ctx.Load(siteGroups, sg => sg.Include(g => g.Title));
+                ctx.ExecuteQueryRetry();
+                IList<Group> groupsToRemove = new List<Group>();
+
+                foreach (var group in siteGroups)
+                {
+                    if (group.Title.StartsWith("Test_"))
+                    {
+                        groupsToRemove.Add(group);
+                    }
+                }
+                if (groupsToRemove.Count > 0)
+                {
+                    foreach (var group in groupsToRemove)
+                    {
+                        ctx.Web.SiteGroups.Remove(group);
+                    }
+                    ctx.ExecuteQueryRetry();
                 }
             }
         }
@@ -112,6 +135,56 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                 Assert.IsTrue(template.Security.AdditionalAdministrators.Any());
                 Assert.IsTrue(template.Security.SiteGroups.Any());
 
+            }
+        }
+
+        [TestMethod]
+        public void CanProvisionSiteGroupDescription()
+        {
+
+            string plainTextGroupName = string.Format("Test_PlainText_{0}", DateTime.Now.Ticks);
+            string htmlGroupName = string.Format("Test_HTML_{0}", DateTime.Now.Ticks);
+            string plainTextDescription = "Testing plain text";
+            string richHtmlDescription = "Testing HTML with link to <a href=\"/\">Root Site</a>";
+
+            var template = new ProvisioningTemplate();
+
+            template.Security.SiteGroups.Add(new SiteGroup()
+            {
+                Title = plainTextGroupName,
+                Description = plainTextDescription,
+                Owner = plainTextGroupName,
+            });
+
+            template.Security.SiteGroups.Add(new SiteGroup()
+            {
+                Title = htmlGroupName,
+                Description = richHtmlDescription,
+                Owner = htmlGroupName,
+            });
+
+            using (var ctx = TestCommon.CreateClientContext())
+            {
+                var parser = new TokenParser(ctx.Web, template);
+                new ObjectSiteSecurity().ProvisionObjects(ctx.Web, template, parser, new ProvisioningTemplateApplyingInformation());
+
+                var plainTextGroup = ctx.Web.SiteGroups.GetByName(plainTextGroupName);
+                var htmlGroup = ctx.Web.SiteGroups.GetByName(htmlGroupName);
+                ctx.Load(plainTextGroup, g => g.Id, g => g.Description);
+                ctx.Load(htmlGroup, g => g.Id, g => g.Description);
+                ctx.ExecuteQueryRetry();
+
+                var plainTextGroupItem = ctx.Web.SiteUserInfoList.GetItemById(plainTextGroup.Id);
+                var htmlGroupItem = ctx.Web.SiteUserInfoList.GetItemById(htmlGroup.Id);
+                ctx.Web.Context.Load(plainTextGroupItem, g => g["Notes"]);
+                ctx.Web.Context.Load(htmlGroupItem, g => g["Notes"]);
+                ctx.Web.Context.ExecuteQueryRetry();
+
+                Assert.AreEqual(plainTextDescription, plainTextGroup.Description);
+                Assert.AreEqual(plainTextDescription, plainTextGroupItem["Notes"]);
+
+                Assert.AreEqual(PnPHttpUtility.ConvertSimpleHtmlToText(richHtmlDescription, int.MaxValue), htmlGroup.Description);
+                Assert.AreEqual(richHtmlDescription, htmlGroupItem["Notes"]);
             }
         }
     }

--- a/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
+++ b/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
@@ -913,6 +913,7 @@
     <Compile Include="Diagnostics\Tree\TreeNode.cs" />
     <Compile Include="Diagnostics\Tree\TreeNodeList.cs" />
     <Compile Include="Framework\Graph\SiteClassificationUtility.cs" />
+    <Compile Include="Utilities\PnPHttpUtility.cs" />
     <Compile Include="Utilities\PnPCoreUtilities.cs" />
     <Compile Include="Utilities\PnPHttpProvider.cs" />
     <Compile Include="Utilities\RESTUtilities.cs" />

--- a/Core/OfficeDevPnP.Core/Utilities/PnPHttpUtility.cs
+++ b/Core/OfficeDevPnP.Core/Utilities/PnPHttpUtility.cs
@@ -1,0 +1,205 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OfficeDevPnP.Core.Utilities
+{
+    public static class PnPHttpUtility
+    {
+        //Code copied from Microsoft.SharePoint.Utilities.SPHttpUtility 
+        internal static readonly string[] HTMLData;
+
+        static PnPHttpUtility()
+        {
+            //Code copied from Microsoft.SharePoint.Utilities.SPHttpUtility 
+            HTMLData = new string[] { "", "&quot;", "&amp;", "&#39;", "&lt;", "&gt;", " ", "<br />", "&#160;", "<b>", "<i>", "<u>", "</b>", "</i>", "</u>", "<wbr />" };
+        }
+
+        //Code copied from Microsoft.SharePoint.Utilities.SPHttpUtility 
+        /// <summary>
+        /// Converts an HTML string from a Windows SharePoint Services rich text field to plain text.
+        /// </summary>
+        /// <param name="html">An HTML string that contains the contents of a Windows SharePoint Services rich text field.</param>
+        /// <param name="maxLength">A 32-bit integer representing the maximum desired length of the returned string, or -1 to specify no maximum length.</param>
+        /// <returns>A plain-text string version of the string.</returns>        
+        public static string ConvertSimpleHtmlToText(string html, int maxLength)
+        {
+            
+            return HtmlDecodeCore(html, maxLength, null);
+        }
+
+        //Code copied from Microsoft.SharePoint.Utilities.SPHttpUtility
+        internal static string HtmlDecodeCore(string html, int maxLength, IList<string> tagsToRetain)
+        {
+            if (string.IsNullOrEmpty(html))
+            {
+                return html;
+            }
+            if (maxLength == 0)
+            {
+                return string.Empty;
+            }
+            StringBuilder builder = new StringBuilder();
+            int currentPosition = 0;
+            int startIndex = 0;
+            while ((currentPosition < html.Length) && ((maxLength < 0) || (builder.Length < maxLength)))
+            {
+                char ch = html[currentPosition];
+                switch (ch)
+                {
+                    case '&':
+                    case '<':
+                        {
+                            int length = currentPosition - startIndex;
+                            bool flag = false;
+                            if ((maxLength > -1) && ((builder.Length + length) >= maxLength))
+                            {
+                                flag = true;
+                                length = maxLength - builder.Length;
+                            }
+                            if (length > 0)
+                            {
+                                builder.Append(html.Substring(startIndex, length));
+                            }
+                            if (flag)
+                            {
+                                return builder.ToString();
+                            }
+                            break;
+                        }
+                }
+                switch (ch)
+                {
+                    case '&':
+                        {
+                            builder.Append(ProceedToEndOfHtmlString(html, ref currentPosition));
+                            startIndex = currentPosition;
+                            continue;
+                        }
+                    case '<':
+                        {
+                            builder.Append(ProceedToEndOfTag(html, tagsToRetain, ref currentPosition));
+                            startIndex = currentPosition;
+                            continue;
+                        }
+                }
+                currentPosition++;
+            }
+            if ((maxLength < 0) || ((maxLength - builder.Length) >= (html.Length - startIndex)))
+            {
+                builder.Append(html.Substring(startIndex));
+            }
+            else
+            {
+                int num4 = maxLength - builder.Length;
+                if (num4 > 0)
+                {
+                    builder.Append(html.Substring(startIndex, num4));
+                }
+            }
+            return builder.ToString();
+        }
+
+        //Code copied from Microsoft.SharePoint.Utilities.SPHttpUtility 
+        internal static string ProceedToEndOfHtmlString(string html, ref int currentPosition)
+        {
+            char ch = html[currentPosition];
+            int num = currentPosition;
+            while ((ch != ';') && (num < (html.Length - 1)))
+            {
+                ch = html[++num];
+            }
+            string str = string.Empty;
+            switch (html.Substring(currentPosition, (num - currentPosition) + 1))
+            {
+                case "&quot;":
+                    str = "\"";
+                    break;
+
+                case "&amp;":
+                    str = "&";
+                    break;
+
+                case "&#39;":
+                    str = "'";
+                    break;
+
+                case "&lt;":
+                    str = "<";
+                    break;
+
+                case "&gt;":
+                    str = ">";
+                    break;
+
+                case "&#160;":
+                    str = " ";
+                    break;
+            }
+            currentPosition = num + 1;
+            return str;
+        }
+
+        //Code copied from Microsoft.SharePoint.Utilities.SPHttpUtility 
+        internal static string ProceedToEndOfTag(string html, IList<string> tagsToRetain, ref int currentPosition)
+        {
+            char ch = html[currentPosition];
+            int num = currentPosition;
+            while ((ch != '>') && (num < (html.Length - 1)))
+            {
+                ch = html[++num];
+            }
+            string str = html.Substring(currentPosition, (num - currentPosition) + 1);
+            bool flag = str.EndsWith("/>", StringComparison.Ordinal);
+            int index = str.IndexOf(' ');
+            if (index == -1)
+            {
+                index = str.IndexOf('>');
+            }
+            string item = str.Substring(1, index - 1);
+            string targetCloseTag = "</" + item + ">";
+            string str4 = string.Empty;
+            if (str == HTMLData[7])
+            {
+                str4 = "\n";
+            }
+            if ((string.IsNullOrEmpty(str4) && (tagsToRetain != null)) && tagsToRetain.Contains(item))
+            {
+                if (flag)
+                {
+                    str4 = str;
+                    currentPosition = num + 1;
+                    return str4;
+                }
+                int startIndex = num + 1;
+                ProceedToEndOfCloseTag(targetCloseTag, html, ref currentPosition);
+                return (str + html.Substring(startIndex, currentPosition - startIndex));
+            }
+            if (!flag && ((str == "<style>") || str.Contains("display:none")))
+            {
+                ProceedToEndOfCloseTag(targetCloseTag, html, ref currentPosition);
+                return str4;
+            }
+            currentPosition = num + 1;
+            return str4;
+        }
+
+        //Code copied from Microsoft.SharePoint.Utilities.SPHttpUtility 
+        private static void ProceedToEndOfCloseTag(string targetCloseTag, string html, ref int currentPosition)
+        {
+            int length = targetCloseTag.Length;
+            while (currentPosition < (html.Length - 1))
+            {
+                int num2;
+                currentPosition = num2 = currentPosition + 1;
+                if (((html[num2] == '<') && ((currentPosition + length) < html.Length)) && targetCloseTag.Equals(html.Substring(currentPosition, length)))
+                {
+                    currentPosition += targetCloseTag.Length;
+                    return;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
Fix incorrect update of site group description during provisioning. 
There are two places that holds the description for a group:
1. The group object Description property
2. The Note field for the group entry in the User Information List (UIL)

SharePoint UI uses the content in the Note Field from UIL to render the group description text in the UI.
It's therefore critical that the UIL is always updated with any group description changes.

Previously only the site group description would be set if the description was plain text. The entry in UIL was not set.
If the group was created with a rich text description both the group description and the UIL entry would contain the rich text entry. This is a bug as the group description property should only contain plain text.
The previous implementation had a bug where if you tried to update the group description with a plain text description it would never do the update if the group had no description already set. This was due to an incorrect check for null or empty string on the group description instead of checking the template group description.
Finally the group description would only update UIL if a rich text description was supplied.

Implementation has changed so that UIL and group description properties are always held in sync. This is done by using the ConvertSimpleHtmlToText method in Microsoft.SharePoint.Utilities.SPHttpUtility.