### PR TITLE
CustomAction ClientSideComponentId and ClientSideComponentProperties not updated

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectCustomActions.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectCustomActions.cs
@@ -86,9 +86,9 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     var customActionEntity = new CustomActionEntity()
                     {
 #if !ONPREMISES
-                        ClientSideComponentId = customAction.ClientSideComponentId,                        
+                        ClientSideComponentId = customAction.ClientSideComponentId,
                         ClientSideComponentProperties = customAction.ClientSideComponentProperties != null ? parser.ParseString(customAction.ClientSideComponentProperties) : customAction.ClientSideComponentProperties,
-#endif 
+#endif
                         CommandUIExtension = customAction.CommandUIExtension != null ? parser.ParseString(customAction.CommandUIExtension.ToString()) : string.Empty,
                         Description = parser.ParseString(customAction.Description),
                         Group = customAction.Group,
@@ -199,6 +199,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 if  (existingCustomAction.ClientSideComponentId != customAction.ClientSideComponentId)
                 {
                     existingCustomAction.ClientSideComponentId = customAction.ClientSideComponentId;
+                    isDirty = true;
                 }
             }
 
@@ -207,6 +208,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 if (existingCustomAction.ClientSideComponentProperties != parser.ParseString(customAction.ClientSideComponentProperties))
                 {
                     existingCustomAction.ClientSideComponentProperties = parser.ParseString(customAction.ClientSideComponentProperties);
+                    isDirty = true;
                 }
             }
 #endif
@@ -421,7 +423,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 #if !ONPREMISES
             customAction.ClientSideComponentId = userCustomAction.ClientSideComponentId;
             customAction.ClientSideComponentProperties = userCustomAction.ClientSideComponentProperties;
-#endif 
+#endif
 
             customAction.CommandUIExtension = !System.String.IsNullOrEmpty(userCustomAction.CommandUIExtension) ?
                 XElement.Parse(userCustomAction.CommandUIExtension) : null;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | N/A

#### What's in this Pull Request?
If a CustomAction is updated with a new ClientSideComponentId and ClientSideComponentProperties, the properties are not set when the provisioning template is applied.
