### PR TITLE
Optimize provisioning speed of fields and content types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 
 ### Changed
+- Refactored token parsing for PnP template handling for performance
 
 ### Deprecated
+- Marked regex functions in TokenDefinition as obsolete, as they are not needed
 
 ## [3.0.1808.0 - August 2018 release]
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/FieldAndListProvisioningStepHelper.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/FieldAndListProvisioningStepHelper.cs
@@ -7,7 +7,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
     {
         internal static Step GetFieldProvisioningStep(this Field templateField, TokenParser parser)
         {
-            var schemaElement = XElement.Parse(parser.ParseString(templateField.SchemaXml));
+            var schemaElement = XElement.Parse(templateField.SchemaXml);
             var type = (string)schemaElement.Attribute("Type");
             if (type != "Lookup" && type != "LookupMulti")
             {

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/FieldAndListProvisioningStepHelper.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/FieldAndListProvisioningStepHelper.cs
@@ -1,22 +1,49 @@
-﻿using System.Xml.Linq;
+﻿using System;
+using System.Collections.Generic;
+using System.Xml.Linq;
 using Field = OfficeDevPnP.Core.Framework.Provisioning.Model.Field;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 {
     public static class FieldAndListProvisioningStepHelper
     {
+        static readonly Dictionary<Field,XElement> _fieldXmlDictionary = new Dictionary<Field, XElement>();
         internal static Step GetFieldProvisioningStep(this Field templateField, TokenParser parser)
         {
-            var schemaElement = XElement.Parse(templateField.SchemaXml);
+            XElement schemaElement;
+            if (!_fieldXmlDictionary.TryGetValue(templateField, out schemaElement)) {
+                schemaElement = XElement.Parse(parser.ParseString(templateField.SchemaXml));
+                _fieldXmlDictionary[templateField] = schemaElement;
+            }
             var type = (string)schemaElement.Attribute("Type");
             if (type != "Lookup" && type != "LookupMulti")
             {
                 return Step.ListAndStandardFields;
             }
-            else
+            return Step.LookupFields;
+        }
+
+        internal static Guid GetFieldId(this Field templateField, TokenParser parser)
+        {
+            XElement schemaElement;
+            if (!_fieldXmlDictionary.TryGetValue(templateField, out schemaElement))
             {
-                return Step.LookupFields;
+                schemaElement = XElement.Parse(parser.ParseString(templateField.SchemaXml));
+                _fieldXmlDictionary[templateField] = schemaElement;
             }
+            var id = (Guid)schemaElement.Attribute("ID");
+            return id;
+        }
+
+        internal static XElement GetSchemaXml(this Field templateField, TokenParser parser, params string[] tokensToSkip)
+        {
+            XElement schemaElement;
+            if (!_fieldXmlDictionary.TryGetValue(templateField, out schemaElement))
+            {
+                schemaElement = XElement.Parse(parser.ParseString(templateField.SchemaXml, tokensToSkip));
+                _fieldXmlDictionary[templateField] = schemaElement;
+            }
+            return schemaElement;
         }
 
         public enum Step

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
@@ -333,15 +333,10 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
             var createdCT = web.CreateContentType(name, description, id, group);
 
-            foreach (Field siteField in template.SiteFields)
-            {
-                siteField.SchemaXml = parser.ParseString(siteField.SchemaXml);
-            }
-
             List<FieldRef> fieldsRefsToProcess = new List<FieldRef>();
             foreach (FieldRef fr in templateContentType.FieldRefs)
             {
-                var templateField = template.SiteFields.FirstOrDefault(tf => (Guid)XElement.Parse(tf.SchemaXml).Attribute("ID") == fr.Id);
+                var templateField = template.SiteFields.FirstOrDefault(tf => tf.GetFieldId(parser) == fr.Id);
                 if (templateField == null || templateField.GetFieldProvisioningStep(parser) == _step)
                 {
                     fieldsRefsToProcess.Add(fr);
@@ -669,18 +664,18 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         newCT.DocumentSetTemplate = new DocumentSetTemplate(
                             null, // TODO: WelcomePage not yet supported
                             (from allowedCT in documentSetTemplate.AllowedContentTypes.AsEnumerable()
-                             select allowedCT.StringValue).ToArray(),
+                             select allowedCT.StringValue).ToList(),
                             (from defaultDocument in documentSetTemplate.DefaultDocuments.AsEnumerable()
                              select new DefaultDocument
                              {
                                  ContentTypeId = defaultDocument.ContentTypeId.StringValue,
                                  Name = defaultDocument.Name,
                                  FileSourcePath = String.Empty, // TODO: How can we extract the proper file?!
-                             }).ToArray(),
+                             }).ToList(),
                             (from sharedField in documentSetTemplate.SharedFields.AsEnumerable()
-                             select sharedField.Id).ToArray(),
+                             select sharedField.Id).ToList(),
                             (from welcomePageField in documentSetTemplate.WelcomePageFields.AsEnumerable()
-                             select welcomePageField.Id).ToArray()
+                             select welcomePageField.Id).ToList()
                         );
                     }
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
@@ -34,6 +34,21 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             this._step = step;
         }
 
