### PR TITLE
Fix: SetOpenBySitePolicy always returns false

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/InformationManagementExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/InformationManagementExtensions.cs
@@ -561,9 +561,9 @@ namespace Microsoft.SharePoint.Client
 #endif
         {
 #if ONPREMISES
-            if (web.HasSitePolicyAppliedImplementation() && !IsClosedBySitePolicyImplementation(web))
+            if (web.HasSitePolicyAppliedImplementation() && IsClosedBySitePolicyImplementation(web))
 #else
-            if (await web.HasSitePolicyAppliedImplementation() && !await web.IsClosedBySitePolicyImplementation())
+            if (await web.HasSitePolicyAppliedImplementation() && await web.IsClosedBySitePolicyImplementation())
 #endif
             {
                 ProjectPolicy.OpenProject(web.Context, web);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #1906

#### What's in this Pull Request?

As mentioned in #1906, because of wrong negation operator, the method `SetOpenBySitePolicy` doesn't work in the InformationManagementExtension. 