### PR TITLE
Fix to support creating list from a list definition (stp)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Changed
 - ClientComponentId and ClientComponentProperties are now updated when applying a template to a site where the customaction already exists [SchauDK]
 - Fixes issue with requiring tenant admin access while not provisioning tenant scoped artifacts
+- Fixed issue where a list would not be created based on a list template (TemplateFeatureId)
 
 ### Deprecated
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/SiteToTemplateConversion.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/SiteToTemplateConversion.cs
@@ -235,6 +235,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 if (provisioningInfo.HandlersToProcess.HasFlag(Handlers.ContentTypes)) objectHandlers.Add(new ObjectContentType(FieldAndListProvisioningStepHelper.Step.LookupFields));
                 if (provisioningInfo.HandlersToProcess.HasFlag(Handlers.Lists)) objectHandlers.Add(new ObjectListInstance(FieldAndListProvisioningStepHelper.Step.LookupFields));
 
+                if (provisioningInfo.HandlersToProcess.HasFlag(Handlers.Files)) objectHandlers.Add(new ObjectFiles());
+
                 // 3rd. Create remaining objects in lists (views, user custom actions, ...)
                 if (provisioningInfo.HandlersToProcess.HasFlag(Handlers.Lists)) objectHandlers.Add(new ObjectListInstance(FieldAndListProvisioningStepHelper.Step.ListSettings));
 
@@ -242,7 +244,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                 if (provisioningInfo.HandlersToProcess.HasFlag(Handlers.Fields) || provisioningInfo.HandlersToProcess.HasFlag(Handlers.Lists)) objectHandlers.Add(new ObjectListInstanceDataRows());
                 if (provisioningInfo.HandlersToProcess.HasFlag(Handlers.Workflows)) objectHandlers.Add(new ObjectWorkflows());
-                if (provisioningInfo.HandlersToProcess.HasFlag(Handlers.Files)) objectHandlers.Add(new ObjectFiles());
                 if (provisioningInfo.HandlersToProcess.HasFlag(Handlers.Pages)) objectHandlers.Add(new ObjectPages());
                 if (provisioningInfo.HandlersToProcess.HasFlag(Handlers.PageContents)) objectHandlers.Add(new ObjectPageContents());
 #if !ONPREMISES


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes

#### What's in this Pull Request?

Fix so that list instances created from list definitions (stp) files get's created correct. When a FeatureId is present we need to check the template and set `ListTemplate` instead of `TemplateType`.

Sample template
```xml
<?xml version="1.0"?>
<pnp:Provisioning 
    xmlns:pnp="http://schemas.dev.office.com/PnP/2018/05/ProvisioningSchema">
    <pnp:Preferences Generator="OfficeDevPnP.Core, Version=2.27.1806.0, Culture=neutral, PublicKeyToken=null" />
    <pnp:Templates ID="CONTAINER-TEMPLATE-B417026045BA442685C3AB4351F0BF21">
        <pnp:ProvisioningTemplate ID="TEMPLATE-B417026045BA442685C3AB4351F0BF21" Version="1" BaseSiteTemplate="STS#0" Scope="RootSite">
            <pnp:Lists>
                <pnp:ListInstance Title="PnP" TemplateType="100" Url="Lists/PnP" TemplateFeatureID="00bfea71-de22-43b2-a848-c05709900100"></pnp:ListInstance>
            </pnp:Lists>
        </pnp:ProvisioningTemplate>
    </pnp:Templates>
</pnp:Provisioning>
```