### PR TITLE
Fix: object reference error for sharepoint groups in GroupToken

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/AssociatedGroupToken.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/AssociatedGroupToken.cs
@@ -33,23 +33,36 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitio
 
             if (string.IsNullOrEmpty(CacheValue))
             {
-                TokenContext.Load(TokenContext.Web, w => w.AssociatedOwnerGroup.Title, w => w.AssociatedMemberGroup.Title, w => w.AssociatedVisitorGroup.Title);
-                TokenContext.ExecuteQueryRetry();
                 switch (_groupType)
                 {
                     case AssociatedGroupType.owners:
                         {
-                            CacheValue = TokenContext.Web.AssociatedOwnerGroup.Title;
+                            TokenContext.Load(TokenContext.Web, w => w.AssociatedOwnerGroup.Title);
+                            TokenContext.ExecuteQueryRetry();
+                            if (!TokenContext.Web.AssociatedOwnerGroup.ServerObjectIsNull.Value)
+                            {
+                                CacheValue = TokenContext.Web.AssociatedOwnerGroup.Title;
+                            }
                             break;
                         }
                     case AssociatedGroupType.members:
                         {
-                            CacheValue = TokenContext.Web.AssociatedMemberGroup.Title;
+                            TokenContext.Load(TokenContext.Web, w => w.AssociatedMemberGroup.Title);
+                            TokenContext.ExecuteQueryRetry();
+                            if (!TokenContext.Web.AssociatedMemberGroup.ServerObjectIsNull.Value)
+                            {
+                                CacheValue = TokenContext.Web.AssociatedMemberGroup.Title;
+                            }
                             break;
                         }
                     case AssociatedGroupType.visitors:
                         {
-                            CacheValue = TokenContext.Web.AssociatedVisitorGroup.Title;
+                            TokenContext.Load(TokenContext.Web, w => w.AssociatedVisitorGroup.Title);
+                            TokenContext.ExecuteQueryRetry();
+                            if (!TokenContext.Web.AssociatedVisitorGroup.ServerObjectIsNull.Value)
+                            {
+                                CacheValue = TokenContext.Web.AssociatedVisitorGroup.Title;
+                            }
                             break;
                         }
                 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| New sample?      | no
| Related issues?  | fixes #1905 

#### What's in this Pull Request?

This PR fixes the `Object reference not set to instance of an object on server` error method.
This error occurs when there is no default associated visitor, member or owner group of a site.

To reproduce it, create a subsite with unique permissions. After that delete the visitor group and apply the template. It fails. So added a null check to determine whether the group exists or not.

Also, kinda improved the performance by sending minimal payload for each request. Currently, it fetches data for all groups in each iteration which can be avoided.

cc @wobba - can you please review this ? Please let me know if you need more details ! Cheers :)