### PR TITLE
ExtractClientSidePage fixes

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/CanvasControl.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/CanvasControl.cs
@@ -17,7 +17,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model
         /// <summary>
         /// Defines the custom properties for the client-side web part control.
         /// </summary>
-        public Dictionary<String, String> ControlProperties { get; set; }
+        public Dictionary<String, String> ControlProperties { get; set; } = new Dictionary<string, string>();
 
         /// <summary>
         /// Defines the Type of Client-side Web Part.

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Utilities/ClientSidePageContentsHelper.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Utilities/ClientSidePageContentsHelper.cs
@@ -52,6 +52,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
                         Publish = true,
                         Layout = pageToExtract.LayoutType.ToString(),
                         EnableComments = !pageToExtract.CommentsDisabled,
+                        Title = pageToExtract.PageTitle
                     };
 
                     if(pageToExtract.PageHeader != null)
@@ -106,7 +107,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
                         {
                             foreach (var control in column.Controls)
                             {
-                                // Create control 
+                                // Create control
                                 CanvasControl controlInstance = new CanvasControl()
                                 {
                                     Column = column.Order,
@@ -127,7 +128,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
                                 }
                                 else
                                 {
-                                    // set ControlId to webpart id 
+                                    // set ControlId to webpart id
                                     controlInstance.ControlId = Guid.Parse((control as Pages.ClientSideWebPart).WebPartId);
                                     var webPartType = Pages.ClientSidePage.NameToClientSideWebPartEnum((control as Pages.ClientSideWebPart).WebPartId);
                                     switch (webPartType)
@@ -366,7 +367,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
                     {
                         if (template.WebSettings == null)
                         {
-                            template.WebSettings = new WebSettings();                            
+                            template.WebSettings = new WebSettings();
                         }
 
                         if (pageUrl.StartsWith(web.ServerRelativeUrl, StringComparison.InvariantCultureIgnoreCase))
@@ -376,7 +377,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
                         else
                         {
                             template.WebSettings.WelcomePage = pageUrl;
-                        }                        
+                        }
                     }
                 }
             }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |  yes
| New feature?    | no
| New sample?      | no
| Related issues?  | NA

#### What's in this Pull Request?

- Set Title when extracting ClientSidePage
When a ClientSidePage is extracted using ClientSidePageContentsHelper.ExtractClientSidePage the Title is not set on the extracted ClientSidePage model.
- Fix NullReference exception when applying extracted Client Side Page
If CanvasControl.ControlProperties is null, provisioning of an extracted Client Side Page will fail.
