### PR TITLE
Adding ConfigureAwait for GetRequestDigest helper method to avoid dea…

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/ClientContextExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/ClientContextExtensions.cs
@@ -533,7 +533,7 @@ namespace Microsoft.SharePoint.Client
                     {
                         request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", accessToken);
                     }
-                    HttpResponseMessage response = await httpClient.SendAsync(request);
+                    HttpResponseMessage response = await httpClient.SendAsync(request).ConfigureAwait(false);
 
                     if (response.IsSuccessStatusCode)
                     {


### PR DESCRIPTION
…dlocks

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | Possibly fixes #1537

#### What's in this Pull Request?
As previous PR #1649 in relation to avoiding deadlocks of async using ConfigureAwait, here the addition of that in GetRequestDigest when it calls PnPHttpProvider.SendAsync

I say possibly fixes #1537 because I didn't verify myself it does provide a fix for it, and it isn't easy to find where the deadlock is caused in the current call stack. We should probably apply ConfigureAwait throughout all await calls (where possible).