### PR TITLE
Feature - added support for ResourcePath API in FileFolderExtensions

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/FileFolderExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/FileFolderExtensions.cs
@@ -29,8 +29,7 @@ namespace Microsoft.SharePoint.Client
 #if ONPREMISES
             var file = web.GetFileByServerRelativeUrl(serverRelativeUrl);
 #else
-            ResourcePath filePath = ResourcePath.FromDecodedUrl(serverRelativeUrl);
-            var file = web.GetFileByServerRelativePath(filePath);
+            var file = web.GetFileByServerRelativePath(ResourcePath.FromDecodedUrl(serverRelativeUrl));
 #endif
             web.Context.Load(file, x => x.Exists, x => x.CheckOutType);
             web.Context.ExecuteQueryRetry();
@@ -55,8 +54,7 @@ namespace Microsoft.SharePoint.Client
 
             var file = web.GetFileByServerRelativeUrl(serverRelativeUrl);
 #else
-            ResourcePath filePath = ResourcePath.FromDecodedUrl(serverRelativeUrl);
-            var file = web.GetFileByServerRelativePath(filePath);
+            var file = web.GetFileByServerRelativePath(ResourcePath.FromDecodedUrl(serverRelativeUrl));
 #endif
             var scope = new ConditionalScope(web.Context, () => file.ServerObjectIsNull.Value != true && file.Exists && file.CheckOutType != CheckOutType.None);
 
@@ -83,8 +81,7 @@ namespace Microsoft.SharePoint.Client
 #if ONPREMISES
             var file = web.GetFileByServerRelativeUrl(serverRelativeUrl);
 #else
-            ResourcePath filePath = ResourcePath.FromDecodedUrl(serverRelativeUrl);
-            var file = web.GetFileByServerRelativePath(filePath);
+            var file = web.GetFileByServerRelativePath(ResourcePath.FromDecodedUrl(serverRelativeUrl));
 #endif
 
             var scope = new ConditionalScope(web.Context, () => file.ServerObjectIsNull.Value != true && file.Exists && file.CheckOutType == CheckOutType.None);
@@ -346,8 +343,7 @@ namespace Microsoft.SharePoint.Client
 #if ONPREMISES
             Folder folder = web.GetFolderByServerRelativeUrl(serverRelativeFolderUrl);
 #else
-            ResourcePath folderPath = ResourcePath.FromDecodedUrl(serverRelativeFolderUrl);
-            Folder folder = web.GetFolderByServerRelativePath(folderPath);
+            Folder folder = web.GetFolderByServerRelativePath(ResourcePath.FromDecodedUrl(serverRelativeFolderUrl));
 #endif
 
             web.Context.Load(folder);
@@ -735,8 +731,7 @@ namespace Microsoft.SharePoint.Client
 #if ONPREMISES
             var file = web.GetFileByServerRelativeUrl(serverRelativeUrl);
 #else
-            ResourcePath filePath = ResourcePath.FromDecodedUrl(serverRelativeUrl);
-            var file = web.GetFileByServerRelativePath(filePath);
+            var file = web.GetFileByServerRelativePath(ResourcePath.FromDecodedUrl(serverRelativeUrl));
 #endif
 
             web.Context.Load(file);
@@ -787,8 +782,7 @@ namespace Microsoft.SharePoint.Client
 #if ONPREMISES
             var file = web.GetFileByServerRelativeUrl(serverRelativeUrl);
 #else
-            ResourcePath filePath = ResourcePath.FromDecodedUrl(serverRelativeUrl);
-            var file = web.GetFileByServerRelativePath(filePath);
+            var file = web.GetFileByServerRelativePath(ResourcePath.FromDecodedUrl(serverRelativeUrl));
 #endif
 
             web.Context.Load(file, x => x.Exists, x => x.CheckOutType);
@@ -844,8 +838,7 @@ namespace Microsoft.SharePoint.Client
 #if ONPREMISES
             var file = web.GetFileByServerRelativeUrl(serverRelativeUrl);
 #else
-            ResourcePath filePath = ResourcePath.FromDecodedUrl(serverRelativeUrl);
-            var file = web.GetFileByServerRelativePath(filePath);
+            var file = web.GetFileByServerRelativePath(ResourcePath.FromDecodedUrl(serverRelativeUrl));
 #endif
 
             clientContext.Load(file);
@@ -1049,8 +1042,7 @@ namespace Microsoft.SharePoint.Client
 #if ONPREMISES
                 var file = web.GetFileByServerRelativeUrl(fileServerRelativeUrl);
 #else
-                ResourcePath filePath = ResourcePath.FromDecodedUrl(fileServerRelativeUrl);
-                var file = web.GetFileByServerRelativePath(filePath);
+                var file = web.GetFileByServerRelativePath(ResourcePath.FromDecodedUrl(fileServerRelativeUrl));
 #endif
 
                 web.Context.Load(file);

