### PR TITLE
Fixing #1770 issue. Now we are considering Publishing Images field type

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
@@ -285,6 +285,10 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                                                         }
                                                                         break;
                                                                     }
+                                                                default:
+                                                                    //Publishing image case, but can be others too
+                                                                    updateValues.Add(new FieldUpdateValue(dataValue.Key, fieldValue));
+                                                                    break;
                                                             }
                                                             break;
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no 
| Related issues?  | fixes #1770

#### What's in this Pull Request?

This PR proposes a fix to issue #1770 
Now the _ObjectListInstanceDataRows_ Handler considers the case when the Field is a Publishing image field, and sets the value from the template