### PR TITLE
Feature: Added support for Resource Path API in modern pages

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectClientSidePages.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectClientSidePages.cs
@@ -47,13 +47,13 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     var exists = true;
                     try
                     {
-                        var file = web.GetFileByServerRelativeUrl(url);
-                        web.Context.Load(file, f => f.UniqueId, f => f.ServerRelativeUrl);
+                        var file = web.GetFileByServerRelativePath(ResourcePath.FromDecodedUrl(url));
+                        web.Context.Load(file, f => f.UniqueId, f => f.ServerRelativePath);
                         web.Context.ExecuteQueryRetry();
 
                         // Fill token
-                        parser.AddToken(new PageUniqueIdToken(web, file.ServerRelativeUrl.Substring(web.ServerRelativeUrl.Length).TrimStart("/".ToCharArray()), file.UniqueId));
-                        parser.AddToken(new PageUniqueIdEncodedToken(web, file.ServerRelativeUrl.Substring(web.ServerRelativeUrl.Length).TrimStart("/".ToCharArray()), file.UniqueId));
+                        parser.AddToken(new PageUniqueIdToken(web, file.ServerRelativePath.DecodedUrl.Substring(web.ServerRelativeUrl.Length).TrimStart("/".ToCharArray()), file.UniqueId));
+                        parser.AddToken(new PageUniqueIdEncodedToken(web, file.ServerRelativePath.DecodedUrl.Substring(web.ServerRelativeUrl.Length).TrimStart("/".ToCharArray()), file.UniqueId));
                     }
                     catch (ServerException ex)
                     {
@@ -83,13 +83,13 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                         page.Save(pageName);
 
-                        var file = web.GetFileByServerRelativeUrl(url);
-                        web.Context.Load(file, f => f.UniqueId, f => f.ServerRelativeUrl);
+                        var file = web.GetFileByServerRelativePath(ResourcePath.FromDecodedUrl(url));
+                        web.Context.Load(file, f => f.UniqueId, f => f.ServerRelativePath);
                         web.Context.ExecuteQueryRetry();
 
                         // Fill token
-                        parser.AddToken(new PageUniqueIdToken(web, file.ServerRelativeUrl.Substring(web.ServerRelativeUrl.Length).TrimStart("/".ToCharArray()), file.UniqueId));
-                        parser.AddToken(new PageUniqueIdEncodedToken(web, file.ServerRelativeUrl.Substring(web.ServerRelativeUrl.Length).TrimStart("/".ToCharArray()), file.UniqueId));
+                        parser.AddToken(new PageUniqueIdToken(web, file.ServerRelativePath.DecodedUrl.Substring(web.ServerRelativeUrl.Length).TrimStart("/".ToCharArray()), file.UniqueId));
+                        parser.AddToken(new PageUniqueIdEncodedToken(web, file.ServerRelativePath.DecodedUrl.Substring(web.ServerRelativeUrl.Length).TrimStart("/".ToCharArray()), file.UniqueId));
 
                         // Track that we pre-added this page
                         preCreatedPages.Add(url);
@@ -111,7 +111,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     var exists = true;
                     try
                     {
-                        var file = web.GetFileByServerRelativeUrl(url);
+                        var file = web.GetFileByServerRelativePath(ResourcePath.FromDecodedUrl(url));
                         web.Context.Load(file);
                         web.Context.ExecuteQueryRetry();
                     }

--- a/Core/OfficeDevPnP.Core/Pages/ClientSidePage.cs
+++ b/Core/OfficeDevPnP.Core/Pages/ClientSidePage.cs
@@ -590,7 +590,7 @@ namespace OfficeDevPnP.Core.Pages
 
             page.sitePagesServerRelativeUrl = pagesLibrary.RootFolder.ServerRelativeUrl;
 
-            var file = page.Context.Web.GetFileByServerRelativeUrl($"{page.sitePagesServerRelativeUrl}/{page.pageName}");
+            var file = page.Context.Web.GetFileByServerRelativePath(ResourcePath.FromDecodedUrl($"{page.sitePagesServerRelativeUrl}/{page.pageName}"));
             page.Context.Web.Context.Load(file, f => f.ListItemAllFields, f => f.Exists);
             page.Context.Web.Context.ExecuteQueryRetry();
 
@@ -743,7 +743,7 @@ namespace OfficeDevPnP.Core.Pages
                             this.Context.Site.EnsureProperties(p => p.Id);
                             this.Context.Web.EnsureProperties(p => p.Id, p => p.Url);
 
-                            var previewImage = this.Context.Web.GetFileByServerRelativeUrl(previewImageServerRelativeUrl);
+                            var previewImage = this.Context.Web.GetFileByServerRelativePath(ResourcePath.FromDecodedUrl(previewImageServerRelativeUrl));
                             this.Context.Load(previewImage, p => p.UniqueId);
                             this.Context.ExecuteQueryRetry();
 
@@ -1247,7 +1247,7 @@ namespace OfficeDevPnP.Core.Pages
             serverRelativePageName = $"{this.sitePagesServerRelativeUrl}/{this.pageName}";
 
             // ensure page exists
-            pageFile = this.Context.Web.GetFileByServerRelativeUrl(serverRelativePageName);
+            pageFile = this.Context.Web.GetFileByServerRelativePath(ResourcePath.FromDecodedUrl(serverRelativePageName));
             this.Context.Web.Context.Load(pageFile, f => f.ListItemAllFields, f => f.Exists);
             this.Context.Web.Context.ExecuteQueryRetry();
         }

--- a/Core/OfficeDevPnP.Core/Pages/ClientSidePageHeader.cs
+++ b/Core/OfficeDevPnP.Core/Pages/ClientSidePageHeader.cs
@@ -396,7 +396,7 @@ namespace OfficeDevPnP.Core.Pages
                 this.clientContext.Site.EnsureProperties(p => p.Id);
                 this.clientContext.Web.EnsureProperties(p => p.Id);
 
-                var pageHeaderImage = this.clientContext.Web.GetFileByServerRelativeUrl(ImageServerRelativeUrl);
+                var pageHeaderImage = this.clientContext.Web.GetFileByServerRelativePath(ResourcePath.FromDecodedUrl(ImageServerRelativeUrl));
                 this.clientContext.Load(pageHeaderImage, p => p.UniqueId, p => p.ListId);
                 this.clientContext.ExecuteQueryRetry();
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| New sample?      | no
| Related issues?  | NA

#### What's in this Pull Request?

Added support for Resource Path API in the modern site pages. 
It fixes the issue wherein we have `#` or `%` characters in page names or image names for modern site pages.

Should I go ahead and modify it across the solution for SPO ? I saw that we are using the `GetFileByServerRelativeUrl` across multiple extensions and provisioning handlers. I will ofcourse test it before making PR, but seems like something we should use across the PnP Core package.