### PR TITLE
Fix: Unable to import Taxonomy Hashtag values

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTermGroups.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTermGroups.cs
@@ -457,7 +457,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         }
                     }
                 }
-                if (modelTerm.Terms.Any(t => t.CustomSortOrder > -1))
+                if (modelTerm.Terms.Any(t => t.CustomSortOrder > 0))
                 {
                     var sortedTerms = modelTerm.Terms.OrderBy(t => t.CustomSortOrder);
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTermGroups.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTermGroups.cs
@@ -242,7 +242,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         }
 
                         // do we need custom sorting?
-                        if (modelTermSet.Terms.Any(t => t.CustomSortOrder > -1))
+                        if (modelTermSet.Terms.Any(t => t.CustomSortOrder > 0))
                         {
                             var sortedTerms = modelTermSet.Terms.OrderBy(t => t.CustomSortOrder);
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #1897

#### What's in this Pull Request?

Analysis of the issue #1897 showed that the root cause of the ServerException being thrown is the fact that the provisioning engine tries to create a custom sort order on the HashTags TermSet which is in fact **not allowed**. 

The IF statement inside ObjectTermGroups.cs at line 245 https://github.com/SharePoint/PnP-Sites-Core/blob/c6afdf14f55004b1b1255b9c57cde1920495c5ea/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTermGroups.cs#L245 

compares using -1. Custom sort order in SharePoint always starts with 1 for the element which should be located at the start of the list.
