### PR TITLE
Feature - Added support to get and set the audit log reports of a site collection

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/WebExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/WebExtensions.cs
@@ -1312,6 +1312,34 @@ namespace Microsoft.SharePoint.Client
 #endif
         #endregion
 
+        #region Site Audit settings extension
+
+        /// <summary>
+        /// Gets the audit log reports storage location
+        /// </summary>
+        /// <param name="site">SharePoint site collection</param>
+        /// <returns></returns>
+        public static String GetAuditLogReportsStorageLocation(this Site site)
+        {            
+            return Convert.ToString(GetPropertyBagValueInternal(site.RootWeb, "_auditlogreportstoragelocation"));
+        }
+
+        /// <summary>
+        /// Sets the audit log reports storage location
+        /// </summary>
+        /// <param name="site">SharePoint site collection</param>
+        /// <param name="value">Specify the location(server-relative url) of the document library where you want to store audit log reports</param>
+        public static void SetAuditLogReportsStorageLocation(this Site site, string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+            site.RootWeb.SetPropertyBagValue("_auditlogreportstoragelocation", value);
+        }
+
+        #endregion        
+
         /// <summary>
         /// Gets the name part of the URL of the Server Relative URL of the Web.
         /// </summary>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | yes
| Related issues?  | https://github.com/SharePoint/PnP-Provisioning-Schema/issues/178

#### What's in this Pull Request?

This PR addresses the missing piece in the Audit settings puzzle. 
Other than the audit log location, we are able to get/set Audit settings.
Using these methods, we can get and set the storage location of Audit Logs in a site collection.
In near future, we can add an extra attribute in the provisioning schema to get/set this value.