### PR TITLE
Fix issue #1670: wrong view provisioned on webpart

### DIFF
--- a/Core/OfficeDevPnP.Core/Utilities/WebParts/Processors/XsltWebPartPostProcessor.cs
+++ b/Core/OfficeDevPnP.Core/Utilities/WebParts/Processors/XsltWebPartPostProcessor.cs
@@ -147,7 +147,7 @@ namespace OfficeDevPnP.Core.Utilities.WebParts.Processors
                 }
 
                 var displayNameAttribute = viewSchemaElement.Attribute("DisplayName");
-                if (displayNameAttribute != null && TryGetView(() =>
+                if (string.IsNullOrEmpty(displayNameAttribute?.Value) != null && TryGetView(() =>
                 {
                     var listView = list.Views.GetByTitle(displayNameAttribute.Value);
                     list.Context.Load(listView);

--- a/Core/OfficeDevPnP.Core/Utilities/WebParts/Processors/XsltWebPartPostProcessor.cs
+++ b/Core/OfficeDevPnP.Core/Utilities/WebParts/Processors/XsltWebPartPostProcessor.cs
@@ -147,7 +147,7 @@ namespace OfficeDevPnP.Core.Utilities.WebParts.Processors
                 }
 
                 var displayNameAttribute = viewSchemaElement.Attribute("DisplayName");
-                if (string.IsNullOrEmpty(displayNameAttribute?.Value) != null && TryGetView(() =>
+                if (!string.IsNullOrEmpty(displayNameAttribute?.Value) && TryGetView(() =>
                 {
                     var listView = list.Views.GetByTitle(displayNameAttribute.Value);
                     list.Context.Load(listView);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #1670

#### What's in this Pull Request?
Fetching a view where the displayNameAttribute value is empty should not be be allowed. This returns the default view as illustrated in the image below:

![image](https://user-images.githubusercontent.com/3862716/37454094-ece20d50-2839-11e8-9915-1f42fd16ccd1.png)

Fixed this by checking if the value of the displayNameAttribute is not empty

```csharp
!string.IsNullOrEmpty(displayNameAttribute?.Value)
```