+        public class DuplicateKeyComparer<TKey>
+            :
+                IComparer<TKey> where TKey : IComparable
+        {
+            #region IComparer<TKey> Members
+
+            public int Compare(TKey x, TKey y)
+            {
+                int result = x.CompareTo(y);
+                return result == 0 ? -1 : result;
+            }
+
+            #endregion
+        }
+
         public override TokenParser ProvisionObjects(Web web, ProvisioningTemplate template, TokenParser parser, ProvisioningTemplateApplyingInformation applyingInformation)
         {
             using (var scope = new PnPMonitoredScope(this.Name))
@@ -52,27 +67,28 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 web.Context.ExecuteQueryRetry();
                 var existingFieldIds = existingFields.AsEnumerable<SPField>().Select(l => l.Id).ToList();
 
-                var fields = template.SiteFields
-                    .Select(fld => new
+                SortedList<string,Field> fieldDict = new SortedList<string, Field>(new DuplicateKeyComparer<string>());
+                foreach (Field siteField in template.SiteFields)
+                {                    
+                    var step = siteField.GetFieldProvisioningStep(parser);
+
+                    if (step == _step)
                     {
-                        Field = fld,
-                        FieldRef = (string)XElement.Parse(parser.ParseString(fld.SchemaXml, "~sitecollection", "~site")).Attribute("FieldRef"),
-                        Step = fld.GetFieldProvisioningStep(parser)
-                    })
-                    .Where(fldData => fldData.Step == _step) // Only include fields related to the current step
-                    .OrderBy(fldData => fldData.FieldRef) // Ensure fields having fieldRef are handled after. This ensure lookups are created before dependent lookups
-                    .Select(fldData => fldData.Field)
-                    .ToArray();
+                        var fieldRef = (string)XElement.Parse(parser.ParseString(siteField.SchemaXml, "~sitecollection", "~site")).Attribute("FieldRef") + "";
+                        fieldDict.Add(fieldRef,siteField);
+                    }
+                }
+
+                var fields = fieldDict.Values.ToList();
 
                 var currentFieldIndex = 0;
                 foreach (var field in fields)
                 {
                     currentFieldIndex++;
-
                     var fieldSchemaElement = XElement.Parse(parser.ParseString(field.SchemaXml, "~sitecollection", "~site"));
                     var fieldId = fieldSchemaElement.Attribute("ID").Value;
                     var fieldInternalName = (string)fieldSchemaElement.Attribute("InternalName") != null ? (string)fieldSchemaElement.Attribute("InternalName") : "";
-                    WriteMessage($"Field|{(!string.IsNullOrWhiteSpace(fieldInternalName) ? fieldInternalName : fieldId)}|{currentFieldIndex}|{fields.Length}", ProvisioningMessageType.Progress);
+                    WriteMessage($"Field|{(!string.IsNullOrWhiteSpace(fieldInternalName) ? fieldInternalName : fieldId)}|{currentFieldIndex}|{fields.Count}", ProvisioningMessageType.Progress);
                     if (!existingFieldIds.Contains(Guid.Parse(fieldId)))
                     {
                         try

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/TokenDefinition.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/TokenDefinition.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.SharePoint.Client;
@@ -13,7 +14,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitio
         private ClientContext _context;
         protected string CacheValue;
         private readonly string[] _tokens;
-        private static readonly Dictionary<string, Regex> _tokeRegexes = new Dictionary<string, Regex>(1500);
 
         /// <summary>
         /// Constructor
@@ -60,16 +60,13 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitio
         /// Gets array of regular expressions
         /// </summary>
         /// <returns>Returns all Regular Expressions</returns>
+        [Obsolete]
         public Regex[] GetRegex()
         {
-            if (_tokeRegexes.Count == this._tokens.Length) return _tokeRegexes.Values.ToArray();
-
-            _tokeRegexes.Clear();
             var regexs = new Regex[this._tokens.Length];
             for (var q = 0; q < this._tokens.Length; q++)
             {
                 regexs[q] = new Regex(this._tokens[q], RegexOptions.IgnoreCase | RegexOptions.Compiled);
-                _tokeRegexes.Add(this._tokens[q], regexs[q]);
             }
             return regexs;
         }
@@ -79,14 +76,10 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitio
         /// </summary>
         /// <param name="token">token string</param>
         /// <returns>Returns RegularExpression</returns>
+        [Obsolete]
         public Regex GetRegexForToken(string token)
         {
-            if (!_tokeRegexes.TryGetValue(token, out var regEx))
-            {
-                regEx = new Regex(token, RegexOptions.IgnoreCase | RegexOptions.Compiled);
-                _tokeRegexes[token] = regEx;
-            }
-            return regEx;
+            return new Regex(token, RegexOptions.IgnoreCase);
         }
 
         /// <summary>

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/TokenDefinition.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/TokenDefinition.cs
@@ -60,13 +60,13 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitio
         /// Gets array of regular expressions
         /// </summary>
         /// <returns>Returns all Regular Expressions</returns>
-        [Obsolete]
+        [Obsolete("No longer in use")]
         public Regex[] GetRegex()
         {
             var regexs = new Regex[this._tokens.Length];
             for (var q = 0; q < this._tokens.Length; q++)
             {
-                regexs[q] = new Regex(this._tokens[q], RegexOptions.IgnoreCase | RegexOptions.Compiled);
+                regexs[q] = new Regex(this._tokens[q], RegexOptions.IgnoreCase);
             }
             return regexs;
         }
@@ -76,7 +76,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitio
         /// </summary>
         /// <param name="token">token string</param>
         /// <returns>Returns RegularExpression</returns>
-        [Obsolete]
+        [Obsolete("No longer in use")]
         public Regex GetRegexForToken(string token)
         {
             return new Regex(token, RegexOptions.IgnoreCase);

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
@@ -544,7 +544,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 foreach (string token in tokenDefinition.GetTokens())
                 {
                     if (TokenDictionary.ContainsKey(token)) continue;
-                    if (tokensToSkip != null && tokensToSkip.Contains(token, StringComparer.OrdinalIgnoreCase)) continue;
                     string value = tokenDefinition.GetReplaceValue();
                     TokenDictionary[Regex.Unescape(token)] = value;
                 }
@@ -600,7 +599,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 foreach (string token in tokenDefinition.GetTokens())
                 {
                     if (TokenDictionary.ContainsKey(token)) continue;
-                    if (tokensToSkip != null && tokensToSkip.Contains(token, StringComparer.OrdinalIgnoreCase)) continue;
                     string value = tokenDefinition.GetReplaceValue();
                     TokenDictionary[Regex.Unescape(token)] = value;
                 }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
@@ -7,7 +7,6 @@ using OfficeDevPnP.Core.Framework.Provisioning.Model;
 using OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitions;
 using System.Resources;
 using System.Collections;
-using System.Diagnostics;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using OfficeDevPnP.Core.ALM;
@@ -25,7 +24,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         public Web _web;
 
         private List<TokenDefinition> _tokens;
-        private List<Localization> _localizations = new List<Localization>();
 
         /// <summary>
         /// List of token definitions
@@ -123,7 +121,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             if (web.IsSubSite())
             {
                 // SiteColumns from rootsite
-                var rootWeb = (web.Context as ClientContext).Site.RootWeb;
+                var rootWeb = ((ClientContext)web.Context).Site.RootWeb;
                 var siteColumns = rootWeb.Fields;
                 web.Context.Load(siteColumns, flds => flds.Include(f => f.Title, f => f.InternalName));
                 web.Context.ExecuteQueryRetry();
@@ -328,14 +326,14 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     siteEntities = ParseStorageEntitiesString(storageEntitiesIndex);
                 }
                 var combinedEntities = siteEntities.Concat(tenantEntities).GroupBy(x => x.Key).Select(x => x.First());
-        
-                foreach(var entity in combinedEntities)
+
+                foreach (var entity in combinedEntities)
                 {
                     _tokens.Add(new StorageEntityValueToken(web, entity.Key, entity.Value));
                 }
             }
             catch { }
-        } 
+        }
 
         private List<StorageEntity> ParseStorageEntitiesString(string storageEntitiesIndex)
         {
@@ -505,6 +503,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             return ParseString(input, null);
         }
 
