### PR TITLE
Allow us to describe metadata for some, but not all files in a directory

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
@@ -558,7 +558,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                 directory.Folder,
                                 directory.Overwrite,
                                 null, // No WebPartPages are supported with this technique
-                                metadataProperties != null ? metadataProperties[directory.Src + @"\" + file] : null,
+                                metadataProperties != null && metadataProperties.ContainsKey(directory.Src + @"\" + file) ? 
+                                    metadataProperties[directory.Src + @"\" + file] : null,
                                 directory.Security,
                                 directory.Level
                                 ));


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no 
| Related issues?  | n/a

#### What's in this Pull Request?

If we use a directory element in combination with MetadataMappingFile we currently have to create metadata mappings for _all_ files in the directory. This removes most of the benefit of using the Directory element. This fix allows us to specify metadata for some files, but any file in the directory will be uploaded to the target library regardless

cc: @wobba 
