### PR TITLE
Fix: existing role assignments not removed when remove="true"

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
@@ -339,7 +339,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                 var assignmentsForPrincipal = webRoleAssignments.Where(t => t.PrincipalId == principal.Id);
                                 foreach (var assignmentForPrincipal in assignmentsForPrincipal)
                                 {
-                                    var binding = assignmentForPrincipal.EnsureProperty(r => r.RoleDefinitionBindings).FirstOrDefault(b => b.Name == parsedRoleDefinition);
+                                    var binding = assignmentForPrincipal.EnsureProperty(r => r.RoleDefinitionBindings).FirstOrDefault(b => b.Name == parser.ParseString(roleAssignment.RoleDefinition));
                                     if (binding != null)
                                     {
                                         assignmentForPrincipal.DeleteObject();


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

Resolved issue: when removing existing role assignment tokens were not replaced, so role assignment was not found and thus was not removed.