### PR TITLE
Fix #1810 ContentTypeBinding with lowercase ContentTypeID no longer w…

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/FieldAndContentTypeExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/FieldAndContentTypeExtensions.cs
@@ -1573,7 +1573,7 @@ namespace Microsoft.SharePoint.Client
             var ctx = contentTypes.Context;
             contentTypes.EnsureProperties(c => c.Include(ct => ct.Id));
 
-            var res = contentTypes.Where(c => c.Id.StringValue.StartsWith(contentTypeId)).OrderBy(c => c.Id.StringValue.Length).FirstOrDefault();
+            var res = contentTypes.Where(c => c.Id.StringValue.ToUpper().StartsWith(contentTypeId.ToUpper())).OrderBy(c => c.Id.StringValue.Length).FirstOrDefault();
             if (res != null)
             {
                 return res.Id;


### PR DESCRIPTION

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #1810 

#### What's in this Pull Request?

Added ToUpper so the Content Type IDs can be matched no matter of the case
