### PR TITLE
Fixed applying structural navigation to subsite

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectNavigation.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectNavigation.cs
@@ -144,6 +144,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                 navigationSettings.GlobalNavigation.Source = StandardNavigationSource.TaxonomyProvider;
                                 navigationSettings.GlobalNavigation.TermStoreId = Guid.Parse(parser.ParseString(template.Navigation.GlobalNavigation.ManagedNavigation.TermStoreId));
                                 navigationSettings.GlobalNavigation.TermSetId = Guid.Parse(parser.ParseString(template.Navigation.GlobalNavigation.ManagedNavigation.TermSetId));
+                                web.Navigation.UseShared = false;
                                 break;
                             case GlobalNavigationType.Structural:
                             default:
@@ -152,6 +153,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                     throw new ApplicationException(CoreResources.Provisioning_ObjectHandlers_Navigation_missing_global_structural_navigation);
                                 }
                                 navigationSettings.GlobalNavigation.Source = StandardNavigationSource.PortalProvider;
+                                web.Navigation.UseShared = false;
 
                                 ProvisionGlobalStructuralNavigation(web,
                                     template.Navigation.GlobalNavigation.StructuralNavigation, parser, applyingInformation.ClearNavigation, scope);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

The UseShared property of web.Navigation wasn't being properly set to false when applying structural or managed navigation to a subsite, resulting in the error 'The top link bar can only be edited for a Web site with unique navigation' if the subsite's global nav was currently set to Inherit. Fixed to set to false before applying structural or managed navigation.