+
+        static readonly Regex ReGuid = new Regex("(?<guid>\\{\\S{8}-\\S{4}-\\S{4}-\\S{4}-\\S{12}?\\})", RegexOptions.Compiled);
         /// <summary>
         /// Gets left over tokens
         /// </summary>
@@ -513,7 +513,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         public IEnumerable<string> GetLeftOverTokens(string input)
         {
             List<string> values = new List<string>();
-            var matches = Regex.Matches(input, "(?<guid>\\{\\S{8}-\\S{4}-\\S{4}-\\S{4}-\\S{12}?\\})").OfType<Match>().Select(m => m.Value);
+            var matches = ReGuid.Matches(input).OfType<Match>().Select(m => m.Value);
             foreach (var match in matches)
             {
                 Guid gout;
@@ -539,31 +539,48 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             var tokenChars = new[] { '{', '~' };
             if (string.IsNullOrEmpty(input) || input.IndexOfAny(tokenChars) == -1) return input;
 
-            var tokensToSkipList = tokensToSkip?.ToList() ?? new List<string>();
-            string origInput;
+            foreach (TokenDefinition tokenDefinition in _tokens)
+            {
+                foreach (string token in tokenDefinition.GetTokens())
+                {
+                    if (TokenDictionary.ContainsKey(token)) continue;
+                    if (tokensToSkip != null && tokensToSkip.Contains(token, StringComparer.OrdinalIgnoreCase)) continue;
+                    string value = tokenDefinition.GetReplaceValue();
+                    TokenDictionary[Regex.Unescape(token)] = value;
+                }
+            }
 
+            string output = input;
+            bool hasMatch = false;
             do
             {
-                origInput = input;
-
-                foreach (var token in _tokens)
+                hasMatch = false;
+                output = ReToken.Replace(output, match =>
                 {
-                    foreach (var filteredToken in token.GetTokens().Except(tokensToSkipList, StringComparer.InvariantCultureIgnoreCase))
+                    string tokenString = match.Groups[1].Value;
+                    if (TokenDictionary.TryGetValue(tokenString, out string val))
                     {
-                        var regex = token.GetRegexForToken(filteredToken);
-                        if (regex.IsMatch(input))
+                        if (tokenString.IndexOf("listid", StringComparison.OrdinalIgnoreCase) != -1)
                         {
-                            if (token is ListIdToken && !token.Web.Id.Equals(web.Id))
-                                continue;
-
-                            input = regex.Replace(input, ParseString(token.GetReplaceValue(), tokensToSkipList.Concat(new[] { filteredToken }).ToArray()));
+                            var token = _tokens.Single(t => t.GetTokens().Contains(tokenString));
+                            if (!token.Web.Id.Equals(web.Id))
+                            {
+                                return tokenString;
+                            }
                         }
+                        hasMatch = true;
+                        return val;
                     }
-                }
-            } while (origInput != input && input.IndexOfAny(tokenChars) >= 0);
+                    return tokenString;
+                });
+            } while (hasMatch);
 
