### PR TITLE
Enables Web.RequestAccessEmail for OnPrem (both 15.0 and 16.0)

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/Framework/Functional/Validators/WebSettingsValidator.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/Functional/Validators/WebSettingsValidator.cs
@@ -78,11 +78,9 @@ namespace OfficeDevPnP.Core.Tests.Framework.Functional.Validators
             }
 
 #if ONPREMISES
-            // we don't support NoCrawl and RequestAccessEmail in on-premises so drop them from source and target
+            // we don't support NoCrawl in on-premises so drop them from source and target
             DropAttribute(sourceObject, "NoCrawl");
             DropAttribute(targetObject, "NoCrawl");
-            DropAttribute(sourceObject, "RequestAccessEmail");
-            DropAttribute(targetObject, "RequestAccessEmail");
 #endif
 
             if (isNoScriptSite)

--- a/Core/OfficeDevPnP.Core/Extensions/WebExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/WebExtensions.cs
@@ -1229,7 +1229,6 @@ namespace Microsoft.SharePoint.Client
         #endregion
 
         #region Request Access
-#if !ONPREMISES
         /// <summary>
         /// Disables the request access on the web.
         /// </summary>
@@ -1309,7 +1308,6 @@ namespace Microsoft.SharePoint.Client
 
             return emails;
         }
-#endif
         #endregion
 
         /// <summary>

--- a/Core/OfficeDevPnP.Core/Extensions/WebExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/WebExtensions.cs
@@ -1229,6 +1229,7 @@ namespace Microsoft.SharePoint.Client
         #endregion
 
         #region Request Access
+#if !ONPREMISES
         /// <summary>
         /// Disables the request access on the web.
         /// </summary>
@@ -1308,6 +1309,7 @@ namespace Microsoft.SharePoint.Client
 
             return emails;
         }
+#endif
         #endregion
 
         /// <summary>

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectWebSettings.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectWebSettings.cs
@@ -29,7 +29,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 web.EnsureProperties(
 #if !ONPREMISES
                     w => w.NoCrawl,
-                    w => w.RequestAccessEmail,
                     w => w.CommentsOnSitePagesDisabled,
 #endif
                     //w => w.Title,
@@ -37,6 +36,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     w => w.MasterUrl,
                     w => w.CustomMasterUrl,
                     w => w.SiteLogoUrl,
+                    w => w.RequestAccessEmail,
                     w => w.RootFolder,
                     w => w.AlternateCssUrl,
                     w => w.ServerRelativeUrl,
@@ -45,7 +45,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 var webSettings = new WebSettings();
 #if !ONPREMISES
                 webSettings.NoCrawl = web.NoCrawl;
-                webSettings.RequestAccessEmail = web.RequestAccessEmail;
                 webSettings.CommentsOnSitePagesDisabled = web.CommentsOnSitePagesDisabled;
 #endif
                 // We're not extracting Title and Description
@@ -57,6 +56,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 // Notice. No tokenization needed for the welcome page, it's always relative for the site
                 webSettings.WelcomePage = web.RootFolder.WelcomePage;
                 webSettings.AlternateCSS = Tokenize(web.AlternateCssUrl, web.Url);
+                webSettings.RequestAccessEmail = web.RequestAccessEmail;
 
                 if (creationInfo.PersistBrandingFiles)
                 {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no
| Related issues?  | fixes #1793 

#### What's in this Pull Request?
Moved or removed from provisioning engine, and WebExtensions classes the lines where _RequestAccessEmail_ was inside pre-processor directives '#if ONPREMISES' , as it is now supported by CSOM for either SP2013 and SP2016


Massimo