### PR TITLE
Fixed ClientSidePageHeaderType enum inconsistency

### DIFF
--- a/Core/OfficeDevPnP.Core/Pages/ClientSidePageHeaderType.cs
+++ b/Core/OfficeDevPnP.Core/Pages/ClientSidePageHeaderType.cs
@@ -7,13 +7,13 @@
     public enum ClientSidePageHeaderType
     {
         /// <summary>
-        /// The page uses the default page header
-        /// </summary>
-        Default = 0,
-        /// <summary>
         /// The page does not have a header
         /// </summary>
-        None = 1,
+        None = 0,
+        /// <summary>
+        /// The page uses the default page header
+        /// </summary>
+        Default = 1,
         /// <summary>
         /// The page use a customized header (e.g. with image + offset)
         /// </summary>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | NA

#### What's in this Pull Request?
The Enum OfficeDevPnP.Core.Framework.Provisioning.Model.ClientSidePageHeaderType is not consistent with OfficeDevPnP.Core.Pages.ClientSidePageHeaderType

This means that when extracting a ClientSidePage and applying it again the HeaderType is changed.
Eg.
Default is changed to None
None is changed to Default

I've modified Pages.ClientSidePageHeaderType
from
```
    public enum ClientSidePageHeaderType
    {
        Default = 0,
        None = 1,
        Custom = 2
    }
```
to
```
    public enum ClientSidePageHeaderType
    {
        None = 0,
        Default = 1,
        Custom = 2
    }
```