### PR TITLE
Add option for provisioning fields in sub webs.

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
@@ -27,9 +27,10 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             using (var scope = new PnPMonitoredScope(this.Name))
             {
                 // if this is a sub site then we're not provisioning fields. Technically this can be done but it's not a recommended practice
-                if (web.IsSubSite())
+                if (web.IsSubSite() && !applyingInformation.ProvisionFieldsToSubWebs)
                 {
                     scope.LogDebug(CoreResources.Provisioning_ObjectHandlers_Fields_Context_web_is_subweb__skipping_site_columns);
+                    WriteMessage("This template contains fields and you are provisioning to a subweb. If you still want to provision these fields, set the ProvisionFieldsToSubWebs property to true.", ProvisioningMessageType.Warning);
                     return parser;
                 }
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ProvisioningTemplateApplyingInformation.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ProvisioningTemplateApplyingInformation.cs
@@ -60,6 +60,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         public bool ProvisionContentTypesToSubWebs { get; set; }
 
         /// <summary>
+        /// If true then any fields in the template will be provisioned to subwebs
+        /// </summary>
+        public bool ProvisionFieldsToSubWebs { get; set; }
+
+        /// <summary>
         /// Lists of Handlers to process
         /// </summary>
         public Handlers HandlersToProcess


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
Fields can now be provisioned to sub sites. This is similar to how content types are provisioned to sub sites.
I have not implemented or tested support for extracting fields from sub sites, but this is not needed for provisioning. A simple example could be provisioning to add-in webs. [PR 1478](https://github.com/SharePoint/PnP-PowerShell/pull/1478) has also been created in the PowerShell repository to add support for this when extracting provisioning template.