### PR TITLE
Fixed issue 1901 by using a Topological Sort while provisioning SiteGroups

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/TopologicalSort.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/TopologicalSort.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace OfficeDevPnP.Core.Extensions
+{
+    public static class TopologicalSort
+    {
+        private static Func<T, IEnumerable<T>> RemapDependencies<T, TKey>(IEnumerable<T> source, Func<T, IEnumerable<TKey>> getDependencies, Func<T, TKey> getKey)
+        {
+            var map = source.ToDictionary(getKey);
+            return item =>
+            {
+                var dependencies = getDependencies(item);
+                return dependencies != null
+                    ? dependencies.Select(key => map[key])
+                    : null;
+            };
+        }
+
+        public static IList<T> Sort<T, TKey>(this IEnumerable<T> source, Func<T, IEnumerable<TKey>> getDependencies, Func<T, TKey> getKey, bool ignoreCycles = false)
+        {
+            ICollection<T> source2 = (source as ICollection<T>) ?? source.ToArray();
+            return Sort<T>(source2, RemapDependencies(source2, getDependencies, getKey), null, ignoreCycles);
+        }
+
+        public static IList<T> Sort<T>(this IEnumerable<T> source, Func<T, IEnumerable<T>> getDependencies, IEqualityComparer<T> comparer = null, bool ignoreCycles = false)
+        {
+            var sorted = new List<T>();
+            var visited = new Dictionary<T, bool>(comparer);
+
+            foreach (var item in source)
+            {
+                Visit(item, getDependencies, sorted, visited, ignoreCycles);
+            }
+
+            return sorted;
+        }
+
+        private static void Visit<T>(T item, Func<T, IEnumerable<T>> getDependencies, List<T> sorted, Dictionary<T, bool> visited, bool ignoreCycles)
+        {
+            bool inProcess;
+            var alreadyVisited = visited.TryGetValue(item, out inProcess);
+
+            if (alreadyVisited)
+            {
+                if (inProcess && !ignoreCycles)
+                {
+                    throw new ArgumentException("Cyclic dependency found.");
+                }
+            }
+            else
+            {
+                visited[item] = true;
+
+                var dependencies = getDependencies(item);
+                if (dependencies != null)
+                {
+                    foreach (var dependency in dependencies)
+                    {
+                        Visit(dependency, getDependencies, sorted, visited, ignoreCycles);
+                    }
+                }
+
+                visited[item] = false;
+                sorted.Add(item);
+            }
+        }
+
+        public static IList<ICollection<T>> Group<T, TKey>(this IEnumerable<T> source, Func<T, IEnumerable<TKey>> getDependencies, Func<T, TKey> getKey, bool ignoreCycles = true)
+        {
+            ICollection<T> source2 = (source as ICollection<T>) ?? source.ToArray();
+            return Group<T>(source2, RemapDependencies(source2, getDependencies, getKey), null, ignoreCycles);
+        }
+
+        public static IList<ICollection<T>> Group<T>(this IEnumerable<T> source, Func<T, IEnumerable<T>> getDependencies, IEqualityComparer<T> comparer = null, bool ignoreCycles = true)
+        {
+            var sorted = new List<ICollection<T>>();
+            var visited = new Dictionary<T, int>(comparer);
+
+            foreach (var item in source)
+            {
+                Visit(item, getDependencies, sorted, visited, ignoreCycles);
+            }
+
+            return sorted;
+        }
+
+        private static int Visit<T>(T item, Func<T, IEnumerable<T>> getDependencies, List<ICollection<T>> sorted, Dictionary<T, int> visited, bool ignoreCycles)
+        {
+            const int inProcess = -1;
+            int level;
+            var alreadyVisited = visited.TryGetValue(item, out level);
+
+            if (alreadyVisited)
+            {
+                if (level == inProcess && ignoreCycles)
+                {
+                    throw new ArgumentException("Cyclic dependency found.");
+                }
+            }
+            else
+            {
+                visited[item] = (level = inProcess);
+
+                var dependencies = getDependencies(item);
+                if (dependencies != null)
+                {
+                    foreach (var dependency in dependencies)
+                    {
+                        var depLevel = Visit(dependency, getDependencies, sorted, visited, ignoreCycles);
+                        level = Math.Max(level, depLevel);
+                    }
+                }
+
+                visited[item] = ++level;
+                while (sorted.Count <= level)
+                {
+                    sorted.Add(new Collection<T>());
+                }
+                sorted[level].Add(item);
+            }
+
+            return level;
+        }
+
+    }
+}

