### PR TITLE
Removes 60 minute maximum lifetime for Access Tokens in AuthenticationManager

### DIFF
--- a/Core/OfficeDevPnP.Core/AuthenticationManager.cs
+++ b/Core/OfficeDevPnP.Core/AuthenticationManager.cs
@@ -245,9 +245,7 @@ namespace OfficeDevPnP.Core
                                 Log.Debug(Constants.LOGGING_SOURCE, "Lease expiration date: {0}", response.ExpiresOn);
                                 var lease = GetAccessTokenLease(response.ExpiresOn);
                                 lease =
-                                    TimeSpan.FromSeconds(
-                                        Math.Min(lease.TotalSeconds - TimeSpan.FromMinutes(5).TotalSeconds,
-                                                 TimeSpan.FromHours(1).TotalSeconds));
+                                    TimeSpan.FromSeconds(lease.TotalSeconds - TimeSpan.FromMinutes(5).TotalSeconds > 0 ? lease.TotalSeconds - TimeSpan.FromMinutes(5).TotalSeconds : lease.TotalSeconds);
                                 Thread.Sleep(lease);
                                 appOnlyAccessToken = null;
                             }

--- a/Core/OfficeDevPnP.Core/Enums/SharePointPlatform.cs
+++ b/Core/OfficeDevPnP.Core/Enums/SharePointPlatform.cs
@@ -18,7 +18,7 @@
         /// </summary>
         Office365Dedicated = 2,
         /// <summary>
-        /// SharePoint OnPremise platform
+        /// SharePoint On-Premises platform
         /// </summary>
         OnPremises = 3
     }

--- a/Core/OfficeDevPnP.Core/Framework/Graph/SiteClassificationUtility.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Graph/SiteClassificationUtility.cs
@@ -9,6 +9,9 @@ using System.Threading.Tasks;
 
 namespace OfficeDevPnP.Core.Framework.Graph
 {
+    /// <summary>
+    /// Utility class for managing Site Classifications settings on the target tenant using Graph.
+    /// </summary>
     public static class SiteClassificationsUtility
     {
         /// <summary>

--- a/Core/OfficeDevPnP.Core/Framework/TimerJobs/TimerJob.cs
+++ b/Core/OfficeDevPnP.Core/Framework/TimerJobs/TimerJob.cs
@@ -390,7 +390,7 @@ namespace OfficeDevPnP.Core.Framework.TimerJobs
                 }
                 ccTenant = CreateClientContext(tenantAdminSiteUrl);
 #else
-                // No easy way to detect tenant admin site in on-premises, so uses has to specify it            
+                // No easy way to detect tenant admin site in on-premises, so users has to specify it            
                 if (!String.IsNullOrEmpty(tenantAdminSite))
                 {
                     ccTenant = CreateClientContext(tenantAdminSite);

--- a/Core/OfficeDevPnP.Core/Framework/TimerJobs/TimerJob.cs
+++ b/Core/OfficeDevPnP.Core/Framework/TimerJobs/TimerJob.cs
@@ -390,7 +390,7 @@ namespace OfficeDevPnP.Core.Framework.TimerJobs
                 }
                 ccTenant = CreateClientContext(tenantAdminSiteUrl);
 #else
-                // No easy way to detect tenant admin site in on-premises, so users has to specify it            
+                // No easy way to detect tenant admin site in on-premises, so users have to specify it            
                 if (!String.IsNullOrEmpty(tenantAdminSite))
                 {
                     ccTenant = CreateClientContext(tenantAdminSite);

--- a/Core/OfficeDevPnP.Core/Utilities/CredentialManager.cs
+++ b/Core/OfficeDevPnP.Core/Utilities/CredentialManager.cs
@@ -9,7 +9,7 @@ using FILETIME = System.Runtime.InteropServices.ComTypes.FILETIME;
 namespace OfficeDevPnP.Core.Utilities
 {
     /// <summary>
-    /// Class for getting and managing Credentials for SharePoint Online and SharePoint Onpremise
+    /// Class for getting and managing Credentials for SharePoint Online and SharePoint On-premises
     /// </summary>
     public static class CredentialManager
     {

--- a/Core/OfficeDevPnP.Core/Utilities/MailUtility.cs
+++ b/Core/OfficeDevPnP.Core/Utilities/MailUtility.cs
@@ -9,6 +9,9 @@ using System.Threading.Tasks;
 
 namespace OfficeDevPnP.Core.Utilities
 {
+    /// <summary>
+    /// Provides functions for sending email using either Office 365 SMTP service or SharePoint's SendEmail utility
+    /// </summary>
     public class MailUtility
     {
         /// <summary>

--- a/Core/OfficeDevPnP.Core/Utilities/PnPCoreUtilities.cs
+++ b/Core/OfficeDevPnP.Core/Utilities/PnPCoreUtilities.cs
@@ -8,6 +8,9 @@ using System.Threading.Tasks;
 
 namespace OfficeDevPnP.Core.Utilities
 {
+    /// <summary>
+    /// Holds PnP Core library identification tag and user-agent, and a tool to get tenant administration url based the URL of the web
+    /// </summary>
     public static class PnPCoreUtilities
     {
         /// <summary>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #1956 

#### What's in this Pull Request?

Removes the maximum access token lease lifetime, which was set to 60 minutes, even though access tokens can be valid (depending on the case) up to 12 hours.

Doesn't remove the logic, that sets the token to null 5 minutes before validity ends. I suspect that's there for a reason?

Also contains my earlier pull request #1952 (since I messed up branching earlier), which just has fixes for typos and adds summaries for a few classes.