### PR TITLE
Fix: LoginNames should be compared case insensitive

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/TokenParserTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/TokenParserTests.cs
@@ -16,13 +16,13 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
         {
             using (var ctx = TestCommon.CreateClientContext())
             {
-                ctx.Load(ctx.Web, 
-                    w => w.Id, 
-                    w => w.ServerRelativeUrl, 
+                ctx.Load(ctx.Web,
+                    w => w.Id,
+                    w => w.ServerRelativeUrl,
                     w => w.Title,
-                    w => w.AssociatedOwnerGroup.Title, 
-                    w => w.AssociatedMemberGroup.Title, 
-                    w => w.AssociatedVisitorGroup.Title, 
+                    w => w.AssociatedOwnerGroup.Title,
+                    w => w.AssociatedMemberGroup.Title,
+                    w => w.AssociatedVisitorGroup.Title,
                     w => w.AssociatedOwnerGroup.Id,
                     w => w.AssociatedMemberGroup.Id,
                     w => w.AssociatedVisitorGroup.Id);
@@ -93,7 +93,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                 Assert.IsTrue(siteId == ctx.Web.Id.ToString());
                 Assert.IsTrue(currentUserId == currentUser.Id.ToString());
                 Assert.IsTrue(currentUserFullName == currentUser.Title);
-                Assert.IsTrue(currentUserLoginName == currentUser.LoginName);
+                Assert.IsTrue(currentUserLoginName.Equals(currentUser.LoginName, StringComparison.OrdinalIgnoreCase));
                 Guid outGuid;
                 Assert.IsTrue(Guid.TryParse(guid, out outGuid));
                 Assert.IsTrue(int.Parse(associatedOwnerGroupId) == ctx.Web.AssociatedOwnerGroup.Id);
@@ -101,7 +101,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                 Assert.IsTrue(int.Parse(associatedVisitorGroupId) == ctx.Web.AssociatedVisitorGroup.Id);
                 Assert.IsTrue(associatedOwnerGroupId == groupId);
                 Assert.IsTrue(siteOwner == ctx.Site.Owner.LoginName);
-                
+
                 Assert.IsTrue(roleDefinitionId == expectedRoleDefinitionId.ToString(), $"Role Definition Id was not parsed correctly (expected:{expectedRoleDefinitionId};returned:{roleDefinitionId})");
             }
         }
@@ -196,7 +196,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                 template.Parameters.Add("chain3", "{parameter:chain2}");
 
                 var parser = new TokenParser(ctx.Web, template);
-               
+
                 var parameterTest1 = parser.ParseString("parameterTest:{parameter:test1}");
                 var parameterTest2 = parser.ParseString("parameterTest:{parameter:test2}");
                 var parameterTest3 = parser.ParseString("parameterTest:{parameter:test3}");
@@ -207,7 +207,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                 var chainTest1 = parser.ParseString("parameterTest:{parameter:chain1}");
 
                 // Parser should stop processing parent tokens when processing nested tokens,
-                // so we should end up with the value of the last param (chain2) in our param chain, 
+                // so we should end up with the value of the last param (chain2) in our param chain,
                 // which will not get detokenized.
                 Assert.IsTrue(chainTest1 == "parameterTest:{parameter:chain1}");
             }

--- a/Core/OfficeDevPnP.Core/Extensions/SecurityExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/SecurityExtensions.cs
@@ -517,7 +517,7 @@ namespace Microsoft.SharePoint.Client
         }
 
         /// <summary>
-        /// Associate the provided groups as default owners, members or visitors groups. If a group is null then the 
+        /// Associate the provided groups as default owners, members or visitors groups. If a group is null then the
         /// association is not done
         /// </summary>
         /// <param name="web">Site to operate on</param>
@@ -801,7 +801,7 @@ namespace Microsoft.SharePoint.Client
                 {
                     roleDefinitionBindings.Add(roleDefinition);
 
-                    //update                        
+                    //update
                     roleAssignment.ImportRoleDefinitionBindings(roleDefinitionBindings);
                     roleAssignment.Update();
                     securableObject.Context.ExecuteQueryRetry();
@@ -962,7 +962,7 @@ namespace Microsoft.SharePoint.Client
                     rdc.Remove(roleDefinition);
                 }
 
-                //update                      
+                //update
                 roleAssignment.ImportRoleDefinitionBindings(rdc);
                 roleAssignment.Update();
                 securableObject.Context.ExecuteQueryRetry();
@@ -1364,8 +1364,8 @@ namespace Microsoft.SharePoint.Client
 
         /// <summary>
         /// A dictionary to cache resolved user emails. key: user login name, value: user email.
-        /// *** 
-        /// Don't use this cache in a real world application. 
+        /// ***
+        /// Don't use this cache in a real world application.
         /// ***
         /// Instead it should be replaced by a real cache with ref object to clear up intermediate records periodically.
         /// </summary>