--- a/Core/OfficeDevPnP.Core/Extensions/TopologicalSort.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/TopologicalSort.cs
@@ -1,4 +1,9 @@
-﻿using System;
+﻿/**
+ * Author: Tomas Takac
+ * Article: https://www.codeproject.com/Articles/869059/Topological-sorting-in-Csharp
+ * License: https://www.codeproject.com/info/cpol10.aspx
+ */
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
@@ -9,6 +9,7 @@ using Microsoft.SharePoint.Client.Utilities;
 using OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitions;
 using RoleDefinition = Microsoft.SharePoint.Client.RoleDefinition;
 using OfficeDevPnP.Core.Utilities;
+using OfficeDevPnP.Core.Extensions;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 {
@@ -63,29 +64,20 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     AddUserToGroup(web, visitorGroup, siteSecurity.AdditionalVisitors, scope, parser);
                 }
 
-                //sorting groups with respect to possible dependency through Owner property. Groups that are owners of other groups must be processed prior owned groups.
-                for (int i = 0; i < siteSecurity.SiteGroups.Count; i++)
-                {
-                    var currentGroup = siteSecurity.SiteGroups[i];
-                    string currentGroupOwner = currentGroup.Owner;
-                    string currentGroupTitle = parser.ParseString(currentGroup.Title);
-
-                    if (currentGroupOwner != "SHAREPOINT\\system" && currentGroupOwner != currentGroupTitle && !(currentGroupOwner.StartsWith("{{associated") && currentGroupOwner.EndsWith("group}}")))
-                    {
-                        for (int j = i + 1; j < siteSecurity.SiteGroups.Count; j++)
-                        {
-                            if (siteSecurity.SiteGroups[j].Title == currentGroupOwner)
-                            {
-                                siteSecurity.SiteGroups.Insert(i, siteSecurity.SiteGroups[j]);
-                                siteSecurity.SiteGroups.RemoveAt(j);
-                                i--;
-                                break;
+                foreach (var siteGroup in siteSecurity.SiteGroups
+                        .Sort<SiteGroup>(
+                            _grp => {
+                                string groupOwner = _grp.Owner;
+                                if (string.IsNullOrWhiteSpace(groupOwner)
+                                    || "SHAREPOINT\\system".Equals(groupOwner, StringComparison.OrdinalIgnoreCase)
+                                    || _grp.Title.Equals(groupOwner, StringComparison.OrdinalIgnoreCase)
+                                    || (groupOwner.StartsWith("{{associated") && groupOwner.EndsWith("group}}")))
+                                {
+                                    return Enumerable.Empty<SiteGroup>();
+                                }
+                                return siteSecurity.SiteGroups.Where(_item => _item.Title.Equals(groupOwner, StringComparison.OrdinalIgnoreCase));
                             }
-                        }
-                    }
-                }
-
-                foreach (var siteGroup in siteSecurity.SiteGroups)
+                    ))
                 {
                     Group group;
                     var allGroups = web.Context.LoadQuery(web.SiteGroups.Include(gr => gr.LoginName));

--- a/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
+++ b/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
@@ -433,6 +433,7 @@
     <Compile Include="Extensions\SiteExtensions.cs" />
     <Compile Include="Extensions\TaxonomyExtensions.cs" />
     <Compile Include="Extensions\TenantExtensions.cs" />
+	<Compile Include="Extensions\TopologicalSort.cs" />
     <Compile Include="Framework\Graph\Model\DirectorySetting.cs" />
     <Compile Include="Framework\Graph\Model\DirectorySettingTemplates.cs" />
     <Compile Include="Framework\Graph\GraphHttpClient.cs" />


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #1901 

#### What's in this Pull Request?

Analysis of the root cause for issue #1901  showed that the code currently in place for sorting SiteGroup definitions (loaded from a provisioning template) based on it's dependencies at 

https://github.com/SharePoint/PnP-Sites-Core/blob/baa63ca778ab7952fb5f6345e3cea3d1e8e4901a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs#L66

inadvertently deletes SiteGroup definitions. Form the defined 11 groups inside the provisioning template (attached to issue #1901) only **two** are created: `Website Administrator` , `Website Manager`.

The pull request contains a fix which replaces the current sorting routine with an [Topological Sort](https://en.wikipedia.org/wiki/Topological_sorting). Not only this fixes the current issue #1901 but additionally the added code might be applied everywhere in the Core framework where sorting objects based on dependencies is required.

The code for _Topological Sort_ has be taken from the excellent article written by [Tomas Takac at Codeproject](https://www.codeproject.com/Articles/869059/Topological-sorting-in-Csharp).
