### PR TITLE
adds support for a 3rd navigation level in provisioning

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/Extensions/NavigationExtensionsTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Extensions/NavigationExtensionsTests.cs
@@ -60,6 +60,83 @@ namespace OfficeDevPnP.Core.Tests.AppModelExtensions
         }
 
         [TestMethod]
+        public void AddSecondLevelQuickLaunchNodeTest()
+        {
+            using (var clientContext = TestCommon.CreateClientContext())
+            {
+                var web = clientContext.Web;
+
+                web.AddNavigationNode("Level1", new Uri("https://www.microsoft.com"), string.Empty, NavigationType.QuickLaunch);
+                web.AddNavigationNode("Level2", new Uri("https://www.microsoft.com"), "Level1", NavigationType.QuickLaunch);
+
+                clientContext.Load(web, w => w.Navigation.QuickLaunch);
+                clientContext.ExecuteQueryRetry();
+
+                Assert.IsTrue(web.Navigation.QuickLaunch.AreItemsAvailable);
+
+                if (web.Navigation.QuickLaunch.Any())
+                {
+                    var l1NavNode = web.Navigation.QuickLaunch.FirstOrDefault(n => n.Title == "Level1");
+                    Assert.IsNotNull(l1NavNode);
+
+                    clientContext.Load(l1NavNode.Children);
+                    clientContext.ExecuteQueryRetry();
+
+                    var l2NavNode = l1NavNode.Children.FirstOrDefault(n => n.Title == "Level2");
+                    Assert.IsNotNull(l2NavNode);
+
+                    l2NavNode.DeleteObject();
+                    clientContext.ExecuteQueryRetry();
+
+                    l1NavNode.DeleteObject();
+                    clientContext.ExecuteQueryRetry();
+                }
+            }
+        }
+
+        [TestMethod]
+        public void AddThirdLevelQuickLaunchNodeTest()
+        {
+            using (var clientContext = TestCommon.CreateClientContext())
+            {
+                var web = clientContext.Web;
+
+                web.AddNavigationNode("Level1", new Uri("https://www.microsoft.com"), string.Empty, NavigationType.QuickLaunch);
+                web.AddNavigationNode("Level2", new Uri("https://www.microsoft.com"), "Level1", NavigationType.QuickLaunch);
+                web.AddNavigationNode("Level3", new Uri("https://www.microsoft.com"), "Level2", NavigationType.QuickLaunch, l1ParentNodeTitle: "Level1");
+
+                clientContext.Load(web, w => w.Navigation.QuickLaunch);
+                clientContext.ExecuteQueryRetry();
+
+                Assert.IsTrue(web.Navigation.QuickLaunch.AreItemsAvailable);
+
+                if (web.Navigation.QuickLaunch.Any())
+                {
+                    var l1NavNode = web.Navigation.QuickLaunch.FirstOrDefault(n => n.Title == "Level1");
+                    Assert.IsNotNull(l1NavNode);
+
+                    clientContext.Load(l1NavNode.Children);
+                    clientContext.ExecuteQueryRetry();
+
+                    var l2NavNode = l1NavNode.Children.FirstOrDefault(n => n.Title == "Level2");
+                    Assert.IsNotNull(l2NavNode);
+
+                    clientContext.Load(l2NavNode.Children);
+                    clientContext.ExecuteQueryRetry();
+
+                    var l3NavNode = l2NavNode.Children.FirstOrDefault(n => n.Title == "Level3");
+                    Assert.IsNotNull(l3NavNode);
+
+                    l2NavNode.DeleteObject();
+                    clientContext.ExecuteQueryRetry();
+
+                    l1NavNode.DeleteObject();
+                    clientContext.ExecuteQueryRetry();
+                }
+            }
+        }
+
+        [TestMethod]
         public void AddSearchNavigationNodeTest()
         {
             using (var clientContext = TestCommon.CreateClientContext())

--- a/Core/OfficeDevPnP.Core/Extensions/NavigationExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/NavigationExtensions.cs
@@ -526,12 +526,13 @@ namespace Microsoft.SharePoint.Client
         /// <param name="web">Site to be processed - can be root web or sub site</param>
         /// <param name="nodeTitle">the title of node to add</param>
         /// <param name="nodeUri">the URL of node to add</param>
-        /// <param name="parentNodeTitle">if string.Empty, then will add this node as top level node</param>
+        /// <param name="parentNodeTitle">if string.Empty, then will add this node as top level node. Contains the title of the immediate parent node, for third level nodes, providing <paramref name="l1ParentNodeTitle"/> is required.</param>
         /// <param name="navigationType">the type of navigation, quick launch, top navigation or search navigation</param>
         /// <param name="isExternal">true if the link is an external link</param>
         /// <param name="asLastNode">true if the link should be added as the last node of the collection</param>
+        /// <param name="l1ParentNodeTitle">title of the first level parent, if this node is a third level navigation node</param>
         /// <returns>Newly added NavigationNode</returns>
-        public static NavigationNode AddNavigationNode(this Web web, string nodeTitle, Uri nodeUri, string parentNodeTitle, NavigationType navigationType, bool isExternal = false, bool asLastNode = true)
+        public static NavigationNode AddNavigationNode(this Web web, string nodeTitle, Uri nodeUri, string parentNodeTitle, NavigationType navigationType, bool isExternal = false, bool asLastNode = true, string l1ParentNodeTitle=null)
         {
             web.Context.Load(web, w => w.Navigation.QuickLaunch, w => w.Navigation.TopNavigationBar);
             web.Context.ExecuteQueryRetry();
@@ -555,8 +556,7 @@ namespace Microsoft.SharePoint.Client
                     }
                     else
                     {
-                        var parentNode = quickLaunch.FirstOrDefault(n => n.Title == parentNodeTitle);
-                        navigationNode = parentNode?.Children.Add(node);
+                        navigationNode = CreateNodeAsChild(web, quickLaunch, node, parentNodeTitle, l1ParentNodeTitle);
                     }
                 }
                 else if (navigationType == NavigationType.TopNavigationBar)
