### PR TITLE
Fix Incorrect List Tokens Used in Subweb

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -86,8 +86,14 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                 var createdList = returnTuple.Item1;
                                 parser = returnTuple.Item2;
                                 processedLists.Add(new ListInfo { SiteList = createdList, TemplateList = templateList });
+                                var newListToken = new ListIdToken(web, createdList.Title, createdList.Id);
 
-                                parser.AddToken(new ListIdToken(web, createdList.Title, createdList.Id));
+                                // Remove any existing list tokens with the same name, for example, lists with the same name from the root site.
+                                parser.Tokens.RemoveAll(t => t.GetType() == typeof(ListIdToken) && t.GetTokens().SequenceEqual(newListToken.GetTokens()) );
+                                parser.Tokens.RemoveAll(t => t.GetType() == typeof(ListUrlToken) && t.GetTokens().SequenceEqual(newListToken.GetTokens()));
+                                parser.Tokens.RemoveAll(t => t.GetType() == typeof(ListViewIdToken) && t.GetTokens().SequenceEqual(newListToken.GetTokens()));
+
+                                parser.AddToken(newListToken);
 
 #if !SP2013
                                 foreach (var supportedlanguageId in web.SupportedUILanguageIds)

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -86,14 +86,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                 var createdList = returnTuple.Item1;
                                 parser = returnTuple.Item2;
                                 processedLists.Add(new ListInfo { SiteList = createdList, TemplateList = templateList });
-                                var newListToken = new ListIdToken(web, createdList.Title, createdList.Id);
 
-                                // Remove any existing list tokens with the same name, for example, lists with the same name from the root site.
-                                parser.Tokens.RemoveAll(t => t.GetType() == typeof(ListIdToken) && t.GetTokens().SequenceEqual(newListToken.GetTokens()) );
-                                parser.Tokens.RemoveAll(t => t.GetType() == typeof(ListUrlToken) && t.GetTokens().SequenceEqual(newListToken.GetTokens()));
-                                parser.Tokens.RemoveAll(t => t.GetType() == typeof(ListViewIdToken) && t.GetTokens().SequenceEqual(newListToken.GetTokens()));
-
-                                parser.AddToken(newListToken);
+                                parser.AddToken(new ListIdToken(web, createdList.Title, createdList.Id), true);
 
 #if !SP2013
                                 foreach (var supportedlanguageId in web.SupportedUILanguageIds)
@@ -103,10 +97,10 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                     createdList.Context.ExecuteQueryRetry();
 
                                     if (titleResource != null && titleResource.Value != null)
-                                        parser.AddToken(new ListIdToken(web, titleResource.Value, createdList.Id));
+                                        parser.AddToken(new ListIdToken(web, titleResource.Value, createdList.Id), true);
                                 }
 #endif
-                                parser.AddToken(new ListUrlToken(web, createdList.Title, createdList.RootFolder.ServerRelativeUrl.Substring(web.ServerRelativeUrl.Length + 1)));
+                                parser.AddToken(new ListUrlToken(web, createdList.Title, createdList.RootFolder.ServerRelativeUrl.Substring(web.ServerRelativeUrl.Length + 1)), true);
                             }
                             catch (Exception ex)
                             {
@@ -640,7 +634,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                 // Add ListViewId token parser
                 createdView.EnsureProperty(v => v.Id);
-                parser.AddToken(new ListViewIdToken(web, createdList.Title, createdView.Title, createdView.Id));
+                parser.AddToken(new ListViewIdToken(web, createdList.Title, createdView.Title, createdView.Id), true);
 
 #if !SP2013
                 // Localize view title
@@ -1025,8 +1019,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     existingList.Title = parser.ParseString(templateList.Title);
                     if (!oldTitle.Equals(existingList.Title, StringComparison.OrdinalIgnoreCase))
                     {
-                        parser.AddToken(new ListIdToken(web, existingList.Title, existingList.Id));
-                        parser.AddToken(new ListUrlToken(web, existingList.Title, existingList.RootFolder.ServerRelativeUrl.Substring(web.ServerRelativeUrl.Length + 1)));
+                        parser.AddToken(new ListIdToken(web, existingList.Title, existingList.Id), true);
+                        parser.AddToken(new ListUrlToken(web, existingList.Title, existingList.RootFolder.ServerRelativeUrl.Substring(web.ServerRelativeUrl.Length + 1)), true);
                     }
                     isDirty = true;
                 }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
@@ -42,6 +42,20 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         /// <param name="tokenDefinition">A TokenDefinition object</param>
         public void AddToken(TokenDefinition tokenDefinition)
         {
+            AddToken(tokenDefinition, false);
+        }
+
+        /// <summary>
+        /// Adds token definition, replacing any existing tokens of the same type with the same name.
+        /// </summary>
+        /// <param name="tokenDefinition">A TokenDefinition object</param>
+        /// <param name="replaceMatching">Before adding, remove any existing tokens of the same type with the same name</param>
+        public void AddToken(TokenDefinition tokenDefinition, bool replaceMatching)
+        {
+            if (replaceMatching)
+            {
+                _tokens.RemoveAll(t => t.GetType() == tokenDefinition.GetType() && t.GetTokens().SequenceEqual(tokenDefinition.GetTokens()));
+            }
 
             _tokens.Add(tokenDefinition);
             // ORDER IS IMPORTANT!

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
@@ -49,10 +49,10 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         /// Adds token definition, replacing any existing tokens of the same type with the same name.
         /// </summary>
         /// <param name="tokenDefinition">A TokenDefinition object</param>
-        /// <param name="replaceMatching">Before adding, remove any existing tokens of the same type with the same name</param>
-        public void AddToken(TokenDefinition tokenDefinition, bool replaceMatching)
+        /// <param name="removeExisting">Before adding, remove any existing tokens of the same type with the same name</param>
+        public void AddToken(TokenDefinition tokenDefinition, bool removeExisting)
         {
-            if (replaceMatching)
+            if (removeExisting)
             {
                 _tokens.RemoveAll(t => t.GetType() == tokenDefinition.GetType() && t.GetTokens().SequenceEqual(tokenDefinition.GetTokens()));
             }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |  yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 


Fixes issue where an incorrect list token would be used when provisioning a template with a list to a subweb if the root site had an existing list with the same name. If the token {listid:Some Shared List Title} was used in a page's web parts for instance, it would fail to provision saying the list was not found, because the token parser would replace the token with ID of the existing, root site list instead of your newly created list in your subweb.

PR adds a new overload to TokenParser.AddToken that allows you to optionally remove existing tokens with the same type and name before adding the new token, and updates ObjectListInstance to use that new overload when adding the tokens for newly created lists.