### PR TITLE
Fix issue #1672: duplicate token webpart issue - only for web…

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPageContents.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPageContents.cs
@@ -6,6 +6,7 @@ using System;
 using System.Text.RegularExpressions;
 using Microsoft.SharePoint.Client.WebParts;
 using OfficeDevPnP.Core.Utilities;
+using System.Xml;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 {
@@ -261,6 +262,27 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             {
                 xml = Regex.Replace(xml, list.Id.ToString(), $"{{listid:{System.Security.SecurityElement.Escape(list.Title)}}}", RegexOptions.IgnoreCase);
             }
+
+            string webpartType = null;
+            try
+            {
+                var xmlDoc = new System.Xml.XmlDocument();
+                xmlDoc.LoadXml(xml);
+                XmlNamespaceManager ns = new XmlNamespaceManager(xmlDoc.NameTable);
+                ns.AddNamespace("ns", "http://schemas.microsoft.com/WebPart/v3");
+                webpartType = xmlDoc.SelectSingleNode("//webParts/ns:webPart/ns:metaData/ns:type[@name]", ns)?.Attributes["name"]?.Value;
+            }
+            catch (Exception) { }
+
+            //some webparts already contains the site URL using ~sitecollection token (i.e: CQWP)
+            xml = Regex.Replace(xml, "\"~sitecollection/(.)*\"", "\"{site}\"", RegexOptions.IgnoreCase);
+            xml = Regex.Replace(xml, "'~sitecollection/(.)*'", "'{site}'", RegexOptions.IgnoreCase);
+
+            // Support for ContentBySearchWebParts
+            if (!string.IsNullOrEmpty(webpartType) && webpartType.ToLower().Contains("Microsoft.Office.Server.Search.WebControls.ContentBySearchWebPart".ToLower()))
+                xml = Regex.Replace(xml, ">~sitecollection/(.)*<", (Match m) => m.ToString().Replace("~sitecollection", "{sitecollection}"), RegexOptions.IgnoreCase);
+            else
+                xml = Regex.Replace(xml, ">~sitecollection/(.)*<", ">{site}<", RegexOptions.IgnoreCase);
 
             xml = Regex.Replace(xml, web.Id.ToString(), "{siteid}", RegexOptions.IgnoreCase);
             xml = Regex.Replace(xml, "(\"" + web.ServerRelativeUrl + ")(?!&)", "\"{site}", RegexOptions.IgnoreCase);

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPages.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPages.cs
@@ -144,7 +144,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                 {
                                     WebPartEntity wpEntity = new WebPartEntity();
                                     wpEntity.WebPartTitle = parser.ParseString(webPart.Title);
-                                    wpEntity.WebPartXml = parser.ParseXmlString(webPart.Contents.Trim(new[] { '\n', ' ' }), "~sitecollection", "~site");
+                                    wpEntity.WebPartXml = parser.ParseXmlStringWebpart(webPart.Contents.Trim(new[] { '\n', ' ' }), web, "~sitecollection", "~site");
                                     var wpd = web.AddWebPartToWikiPage(url, wpEntity, (int)webPart.Row, (int)webPart.Column, false);
 #if !SP2013
                                     if (webPart.Title.ContainsResourceToken())

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
@@ -417,6 +417,46 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         }
 
         /// <summary>
+        /// Parses given string for a webpart making sure we only parse the token for a given web
+        /// </summary>
+        /// <param name="input">input string</param>
+        /// <param name="web">filters the tokens on web id</param>
+        /// <param name="tokensToSkip">array of tokens to skip</param>
+        /// <returns>Returns parsed string for a webpart</returns>
+        public string ParseStringWebPart(string input, Web web, params string[] tokensToSkip)
+        {
+            web.EnsureProperty(x => x.Id);
+
+            var tokenChars = new[] { '{', '~' };
+            if (string.IsNullOrEmpty(input) || input.IndexOfAny(tokenChars) == -1) return input;
+
+            var tokensToSkipList = tokensToSkip?.ToList() ?? new List<string>();
+            string origInput;
+
+            do
+            {
+                origInput = input;
+
+                foreach (var token in _tokens)
+                {
+                    foreach (var filteredToken in token.GetTokens().Except(tokensToSkipList, StringComparer.InvariantCultureIgnoreCase))
+                    {
+                        var regex = token.GetRegexForToken(filteredToken);
+                        if (regex.IsMatch(input))
+                        {
+                            if (token is ListIdToken && !token.Web.Id.Equals(web.Id))
+                                continue;
+
+                            input = regex.Replace(input, ParseString(token.GetReplaceValue(), tokensToSkipList.Concat(new[] { filteredToken }).ToArray()));
+                        }
+                    }
+                }
+            } while (origInput != input && input.IndexOfAny(tokenChars) >= 0);
+
+            return input;
+        }
+
+        /// <summary>
         /// Parses given string
         /// </summary>
         /// <param name="input">input string</param>
@@ -447,6 +487,40 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             } while (origInput != input && input.IndexOfAny(tokenChars) >= 0);
 
             return input;
+        }
+
+        public string ParseXmlStringWebpart(string inputXml, Web web, params string[] tokensToSkip)
+        {
+            var xmlDoc = new System.Xml.XmlDocument();
+            xmlDoc.LoadXml(inputXml);
+
+            // Swap out tokens in the attributes of all nodes.
+            var nodes = xmlDoc.SelectNodes("//*");
+            if (nodes != null)
+            {
+                foreach (var node in nodes.OfType<System.Xml.XmlElement>().Where(n => n.HasAttributes))
+                {
+                    foreach (var attribute in node.Attributes.OfType<System.Xml.XmlAttribute>().Where(a => !a.Name.Equals("xmlns", StringComparison.OrdinalIgnoreCase) && !string.IsNullOrEmpty(a.Value)))
+                    {
+                        attribute.Value = ParseStringWebPart(attribute.Value, web, tokensToSkip);
+                    }
+                }
+            }
+
+            // Swap out tokens in the values of any elements with a text value.
+            nodes = xmlDoc.SelectNodes("//*[text()]");
+            if (nodes != null)
+            {
+                foreach (var node in nodes.OfType<System.Xml.XmlElement>())
+                {
+                    if (!string.IsNullOrEmpty(node.InnerText))
+                    {
+                        node.InnerText = ParseStringWebPart(node.InnerText, web, tokensToSkip);
+                    }
+                }
+            }
+
+            return xmlDoc.OuterXml;
         }
 
         public string ParseXmlString(string inputXml, params string[] tokensToSkip)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #1239 #1672, related issues: #1149 #1046 #1066

#### What's in this Pull Request?

Replace the ~sitecollection prefix with the correct {sitecollection} token and make sure we keep the url after the ~sitecollection prefix. Using the web object in the token we can check if the token we are looking for is within the specified web. This code is only applied for provisioning a webpart, and I'm not sure if this would be usefull for other code that's dependant on the tokens. So for now I've provided seperate methods for only the webpart token parser: ParseXmlStringWebpart & ParseStringWebPart.