### PR TITLE
Fix - template failure for non-existing links in quick launch or top nav

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectNavigation.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectNavigation.cs
@@ -331,12 +331,53 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         {
             foreach (var node in nodes)
             {
-                var navNode = web.AddNavigationNode(
-                    parser.ParseString(node.Title),
-                    new Uri(parser.ParseString(node.Url), UriKind.RelativeOrAbsolute),
-                    parser.ParseString(parentNodeTitle),
-                    navigationType,
-                    node.IsExternal);
+                try
+                {
+                    var navNode = web.AddNavigationNode(
+                        parser.ParseString(node.Title),
+                        new Uri(parser.ParseString(node.Url), UriKind.RelativeOrAbsolute),
+                        parser.ParseString(parentNodeTitle),
+                        navigationType,
+                        node.IsExternal
+                        );
+
+#if !SP2013
+                    if (node.Title.ContainsResourceToken())
+                    {
+                        navNode.LocalizeNavigationNode(web, node.Title, parser, scope);
+                    }
+#endif
+                }
+                catch (ServerException ex)
+                {
+                    // If the SharePoint link doesn't exist, provision it as external link
+                    // when we provision as external link, the server side URL validation won't kick-in
+                    // This handles the "no such file or url found" error
+
+                    WriteMessage($"Provisioning of the navigation node failed, retrying for : {node.Title}", ProvisioningMessageType.Warning);
+
+                    if (ex.ServerErrorCode == -2130247147)
+                    {
+                        try
+                        {
+                            var navNode = web.AddNavigationNode(
+                                parser.ParseString(node.Title),
+                                new Uri(parser.ParseString(node.Url), UriKind.RelativeOrAbsolute),
+                                parser.ParseString(parentNodeTitle),
+                                navigationType,
+                                true
+                                );
+                        }
+                        catch (Exception innerEx)
+                        {
+                            WriteMessage($"Provisioning of the navigation node failed : {innerEx.Message}", ProvisioningMessageType.Warning);
+                        }
+                    }
+                    else
+                    {
+                        WriteMessage($"Provisioning of the navigation node failed : {ex.Message}", ProvisioningMessageType.Warning);
+                    }
+                }
 
                 ProvisionStructuralNavigationNodes(
                     web,
@@ -345,13 +386,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     node.NavigationNodes,
                     scope,
                     parser.ParseString(node.Title));
-
-#if !SP2013
-                if (node.Title.ContainsResourceToken())
-                {
-                    navNode.LocalizeNavigationNode(web, node.Title, parser, scope);
-                }
-#endif
             }
         }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |  yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #985 

#### What's in this Pull Request?

The PnP provisioning template fails whenever we add a SharePoint url which is non-existent.
The trick here is to provision it as external url which will bypass the server-side validation.
This is also how,  i believe , SharePoint internally works because whenever we add SP relative url which is non-existent it is allowed via the UI.
This fixes a long pending issue which is present even in the latest PnP code.

To repro it, you can use the below minimal template:

```
<?xml version="1.0"?>
<pnp:Provisioning xmlns:pnp="http://schemas.dev.office.com/PnP/2018/05/ProvisioningSchema">
  <pnp:Preferences Generator="OfficeDevPnP.Core, Version=2.26.1805.0, Culture=neutral, PublicKeyToken=null" />
  <pnp:Templates ID="CONTAINER-TEMPLATE-E8282013242746E786EE010B45FE32EF">
    <pnp:ProvisioningTemplate ID="TEMPLATE-E8282013242746E786EE010B45FE32EF" Version="1" BaseSiteTemplate="STS#0" Scope="Web">
      <pnp:Navigation AddNewPagesToNavigation="true" CreateFriendlyUrlsForNewPages="true">
        <pnp:GlobalNavigation NavigationType="Structural">
          <pnp:StructuralNavigation RemoveExistingNodes="false">
            <pnp:NavigationNode Title="Home" Url="{site}" />
          </pnp:StructuralNavigation>
        </pnp:GlobalNavigation>
        <pnp:CurrentNavigation NavigationType="StructuralLocal">
          <pnp:StructuralNavigation RemoveExistingNodes="true">
            <pnp:NavigationNode Title="Home" Url="{site}" />            
            <pnp:NavigationNode Title="News" Url="{site}/_layouts/15/News.aspx" IsExternal="true" />
            <pnp:NavigationNode Title="Documents" Url="{site}/Shared Documents/Forms/AllItems.aspx" />
            <pnp:NavigationNode Title="Client site 4" Url="{site}/abcdefgh" />            
	 </pnp:StructuralNavigation>
        </pnp:CurrentNavigation>
      </pnp:Navigation>
    </pnp:ProvisioningTemplate>
  </pnp:Templates>
</pnp:Provisioning>
```