### PR TITLE
Prevent access denied exception when provisioning content types

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
@@ -382,10 +382,20 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             //will be added at the end. To fix this issue we ordering the fields once more.
 
             createdCT.FieldLinks.Reorder(templateContentType.FieldRefs.Select(fld => parser.ParseString(fld.Name)).ToArray());
+            createdCT.EnsureProperties(ct => ct.ReadOnly, ct => ct.Hidden, ct => ct.Sealed);
 
-            createdCT.ReadOnly = templateContentType.ReadOnly;
-            createdCT.Hidden = templateContentType.Hidden;
-            createdCT.Sealed = templateContentType.Sealed;
+            if (createdCT.ReadOnly != templateContentType.ReadOnly)
+            {
+                createdCT.ReadOnly = templateContentType.ReadOnly;
+            }
+            if (createdCT.Hidden != templateContentType.Hidden)
+            {
+                createdCT.Hidden = templateContentType.Hidden;
+            }
+            if (createdCT.Sealed != templateContentType.Sealed)
+            {
+                createdCT.Sealed = templateContentType.Sealed;
+            }
 
             if (templateContentType.DocumentSetTemplate == null)
             {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #778 

#### What's in this Pull Request?

Change setting of content type properties ReadOnly, Hidden and Sealed to only apply when there is an actual change.
This change will fix #778 as long as the content type does not change the Sealed property. The Sealed property appears to only be allowed to change if the user is a site collection administrator. For new content types the Sealed property will be false by default.
