### PR TITLE
Fix async handling calling ClientSidePage.AvailableClientSideComponents()

### DIFF
--- a/Core/OfficeDevPnP.Core/Pages/ClientSidePage.cs
+++ b/Core/OfficeDevPnP.Core/Pages/ClientSidePage.cs
@@ -1302,6 +1302,8 @@ namespace OfficeDevPnP.Core.Pages
 
         private async Task<string> GetClientSideWebPartsAsync(string accessToken, ClientContext context)
         {
+            await new SynchronizationContextRemover();
+
             string responseString = null;
 
             using (var handler = new HttpClientHandler())


### PR DESCRIPTION

| Q               | A
| --------------- | ---
| Bug fix?        | yes

#### What's in this Pull Request?
Just a small fix...
One more missing SynchronizationContextRemover coming into play when calling Page.AvailableClientSideComponents(). Before it was leading to a deadlock again when calling this method from an application with UI Thread (e.g. MVC)