@@ -564,8 +564,7 @@ namespace Microsoft.SharePoint.Client
                     var topLink = web.Navigation.TopNavigationBar;
                     if (!string.IsNullOrEmpty(parentNodeTitle))
                     {
-                        var parentNode = topLink.FirstOrDefault(n => n.Title == parentNodeTitle);
-                        navigationNode = parentNode?.Children.Add(node);
+                        navigationNode = CreateNodeAsChild(web, topLink, node, parentNodeTitle, l1ParentNodeTitle);
                     }
                     else
                     {
@@ -582,6 +581,34 @@ namespace Microsoft.SharePoint.Client
             {
                 web.Context.ExecuteQueryRetry();
             }
+            return navigationNode;
+        }
+
+        /// <summary>
+        /// Creates a navigation node as a child of another (first or second level) navigation node.
+        /// </summary>
+        /// <param name="web">Site to be processed - can be root web or sub site</param>
+        /// <param name="parentNodes">Level one nodes under which the node should be created</param>
+        /// <param name="nodeToCreate">Node information</param>
+        /// <param name="parentNodeTitle">The title of the immediate parent node (level two if child should be level three, level one otherwise)</param>
+        /// <param name="l1ParentNodeTitle">The level one parent title or null, if the node to be created should be a level two node</param>
+        /// <returns></returns>
+        private static NavigationNode CreateNodeAsChild(Web web, NavigationNodeCollection parentNodes, NavigationNodeCreationInformation nodeToCreate, string parentNodeTitle, string l1ParentNodeTitle)
+        {
+            if (l1ParentNodeTitle != null)
+            {
+                var l1ParentNode = parentNodes.FirstOrDefault(n => n.Title == l1ParentNodeTitle);
+                if (l1ParentNode == null)
+                {
+                    return null;
+                }
+                web.Context.Load(l1ParentNode.Children);
+                web.Context.ExecuteQueryRetry();
+                parentNodes = l1ParentNode.Children;
+            }
+
+            var parentNode = parentNodes.FirstOrDefault(n => n.Title == parentNodeTitle);
+            var navigationNode = parentNode?.Children.Add(nodeToCreate);
             return navigationNode;
         }
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectNavigation.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectNavigation.cs
@@ -329,7 +329,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             }
         }
 
-        private void ProvisionStructuralNavigationNodes(Web web, TokenParser parser, Enums.NavigationType navigationType, Model.NavigationNodeCollection nodes, PnPMonitoredScope scope, string parentNodeTitle = null)
+        private void ProvisionStructuralNavigationNodes(Web web, TokenParser parser, Enums.NavigationType navigationType, Model.NavigationNodeCollection nodes, PnPMonitoredScope scope, string parentNodeTitle = null, string l1ParentNodeTitle = null)
         {
             foreach (var node in nodes)
             {
@@ -340,7 +340,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         new Uri(parser.ParseString(node.Url), UriKind.RelativeOrAbsolute),
                         parser.ParseString(parentNodeTitle),
                         navigationType,
-                        node.IsExternal
+                        node.IsExternal,
+                        l1ParentNodeTitle: l1ParentNodeTitle
                         );
 
 #if !SP2013
@@ -367,7 +368,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                 new Uri(parser.ParseString(node.Url), UriKind.RelativeOrAbsolute),
                                 parser.ParseString(parentNodeTitle),
                                 navigationType,
-                                true
+                                true,
+                                l1ParentNodeTitle: l1ParentNodeTitle
                                 );
                         }
                         catch (Exception innerEx)
@@ -387,7 +389,9 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     navigationType,
                     node.NavigationNodes,
                     scope,
-                    parser.ParseString(node.Title));
+                    parser.ParseString(node.Title),
+                    parentNodeTitle
+                );
             }
         }
 


### PR DESCRIPTION
The quick links navigation may contain up to three levels. However, the provisioning logic previously supported only two levels. This commit adds support for a third level and tests for adding second and third level nodes.

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #1926 

#### What's in this Pull Request?
This PR adds an optional parameter, `string l1ParentNodeTitle=null` to `NavigationExtensions.AddNavigationNode` that should be used to indicate the top-level parent in case the new node should be added on the third level. The logic that finds the parent node and adds the new node as child extracted so it can be reused for both top navigation and quick links.

The recursive `ObjectNavigation.ProvisionStructuralNavigationNodes` was extended to allow a `l1ParentNodeTitle` that it passes to `AddNavigationNode`, thereby supporting third level navigation nodes when provisioning sites.

Further, two tests were added to make sure the `NavigationExtensions.AddNavigationNode` actually works for nodes of the second and third level.