### PR TITLE
Group Classification property fetched from Group object

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Graph/UnifiedGroupsUtility.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Graph/UnifiedGroupsUtility.cs
@@ -700,7 +700,7 @@ namespace OfficeDevPnP.Core.Framework.Graph
 
                     if (includeClassification)
                     {
-                        group.Classification = GetGroupClassification(groupId, accessToken);
+                        group.Classification = g.Classification;
                     }
 
                     return (group);
@@ -794,7 +794,7 @@ namespace OfficeDevPnP.Core.Framework.Graph
 
                                 if (includeClassification)
                                 {
-                                    group.Classification = GetGroupClassification(g.Id, accessToken);
+                                    group.Classification = g.Classification;
                                 }
 
                                 groups.Add(group);


### PR DESCRIPTION

| Q               | A
| --------------- | ---
| Bug fix?        | 
| New feature?    | X
| New sample?      | 
| Related issues?  | 

#### What's in this Pull Request?

Now that the "Microsoft.Graph" and "Microsoft.Graph.Core" packages have been updated, the **Classification** property of an Office 365 Group is available on the Group object itself.

The method **GetGroupClassification** was used to make an explicit call to Graph to fetch this property. This PR removes the call to this method and replaces it with the property available on the group object. Improves performance while fetching groups in bulk.

I have kept the method  **GetGroupClassification** in the code. Can be used explicitly if wanted if the purpose of the task is just to get the classification based on the Group ID.