--- a/Core/OfficeDevPnP.Core/Extensions/FileFolderExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/FileFolderExtensions.cs
@@ -27,12 +27,11 @@ namespace Microsoft.SharePoint.Client
         public static void ApproveFile(this Web web, string serverRelativeUrl, string comment)
         {
 #if ONPREMISES
-
             var file = web.GetFileByServerRelativeUrl(serverRelativeUrl);
-#endif
+#else
             ResourcePath filePath = ResourcePath.FromDecodedUrl(serverRelativeUrl);
             var file = web.GetFileByServerRelativePath(filePath);
-
+#endif
             web.Context.Load(file, x => x.Exists, x => x.CheckOutType);
             web.Context.ExecuteQueryRetry();
 
@@ -55,10 +54,10 @@ namespace Microsoft.SharePoint.Client
 #if ONPREMISES
 
             var file = web.GetFileByServerRelativeUrl(serverRelativeUrl);
-#endif
+#else
             ResourcePath filePath = ResourcePath.FromDecodedUrl(serverRelativeUrl);
             var file = web.GetFileByServerRelativePath(filePath);
-
+#endif
             var scope = new ConditionalScope(web.Context, () => file.ServerObjectIsNull.Value != true && file.Exists && file.CheckOutType != CheckOutType.None);
 
             using (scope.StartScope())
@@ -82,11 +81,11 @@ namespace Microsoft.SharePoint.Client
         public static void CheckOutFile(this Web web, string serverRelativeUrl)
         {
 #if ONPREMISES
-
             var file = web.GetFileByServerRelativeUrl(serverRelativeUrl);
-#endif
+#else
             ResourcePath filePath = ResourcePath.FromDecodedUrl(serverRelativeUrl);
             var file = web.GetFileByServerRelativePath(filePath);
+#endif
 
             var scope = new ConditionalScope(web.Context, () => file.ServerObjectIsNull.Value != true && file.Exists && file.CheckOutType == CheckOutType.None);
 
@@ -346,9 +345,10 @@ namespace Microsoft.SharePoint.Client
         {
 #if ONPREMISES
             Folder folder = web.GetFolderByServerRelativeUrl(serverRelativeFolderUrl);
-#endif
+#else
             ResourcePath folderPath = ResourcePath.FromDecodedUrl(serverRelativeFolderUrl);
             Folder folder = web.GetFolderByServerRelativePath(folderPath);
+#endif
 
             web.Context.Load(folder);
             bool exists = false;
@@ -733,11 +733,11 @@ namespace Microsoft.SharePoint.Client
             string returnString = string.Empty;
 
 #if ONPREMISES
-
             var file = web.GetFileByServerRelativeUrl(serverRelativeUrl);
-#endif
+#else
             ResourcePath filePath = ResourcePath.FromDecodedUrl(serverRelativeUrl);
             var file = web.GetFileByServerRelativePath(filePath);
+#endif
 
             web.Context.Load(file);
             web.Context.ExecuteQueryRetry();
@@ -785,11 +785,11 @@ namespace Microsoft.SharePoint.Client
         public static void PublishFile(this Web web, string serverRelativeUrl, string comment)
         {
 #if ONPREMISES
-
             var file = web.GetFileByServerRelativeUrl(serverRelativeUrl);
-#endif
+#else
             ResourcePath filePath = ResourcePath.FromDecodedUrl(serverRelativeUrl);
             var file = web.GetFileByServerRelativePath(filePath);
+#endif
 
             web.Context.Load(file, x => x.Exists, x => x.CheckOutType);
             web.Context.ExecuteQueryRetry();
@@ -842,11 +842,11 @@ namespace Microsoft.SharePoint.Client
             var clientContext = web.Context as ClientContext;
 
 #if ONPREMISES
-
             var file = web.GetFileByServerRelativeUrl(serverRelativeUrl);
-#endif
+#else
             ResourcePath filePath = ResourcePath.FromDecodedUrl(serverRelativeUrl);
             var file = web.GetFileByServerRelativePath(filePath);
+#endif
 
             clientContext.Load(file);
             clientContext.ExecuteQueryRetry();
@@ -1047,11 +1047,11 @@ namespace Microsoft.SharePoint.Client
                 var web = context.Web;
 
 #if ONPREMISES
-
                 var file = web.GetFileByServerRelativeUrl(fileServerRelativeUrl);
-#endif
+#else
                 ResourcePath filePath = ResourcePath.FromDecodedUrl(fileServerRelativeUrl);
                 var file = web.GetFileByServerRelativePath(filePath);
+#endif
 
                 web.Context.Load(file);
                 web.Context.ExecuteQueryRetry();

--- a/Core/OfficeDevPnP.Core/Extensions/FileFolderExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/FileFolderExtensions.cs
@@ -26,7 +26,13 @@ namespace Microsoft.SharePoint.Client
         /// <param name="comment">Message to be recorded with the approval</param>
         public static void ApproveFile(this Web web, string serverRelativeUrl, string comment)
         {
+#if ONPREMISES
+
             var file = web.GetFileByServerRelativeUrl(serverRelativeUrl);
+#endif
+            ResourcePath filePath = ResourcePath.FromDecodedUrl(serverRelativeUrl);
+            var file = web.GetFileByServerRelativePath(filePath);
+
             web.Context.Load(file, x => x.Exists, x => x.CheckOutType);
             web.Context.ExecuteQueryRetry();
 
@@ -46,7 +52,12 @@ namespace Microsoft.SharePoint.Client
         /// <param name="comment">Message to be recorded with the approval</param>
         public static void CheckInFile(this Web web, string serverRelativeUrl, CheckinType checkinType, string comment)
         {
+#if ONPREMISES
+
             var file = web.GetFileByServerRelativeUrl(serverRelativeUrl);
+#endif
+            ResourcePath filePath = ResourcePath.FromDecodedUrl(serverRelativeUrl);
+            var file = web.GetFileByServerRelativePath(filePath);
 
             var scope = new ConditionalScope(web.Context, () => file.ServerObjectIsNull.Value != true && file.Exists && file.CheckOutType != CheckOutType.None);
 
@@ -70,7 +81,12 @@ namespace Microsoft.SharePoint.Client
         /// <param name="serverRelativeUrl">The server relative URL of the file to checkout</param>
         public static void CheckOutFile(this Web web, string serverRelativeUrl)
         {
+#if ONPREMISES
+
             var file = web.GetFileByServerRelativeUrl(serverRelativeUrl);
+#endif
+            ResourcePath filePath = ResourcePath.FromDecodedUrl(serverRelativeUrl);
+            var file = web.GetFileByServerRelativePath(filePath);
 
             var scope = new ConditionalScope(web.Context, () => file.ServerObjectIsNull.Value != true && file.Exists && file.CheckOutType == CheckOutType.None);
 
@@ -328,7 +344,12 @@ namespace Microsoft.SharePoint.Client
         /// <returns>Returns true if folder exists</returns>
         public static bool DoesFolderExists(this Web web, string serverRelativeFolderUrl)
         {
+#if ONPREMISES
             Folder folder = web.GetFolderByServerRelativeUrl(serverRelativeFolderUrl);
+#endif
+            ResourcePath folderPath = ResourcePath.FromDecodedUrl(serverRelativeFolderUrl);
+            Folder folder = web.GetFolderByServerRelativePath(folderPath);
+
             web.Context.Load(folder);
             bool exists = false;
 
@@ -711,7 +732,13 @@ namespace Microsoft.SharePoint.Client
         {
             string returnString = string.Empty;
 
+#if ONPREMISES
+
             var file = web.GetFileByServerRelativeUrl(serverRelativeUrl);
+#endif
+            ResourcePath filePath = ResourcePath.FromDecodedUrl(serverRelativeUrl);
+            var file = web.GetFileByServerRelativePath(filePath);
+
             web.Context.Load(file);
             web.Context.ExecuteQueryRetry();
             ClientResult<Stream> stream = file.OpenBinaryStream();
@@ -757,7 +784,13 @@ namespace Microsoft.SharePoint.Client
         /// <param name="comment">Comment recorded with the publish action</param>
         public static void PublishFile(this Web web, string serverRelativeUrl, string comment)
         {
+#if ONPREMISES
+
             var file = web.GetFileByServerRelativeUrl(serverRelativeUrl);
+#endif
+            ResourcePath filePath = ResourcePath.FromDecodedUrl(serverRelativeUrl);
+            var file = web.GetFileByServerRelativePath(filePath);
+
             web.Context.Load(file, x => x.Exists, x => x.CheckOutType);
             web.Context.ExecuteQueryRetry();
 
@@ -807,7 +840,13 @@ namespace Microsoft.SharePoint.Client
         public static void SaveFileToLocal(this Web web, string serverRelativeUrl, string localPath, string localFileName = null, Func<string, bool> fileExistsCallBack = null)
         {
             var clientContext = web.Context as ClientContext;
+
+#if ONPREMISES
+
             var file = web.GetFileByServerRelativeUrl(serverRelativeUrl);
+#endif
+            ResourcePath filePath = ResourcePath.FromDecodedUrl(serverRelativeUrl);
+            var file = web.GetFileByServerRelativePath(filePath);
 
             clientContext.Load(file);
             clientContext.ExecuteQueryRetry();
@@ -1007,7 +1046,13 @@ namespace Microsoft.SharePoint.Client
 
                 var web = context.Web;
 
+#if ONPREMISES
+
                 var file = web.GetFileByServerRelativeUrl(fileServerRelativeUrl);
+#endif
+                ResourcePath filePath = ResourcePath.FromDecodedUrl(fileServerRelativeUrl);
+                var file = web.GetFileByServerRelativePath(filePath);
+
                 web.Context.Load(file);
                 web.Context.ExecuteQueryRetry();
                 return file;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no 
| New feature?    | yes
| New sample?      | no
| Related issues?  | NA

#### What's in this Pull Request?

With the introduction of ResourcePath API, file and folder names containing `%` and `#` characters are supported in SharePoint Online.

This PR makes use of that API for various methods in the FileFolderExtensions to fetch files and folders which may contain these special characters. It will work with normal characters as well.