### PR TITLE
adding ConfigureAwait(false) for ExecuteQueryAsync calls

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/ClientContextExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/ClientContextExtensions.cs
@@ -69,9 +69,9 @@ namespace Microsoft.SharePoint.Client
         /// <param name="retryCount">Number of times to retry the request</param>
         /// <param name="delay">Milliseconds to wait before retrying the request. The delay will be increased (doubled) every retry</param>
         /// <param name="userAgent">UserAgent string value to insert for this request. You can define this value in your app's config file using key="SharePointPnPUserAgent" value="PnPRocks"></param>
-        public static async Task ExecuteQueryRetryAsync(this ClientRuntimeContext clientContext, int retryCount = 10, int delay = 500, string userAgent = null)
+        public static Task ExecuteQueryRetryAsync(this ClientRuntimeContext clientContext, int retryCount = 10, int delay = 500, string userAgent = null)
         {
-            await ExecuteQueryImplementation(clientContext, retryCount, delay, userAgent);
+            return ExecuteQueryImplementation(clientContext, retryCount, delay, userAgent);
         }
 #endif
 
@@ -134,7 +134,7 @@ namespace Microsoft.SharePoint.Client
 
                     // DO NOT CHANGE THIS TO EXECUTEQUERYRETRY
 #if !ONPREMISES
-                    await clientContext.ExecuteQueryAsync();
+                    await clientContext.ExecuteQueryAsync().ConfigureAwait(false);
 #else
                     clientContext.ExecuteQuery();
 #endif
@@ -154,7 +154,7 @@ namespace Microsoft.SharePoint.Client
                         Log.Warning(Constants.LOGGING_SOURCE, CoreResources.ClientContextExtensions_ExecuteQueryRetry, backoffInterval);
                         //Add delay for retry
 #if !ONPREMISES
-                        await Task.Delay(backoffInterval);
+                        await Task.Delay(backoffInterval).ConfigureAwait(false);
 #else
                         Thread.Sleep(backoffInterval);
 #endif


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |  yes
| New feature?    | no
| New sample?      | no
| Related issues?  | could be related to #1617 

#### What's in this Pull Request?
In libraries, in general, it is good practice to use ConfigureAwait(false) with async/await to detach the calling context and avoid deadlocks
Here the fixed implementation for ExecuteQueryRetry

In some way already mentioned in #1352 , and here
https://twitter.com/lsspdev/status/962780144707481602

I know that it's actually quite a lot of references, for a small change, but please review the change too ;)

Massimo