### PR TITLE
Feature - ability to update content type properties

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/FieldAndContentTypeExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/FieldAndContentTypeExtensions.cs
@@ -1419,6 +1419,119 @@ namespace Microsoft.SharePoint.Client
         }
 
         /// <summary>
+        /// Update existing content type of a web
+        /// </summary>
+        /// <param name="web">Site to be processed - can be root web or sub site</param>
+        /// <param name="name">Name of the content type</param>
+        /// <param name="newContentTypeName">Updated name of the content type</param>
+        /// <param name="description">Description for the content type</param>
+        /// <param name="displayFormUrl">Display form url of the content type</param>
+        /// <param name="newFormUrl">New form url of the content type</param>
+        /// <param name="editFormUrl">Edit form url of the content type</param>     
+        /// <param name="documentTemplate">Document template of the content type</param>
+        /// <param name="hidden">Toggle value indicating whether content type should be hidden or not</param>
+        /// <param name="group">Group for the content type</param>
+        /// <returns>The updated content type</returns>
+        public static ContentType UpdateContentTypeByName(this Web web, string name, string newContentTypeName = "", string description = "", string group = "",
+            string displayFormUrl = "", string newFormUrl = "", string editFormUrl = "", string documentTemplate = "", bool? hidden = null)
+        {
+            var contentType = GetContentTypeByName(web, name);
+
+            if (contentType == null)
+            {
+                Log.Warning(Constants.LOGGING_SOURCE, CoreResources.FieldAndContentTypeExtensions_DeleteContentTypeByName, name);
+            }
+            else
+            {
+                UpdateContentTypeInternal(web, contentType, newContentTypeName, description, group, displayFormUrl, newFormUrl, editFormUrl, documentTemplate, hidden);
+            }
+            return contentType;
+        }
+
+        /// <summary>
+        /// Update existing content type of a web
+        /// </summary>
+        /// <param name="web">Site to be processed - can be root web or sub site</param>
+        /// <param name="Id">Id of the content type</param>
+        /// <param name="newContentTypeName">Updated name of the content type</param>
+        /// <param name="description">Description for the content type</param>
+        /// <param name="group">Group for the content type</param>
+        /// <param name="displayFormUrl">Display form url of the content type</param>
+        /// <param name="newFormUrl">New form url of the content type</param>
+        /// <param name="editFormUrl">Edit form url of the content type</param>     
+        /// <param name="documentTemplate">Document template of the content type</param>
+        /// <param name="hidden">Toggle value indicating whether content type should be hidden or not</param>
+        /// <returns>The updated content type</returns>
+        public static ContentType UpdateContentTypeById(this Web web, string Id, string newContentTypeName = "", string description = "", string group = "",
+            string displayFormUrl = "", string newFormUrl = "", string editFormUrl = "", string documentTemplate = "", bool? hidden = null)
+        {
+            var contentType = GetContentTypeById(web, Id);
+
+            if (contentType == null)
+            {
+                Log.Warning(Constants.LOGGING_SOURCE, CoreResources.FieldAndContentTypeExtensions_DeleteContentTypeByName, Id);
+            }
+            else
+            {
+                UpdateContentTypeInternal(web, contentType, newContentTypeName, description, group, displayFormUrl, newFormUrl, editFormUrl, documentTemplate, hidden);
+            }
+            return contentType;
+        }
+
+        private static ContentType UpdateContentTypeInternal(this Web web, ContentType contentType, string newContentTypeName = "", string description = "", string group = "",
+            string displayFormUrl = "", string newFormUrl = "", string editFormUrl = "", string documentTemplate = "", bool? hidden = null)
+        {
+            bool isDirty = false;
+
+            if (!string.IsNullOrEmpty(newContentTypeName) && !contentType.Name.Equals(newContentTypeName, StringComparison.OrdinalIgnoreCase))
+            {
+                contentType.Name = newContentTypeName;
+                isDirty = true;
+            }
+            if (!string.IsNullOrEmpty(description))
+            {
+                contentType.Description = description;
+                isDirty = true;
+            }
+            if (!string.IsNullOrEmpty(group) && !contentType.Group.Equals(group, StringComparison.OrdinalIgnoreCase))
+            {
+                contentType.Group = group;
+                isDirty = true;
+            }
+            if (!contentType.DisplayFormUrl.Equals(displayFormUrl, StringComparison.OrdinalIgnoreCase))
+            {
+                contentType.DisplayFormUrl = displayFormUrl;
+                isDirty = true;
+            }
+            if (!contentType.NewFormUrl.Equals(newFormUrl, StringComparison.OrdinalIgnoreCase))
+            {
+                contentType.NewFormUrl = newFormUrl;
+                isDirty = true;
+            }
+            if (!contentType.EditFormUrl.Equals(editFormUrl, StringComparison.OrdinalIgnoreCase))
+            {
+                contentType.EditFormUrl = editFormUrl;
+                isDirty = true;
+            }
+            if (!string.IsNullOrEmpty(documentTemplate) && !contentType.DocumentTemplate.Equals(documentTemplate, StringComparison.OrdinalIgnoreCase))
+            {
+                contentType.DocumentTemplate = documentTemplate;
+                isDirty = true;
+            }
+            if (hidden.HasValue)
+            {
+                contentType.Hidden = hidden.Value;
+                isDirty = true;
+            }
+            if (isDirty)
+            {
+                contentType.Update(true);
+                web.Context.ExecuteQueryRetry();
+            }
+            return contentType;
+        }
+
+        /// <summary>
         /// Deletes a content type from the web by name
         /// </summary>
         /// <param name="web">Web to delete the content type from</param>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no
| Related issues?  | mentioned in https://github.com/SharePoint/PnP-PowerShell/issues/1504

#### What's in this Pull Request?

Using this extension method, you can update the content type properties like description, group, form urls, etc
The associated PnP PowerShell command will be `Set-PnPContentType` which needs to be added.