### PR TITLE
updating webhook expirationdate simplyfied

### DIFF
--- a/Core/OfficeDevPnP.Core/Entities/WebhookSubscription.cs
+++ b/Core/OfficeDevPnP.Core/Entities/WebhookSubscription.cs
@@ -27,7 +27,7 @@ namespace OfficeDevPnP.Core.Entities
         /// <summary>
         /// Webhook notification URL
         /// </summary>
-        [JsonProperty(PropertyName = "notificationUrl")]
+        [JsonProperty(PropertyName = "notificationUrl", NullValueHandling = NullValueHandling.Ignore)]
         public string NotificationUrl { get; set; }
         /// <summary>
         /// The resource endpoint URL you are creating the subscription for. For example a SharePoint List API URL

--- a/Core/OfficeDevPnP.Core/Extensions/ListExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/ListExtensions.cs
@@ -247,10 +247,24 @@ namespace Microsoft.SharePoint.Client
         /// </summary>
         /// <param name="list">The list to remove the Webhook subscription from</param>
         /// <param name="subscriptionId">The id of the subscription to remove</param>
+        /// <param name="expirationDateTime">New web hook expiration date</param>
+        /// <param name="accessToken">(optional) The access token to SharePoint</param>
+        /// <returns><c>true</c> if the update succeeded, <c>false</c> otherwise</returns>
+        public static bool UpdateWebhookSubscription(this List list, Guid subscriptionId, DateTime expirationDateTime, string accessToken = null)
+        {
+            return UpdateWebhookSubscription(list, subscriptionId.ToString(), null, expirationDateTime, accessToken);
+        }
+
+        /// <summary>
+        /// Updates a Webhook subscription from the list
+        /// Note: If the access token is not specified, it will cost a dummy request to retrieve it
+        /// </summary>
+        /// <param name="list">The list to remove the Webhook subscription from</param>
+        /// <param name="subscriptionId">The id of the subscription to remove</param>
         /// <param name="webHookEndPoint">Url of the web hook service endpoint (the one that will be called during an event)</param>
         /// <param name="expirationDateTime">New web hook expiration date</param>
         /// <param name="accessToken">(optional) The access token to SharePoint</param>
-        /// <returns><c>true</c> if the removal succeeded, <c>false</c> otherwise</returns>
+        /// <returns><c>true</c> if the update succeeded, <c>false</c> otherwise</returns>
         public static bool UpdateWebhookSubscription(this List list, Guid subscriptionId, string webHookEndPoint, DateTime expirationDateTime, string accessToken = null)
         {
             return UpdateWebhookSubscription(list, subscriptionId.ToString(), webHookEndPoint, expirationDateTime, accessToken);
@@ -263,7 +277,7 @@ namespace Microsoft.SharePoint.Client
         /// <param name="list">The list to remove the Webhook subscription from</param>
         /// <param name="subscription">The subscription to update</param>
         /// <param name="accessToken">(optional) The access token to SharePoint</param>
-        /// <returns><c>true</c> if the removal succeeded, <c>false</c> otherwise</returns>
+        /// <returns><c>true</c> if the update succeeded, <c>false</c> otherwise</returns>
         public static bool UpdateWebhookSubscription(this List list, WebhookSubscription subscription, string accessToken = null)
         {
             return UpdateWebhookSubscription(list, subscription.Id, subscription.NotificationUrl, subscription.ExpirationDateTime, accessToken);

--- a/Core/OfficeDevPnP.Core/Utilities/Webhooks/WebhookUtility.cs
+++ b/Core/OfficeDevPnP.Core/Utilities/Webhooks/WebhookUtility.cs
@@ -181,9 +181,8 @@ namespace OfficeDevPnP.Core.Utilities
                     {
                         throw new Exception("Identifier of the resource cannot be determined");
                     }
-
+                    
                     string requestUrl = string.Format("{0}/{1}('{2}')", identifierUrl, SubscriptionsUrlPart, subscriptionId);
-
                     HttpRequestMessage request = new HttpRequestMessage(new HttpMethod("PATCH"), requestUrl);
                     request.Headers.Add("X-RequestDigest", await context.GetRequestDigest());
                     request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
@@ -192,12 +191,25 @@ namespace OfficeDevPnP.Core.Utilities
                         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
                     }
 
-                    request.Content = new StringContent(JsonConvert.SerializeObject(
-                        new WebhookSubscription()
+                    WebhookSubscription webhookSubscription;
+
+                    if (string.IsNullOrEmpty(webHookEndPoint))
+                    {
+                        webhookSubscription = new WebhookSubscription()
+                        {
+                            ExpirationDateTime = expirationDateTime
+                        };
+                    }
+                    else
+                    {
+                        webhookSubscription = new WebhookSubscription()
                         {
                             NotificationUrl = webHookEndPoint,
                             ExpirationDateTime = expirationDateTime
-                        }),
+                        };
+                    }
+
+                    request.Content = new StringContent(JsonConvert.SerializeObject(webhookSubscription),
                         Encoding.UTF8, "application/json");
 
                     HttpResponseMessage response = await httpClient.SendAsync(request, new System.Threading.CancellationToken());


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |  no
| New feature?    | yes
| New sample?      | no
| Related issues?  | no

#### What's in this Pull Request?

With this update, it's possible to update list webhook expirationdate without providing notificationUrl in the payload. There is new overload method which only takes subscriptionId and expirationdate as parameters. Some typos fixed too.