### PR TITLE
Parse tokens in the complete SchemaXML

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -484,7 +484,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         {
             try
             {
-                var viewElement = XElement.Parse(view.SchemaXml);
+                var viewElement = XElement.Parse(parser.ParseString(view.SchemaXml));
                 var displayNameElement = viewElement.Attribute("DisplayName");
                 if (displayNameElement == null)
                 {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #1884

#### What's in this Pull Request?

This pull request fixes #1884 by parsing the tokens in the full xmlschema of the view when creating a new view. Tokens used within the View SchemaXML will now be parsed.