### PR TITLE
Fix: Invalid template in a rare situation when Webhook's ServerNotificationUrl is empty

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -2108,16 +2108,13 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         {
             var addedWebhooks = Task.Run(() => siteList.GetWebhookSubscriptionsAsync()).GetAwaiter().GetResult();
 
-            if (addedWebhooks.Any())
+            foreach (var webhook in addedWebhooks.Where(x => !string.IsNullOrEmpty(x.NotificationUrl)))
             {
-                foreach (var webhook in addedWebhooks)
+                list.Webhooks.Add(new Webhook
                 {
-                    list.Webhooks.Add(new Webhook()
-                    {
-                        ExpiresInDays = webhook.ExpirationDateTime.Subtract(DateTime.Now).Days + 1,
-                        ServerNotificationUrl = webhook.NotificationUrl,
-                    });
-                }
+                    ExpiresInDays = webhook.ExpirationDateTime.Subtract(DateTime.Now).Days + 1,
+                    ServerNotificationUrl = webhook.NotificationUrl,
+                });
             }
 
             return list;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #1858, #1907

#### What's in this Pull Request?

Fixed invalid template in a rare situation when Webhook's ServerNotificationUrl is empty solving #1907.