### PR TITLE
Feature - Ability to enable/disable comments, likes and view count on…

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/TenantExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/TenantExtensions.cs
@@ -458,6 +458,8 @@ namespace Microsoft.SharePoint.Client
         /// <param name="userCodeMaximumLevel">A value that represents the maximum allowed resource usage for the site/</param>
         /// <param name="userCodeWarningLevel">A value that determines the level of resource usage at which a warning e-mail message is sent</param>
         /// <param name="noScriptSite">Boolean value which allows to customize the site using scripts</param>
+        /// <param name="commentsOnSitePagesDisabled">Boolean value which Enables/Disables comments on the Site Pages</param>
+        /// <param name="socialBarOnSitePagesDisabled">Boolean value which Enables/Disables likes and view count on the Site Pages</param>
         /// <param name="wait">Id true this function only returns when the tenant properties are set, if false it will return immediately</param>
         /// <param name="timeoutFunction">An optional function that will be called while waiting for the tenant properties to be set. If set will override the wait variable. Return true to cancel the wait loop.</param>
         public static void SetSiteProperties(this Tenant tenant, string siteFullUrl,
@@ -469,6 +471,8 @@ namespace Microsoft.SharePoint.Client
             double? userCodeMaximumLevel = null,
             double? userCodeWarningLevel = null,
             bool? noScriptSite = null,
+            bool? commentsOnSitePagesDisabled = null,
+            bool? socialBarOnSitePagesDisabled = null,
             bool wait = true, Func<TenantOperationMessage, bool> timeoutFunction = null
             )
         {
@@ -493,6 +497,10 @@ namespace Microsoft.SharePoint.Client
                     siteProps.Title = title;
                 if (noScriptSite != null)
                     siteProps.DenyAddAndCustomizePages = (noScriptSite == true ? DenyAddAndCustomizePagesStatus.Enabled : DenyAddAndCustomizePagesStatus.Disabled);
+                if (commentsOnSitePagesDisabled != null)
+                    siteProps.CommentsOnSitePagesDisabled = commentsOnSitePagesDisabled.Value;
+                if (socialBarOnSitePagesDisabled != null)
+                    siteProps.SocialBarOnSitePagesDisabled = socialBarOnSitePagesDisabled.Value;
 
                 var op = siteProps.Update();
                 tenant.Context.Load(op, i => i.IsComplete, i => i.PollingInterval);
@@ -981,9 +989,9 @@ namespace Microsoft.SharePoint.Client
                 }
             }
         }
-#endregion
+        #endregion
 
-#region Site collection deletion
+        #region Site collection deletion
         /// <summary>
         /// Deletes a site collection
         /// </summary>
@@ -994,7 +1002,7 @@ namespace Microsoft.SharePoint.Client
             tenant.RemoveSite(siteFullUrl);
             tenant.Context.ExecuteQueryRetry();
         }
-#endregion
+        #endregion
 #endif
     }
 }


### PR DESCRIPTION
… modern site pages

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no
| Related issues?  | NA

#### What's in this Pull Request?

With this feature, you can enable or disable the comments, likes and view count on the modern site pages library.

Need to make the necessary change in the PnP PowerShell's `Set-PnPTenantSite` command as well.