-            return input;
+            return output;
         }
+
+        private static readonly Regex ReToken = new Regex(@"(\{(?:\1??[^{]*?\}))+", RegexOptions.Compiled);
+        private static readonly char[] TokenChars = { '{', '~' };
+        private static readonly Dictionary<string, string> TokenDictionary = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// Parses given string
@@ -575,29 +592,36 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         {
             if (string.IsNullOrWhiteSpace(input)) return input;
 
-            var tokenChars = new[] { '{', '~' };
-            if (string.IsNullOrEmpty(input) || input.IndexOfAny(tokenChars) == -1) return input;
 
-            var tokensToSkipList = tokensToSkip?.ToList() ?? new List<string>();
-            string origInput;
+            if (string.IsNullOrEmpty(input) || input.IndexOfAny(TokenChars) == -1) return input;
 
+            foreach (TokenDefinition tokenDefinition in _tokens)
+            {
+                foreach (string token in tokenDefinition.GetTokens())
+                {
+                    if (TokenDictionary.ContainsKey(token)) continue;
+                    if (tokensToSkip != null && tokensToSkip.Contains(token, StringComparer.OrdinalIgnoreCase)) continue;
+                    string value = tokenDefinition.GetReplaceValue();
+                    TokenDictionary[Regex.Unescape(token)] = value;
+                }
+            }
+
+            string output = input;
+            bool hasMatch = false;
             do
             {
-                origInput = input;
-                foreach (var token in _tokens)
+                hasMatch = false;
+                output = ReToken.Replace(output, match =>
                 {
-                    foreach (var filteredToken in token.GetTokens().Except(tokensToSkipList, StringComparer.InvariantCultureIgnoreCase))
+                    if (TokenDictionary.TryGetValue(match.Groups[1].Value, out string val))
                     {
-                        var regex = token.GetRegexForToken(filteredToken);
-                        if (regex.IsMatch(input))
-                        {
-                            input = regex.Replace(input, ParseString(token.GetReplaceValue(), tokensToSkipList.Concat(new[] { filteredToken }).ToArray()));
-                        }
+                        hasMatch = true;
+                        return val;
                     }
-                }
-            } while (origInput != input && input.IndexOfAny(tokenChars) >= 0);
-
-            return input;
+                    return match.Groups[1].Value;
+                });
+            } while (hasMatch);
+            return output;
         }
 
         public string ParseXmlStringWebpart(string inputXml, Web web, params string[] tokensToSkip)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| Related issues?  | fixes https://github.com/SharePoint/PnP-PowerShell/issues/1678

#### What's in this Pull Request?

Instead of looping over all tokens, which can get up to 5000+ in large templates, and matching on each part of a template fragment, we instead pick the tokens from the template fragment, and find replacement values from a token dictionary.

This greatly improved CPU usage and over all provision speed on large templates in particular.

Code also breaks up two linq statements to to reduce parsing of xml and unneeded parsing of template fragements for tokens.