### PR TITLE
Stability improvements for updates to RoleDefinition update

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
@@ -281,15 +281,25 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                     isDirty = true;
                                 }
                                 var templateBasePermissions = new BasePermissions();
+
+                                // iterate over all possible PermissionKind values and set them on the new object
+                                foreach (PermissionKind pk in Enum.GetValues(typeof(PermissionKind)))
+                                {
+                                    if (siteRoleDefinition.BasePermissions.Has(pk))
+                                    {
+                                        templateBasePermissions.Set(pk);
+                                    }
+                                }
+
+                                // add the permissions that were specified in the template
                                 templateRoleDefinition.Permissions.ForEach(p => templateBasePermissions.Set(p));
+
                                 if (siteRoleDefinition.BasePermissions != templateBasePermissions)
                                 {
                                     isDirty = true;
-                                    foreach (var permission in templateRoleDefinition.Permissions)
-                                    {
-                                        siteRoleDefinition.BasePermissions.Set(permission);
-                                    }
+                                    siteRoleDefinition.BasePermissions = templateBasePermissions;
                                 }
+
                                 if (isDirty)
                                 {
                                     scope.LogDebug("Updating role definition {0}", parsedRoleDefinitionName);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes

#### What's in this Pull Request?

I encountered a strange behaviour with SharePoint 2013 that updates to BasePermissions did not work. The solution is to create a new BasePermission object, assign it to the RoleDefinition and update.

Additionally I made a small optimization: the IsDirty check now considers existing permissions as well as the permissions in the template.
