### PR TITLE
Fix - Skip calling of Tenant and ALM handlers when not needed , null check in 

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectApplicationLifecycleManagement.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectApplicationLifecycleManagement.cs
@@ -28,7 +28,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                 // Process the collection of Apps installed in the current Site Collection
                 var appCatalogUri = web.GetAppCatalog();
-                if(appCatalogUri != null)
+                if (appCatalogUri != null)
                 {
                     var manager = new AppManager(web.Context as ClientContext);
 
@@ -44,7 +44,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                             });
                         }
                     }
-                }                
+                }
             }
             return template;
         }
@@ -115,7 +115,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         else
                         {
                             WriteMessage($"Tenant app catalog doesn't exist. ALM step will be skipped.", ProvisioningMessageType.Warning);
-                        }                        
+                        }
                     }
                 }
             }
@@ -130,7 +130,13 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
         public override bool WillProvision(Web web, ProvisioningTemplate template, ProvisioningTemplateApplyingInformation applyingInformation)
         {
-            return (!web.IsSubSite() && template.ApplicationLifecycleManagement != null);
+            if (!_willProvision.HasValue && template.ApplicationLifecycleManagement != null)
+            {
+                _willProvision = (template.ApplicationLifecycleManagement.AppCatalog != null ||
+                                  template.ApplicationLifecycleManagement.Apps.Count > 0
+                                 );
+            }
+            return (!web.IsSubSite() && _willProvision.Value);
         }
     }
 #endif

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTenant.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTenant.cs
@@ -54,7 +54,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         {
             if (template.Tenant.AppCatalog != null && template.Tenant.AppCatalog.Packages.Count > 0)
             {
-                
+
                 var manager = new AppManager(web.Context as ClientContext);
 
                 var appCatalogUri = web.GetAppCatalog();
@@ -123,18 +123,25 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             if (template.Tenant.StorageEntities != null && template.Tenant.StorageEntities.Any())
             {
                 var appCatalogUri = web.GetAppCatalog();
-                using (var appCatalogContext = web.Context.Clone(appCatalogUri))
+                if (appCatalogUri != null)
                 {
-                    foreach (var entity in template.Tenant.StorageEntities)
+                    using (var appCatalogContext = web.Context.Clone(appCatalogUri))
                     {
-                        var key = parser.ParseString(entity.Key);
-                        var value = parser.ParseString(entity.Value);
-                        var description = parser.ParseString(entity.Description);
-                        var comment = parser.ParseString(entity.Comment);
-                        appCatalogContext.Web.SetStorageEntity(key, value, description, comment);
+                        foreach (var entity in template.Tenant.StorageEntities)
+                        {
+                            var key = parser.ParseString(entity.Key);
+                            var value = parser.ParseString(entity.Value);
+                            var description = parser.ParseString(entity.Description);
+                            var comment = parser.ParseString(entity.Comment);
+                            appCatalogContext.Web.SetStorageEntity(key, value, description, comment);
+                        }
+                        appCatalogContext.Web.Update();
+                        appCatalogContext.ExecuteQueryRetry();
                     }
-                    appCatalogContext.Web.Update();
-                    appCatalogContext.ExecuteQueryRetry();
+                }
+                else
+                {
+                    WriteMessage($"Tenant app catalog doesn't exist. Provisioning of storage entities will be skipped!", ProvisioningMessageType.Warning);
                 }
             }
             return parser;
@@ -228,7 +235,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                 PreviewImageAltText = designPreviewImageAltText,
                                 IsDefault = siteDesign.IsDefault,
                             };
-                            switch((int)siteDesign.WebTemplate)
+                            switch ((int)siteDesign.WebTemplate)
                             {
                                 case 0:
                                     {
@@ -537,7 +544,17 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
         public override bool WillProvision(Web web, ProvisioningTemplate template, ProvisioningTemplateApplyingInformation applyingInformation)
         {
-            return (template.Tenant != null);
+            if (!_willProvision.HasValue && template.Tenant != null)
+            {
+                _willProvision = (template.Tenant.AppCatalog != null ||
+                                template.Tenant.ContentDeliveryNetwork != null ||
+                                template.Tenant.SiteDesigns.Count > 0 ||
+                                template.Tenant.SiteScripts.Count > 0 ||
+                                template.Tenant.StorageEntities.Count > 0 ||
+                                template.Tenant.WebApiPermissions.Count > 0
+                                );
+            }
+            return (_willProvision.Value);
         }
     }
 


### PR DESCRIPTION
…storage entities processing

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes NA

#### What's in this Pull Request?

1) Currently for SPO, in case of simple provisioning template like the one mentioned below, we are calling the Tenant as well as ALM handlers. It is not needed. This PR will fix it by doing a more robust checking of the schema elements

```
<?xml version="1.0"?>
<pnp:Provisioning xmlns:pnp="http://schemas.dev.office.com/PnP/2018/05/ProvisioningSchema">
  <pnp:Preferences Generator="OfficeDevPnP.Core, Version=2.26.1805.1, Culture=neutral, PublicKeyToken=5e633289e95c321a" />
  <pnp:Templates ID="CONTAINER-TEMPLATE-0F3B0BF2CA31408CB750A266BC6A2CAB">
    <pnp:ProvisioningTemplate ID="TEMPLATE-0F3B0BF2CA31408CB750A266BC6A2CAB" Version="1" BaseSiteTemplate="STS#0" Scope="Web">
      <pnp:ClientSidePages>
        <pnp:ClientSidePage PageName="Test.aspx" PromoteAsNewsArticle="false" Overwrite="true">
        </pnp:ClientSidePage>
	  </pnp:ClientSidePages>
    </pnp:ProvisioningTemplate>
  </pnp:Templates>
</pnp:Provisioning>
```

2) This PR also adds an additional null check during the provisioning of storage entities to check whether the tenant app catalog exists or not. If it doesn't exist, then the step will be skipped. Currently, the provisioning template will fail in this scenario stopping the template provisioning completely.