@@ -1387,8 +1387,8 @@ namespace Microsoft.SharePoint.Client
 
         /// <summary>
         /// A dictionary to cache all user entities of a given SharePoint group. key: group login name, value: an array of user entities belongs to the group.
-        /// *** 
-        /// Don't use this cache in a real world application. 
+        /// ***
+        /// Don't use this cache in a real world application.
         /// ***
         /// Instead it should be replaced by a real cache with ref object to clear up intermediate records periodically.
         /// </summary>
@@ -1404,7 +1404,7 @@ namespace Microsoft.SharePoint.Client
             var context = obj.Context;
             if (!MockupGroupCache.ContainsKey(groupLoginName))
             {
-                var users = context.LoadQuery(obj.RoleAssignments.Groups.First(g => g.LoginName == groupLoginName).Users);
+                var users = context.LoadQuery(obj.RoleAssignments.Groups.First(g => g.LoginName.Equals(groupLoginName, StringComparison.OrdinalIgnoreCase)).Users);
                 context.ExecuteQueryRetry();
                 MockupGroupCache[groupLoginName] = (from u in users select new UserEntity()
                                                     {
@@ -1496,7 +1496,7 @@ namespace Microsoft.SharePoint.Client
                 {
                     return;
                 }
-                var roleAssignments = web.Context.LoadQuery(obj.RoleAssignments.Where(i => i.Member.LoginName == principal.LoginName));
+                var roleAssignments = web.Context.LoadQuery(obj.RoleAssignments.Where(i => i.Member.LoginName.Equals(principal.LoginName, StringComparison.OrdinalIgnoreCase)));
                 web.Context.ExecuteQueryRetry();
 
                 var assignment = roleAssignments.FirstOrDefault();

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Extensions/SecurableObjectExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Extensions/SecurableObjectExtensions.cs
@@ -31,7 +31,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Extensions
                 if (!roleAssignment.Remove)
                 {
                     var roleAssignmentPrincipal = parser.ParseString(roleAssignment.Principal);
-                    Principal principal = groups.FirstOrDefault(g => g.LoginName == roleAssignmentPrincipal);
+                    Principal principal = groups.FirstOrDefault(g => g.LoginName.Equals(roleAssignmentPrincipal, StringComparison.OrdinalIgnoreCase));
                     if (principal == null)
                     {
                         principal = context.Web.EnsureUser(roleAssignmentPrincipal);
@@ -53,7 +53,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Extensions
                 } else
                 {
                     var roleAssignmentPrincipal = parser.ParseString(roleAssignment.Principal);
-                    Principal principal = groups.FirstOrDefault(g => g.LoginName == roleAssignmentPrincipal);
+                    Principal principal = groups.FirstOrDefault(g => g.LoginName.Equals(roleAssignmentPrincipal, StringComparison.OrdinalIgnoreCase));
                     if (principal == null)
                     {
                         principal = context.Web.EnsureUser(roleAssignmentPrincipal);

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
@@ -111,7 +111,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                         if (parsedGroupTitle != parsedGroupOwner)
                         {
-                            Principal ownerPrincipal = allGroups.FirstOrDefault(gr => gr.LoginName == parsedGroupOwner);
+                            Principal ownerPrincipal = allGroups.FirstOrDefault(gr => gr.LoginName.Equals(parsedGroupOwner, StringComparison.OrdinalIgnoreCase));
                             if (ownerPrincipal == null)
                             {
                                 ownerPrincipal = web.EnsureUser(parsedGroupOwner);
@@ -199,7 +199,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         {
                             if (parsedGroupTitle != parsedGroupOwner)
                             {
-                                Principal ownerPrincipal = allGroups.FirstOrDefault(gr => gr.LoginName == parsedGroupOwner);
+                                Principal ownerPrincipal = allGroups.FirstOrDefault(gr => gr.LoginName.Equals(parsedGroupOwner, StringComparison.OrdinalIgnoreCase));
                                 if (ownerPrincipal == null)
                                 {
                                     ownerPrincipal = web.EnsureUser(parsedGroupOwner);
@@ -365,7 +365,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         {
 
             var parsedRoleDefinition = parser.ParseString(roleAssignment.Principal);
-            Principal principal = groups.FirstOrDefault(g => g.LoginName == parsedRoleDefinition);
+            Principal principal = groups.FirstOrDefault(g => g.LoginName.Equals(parsedRoleDefinition, StringComparison.OrdinalIgnoreCase));
 
             if (principal == null)
             {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #1881 

#### What's in this Pull Request?

As described in Issue #1881 the comparison of LoginNames should be performed case-insensitive. 
The PR contains all changes to the master branch to change the comparison logic. 