### PR TITLE
Fixed token parsing and removed ~ tokens tests as they are not supported anymore (#1953)

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/TokenParserTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/TokenParserTests.cs
@@ -52,14 +52,10 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                 var parser = new TokenParser(ctx.Web, template);
                 var siteName = parser.ParseString("{sitename}");
                 var siteId = parser.ParseString("{siteid}");
-                var site1 = parser.ParseString("~siTE/test");
-                var site2 = parser.ParseString("{site}/test");
-                var sitecol1 = parser.ParseString("~siteCOLLECTION/test");
-                var sitecol2 = parser.ParseString("{sitecollection}/test");
-                var masterUrl1 = parser.ParseString("~masterpagecatalog/test");
-                var masterUrl2 = parser.ParseString("{masterpagecatalog}/test");
-                var themeUrl1 = parser.ParseString("~themecatalog/test");
-                var themeUrl2 = parser.ParseString("{themecatalog}/test");
+                var site = parser.ParseString("{site}/test");
+                var sitecol = parser.ParseString("{sitecollection}/test");
+                var masterUrl = parser.ParseString("{masterpagecatalog}/test");
+                var themeUrl = parser.ParseString("{themecatalog}/test");
                 var parameterTest1 = parser.ParseString("abc{parameter:TEST}/test");
                 var parameterTest2 = parser.ParseString("abc{$test}/test");
                 var associatedOwnerGroup = parser.ParseString("{associatedownergroup}");
@@ -76,14 +72,10 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                 var siteOwner = parser.ParseString("{siteowner}");
                 var roleDefinitionId = parser.ParseString($"{{roledefinitionid:{roleDefinition.Name}}}");
 
-                Assert.IsTrue(site1 == $"{ctx.Web.ServerRelativeUrl}/test");
-                Assert.IsTrue(site2 == $"{ctx.Web.ServerRelativeUrl}/test");
-                Assert.IsTrue(sitecol1 == $"{ctx.Site.ServerRelativeUrl}/test");
-                Assert.IsTrue(sitecol2 == $"{ctx.Site.ServerRelativeUrl}/test");
-                Assert.IsTrue(masterUrl1 == $"{masterCatalog.RootFolder.ServerRelativeUrl}/test");
-                Assert.IsTrue(masterUrl2 == $"{masterCatalog.RootFolder.ServerRelativeUrl}/test");
-                Assert.IsTrue(themeUrl1 == $"{themesCatalog.RootFolder.ServerRelativeUrl}/test");
-                Assert.IsTrue(themeUrl2 == $"{themesCatalog.RootFolder.ServerRelativeUrl}/test");
+                Assert.IsTrue(site == $"{ctx.Web.ServerRelativeUrl}/test");
+                Assert.IsTrue(sitecol == $"{ctx.Site.ServerRelativeUrl}/test");
+                Assert.IsTrue(masterUrl == $"{masterCatalog.RootFolder.ServerRelativeUrl}/test");
+                Assert.IsTrue(themeUrl == $"{themesCatalog.RootFolder.ServerRelativeUrl}/test");
                 Assert.IsTrue(parameterTest1 == "abctest/test");
                 Assert.IsTrue(parameterTest2 == "abctest/test");
                 Assert.IsTrue(associatedOwnerGroup == ctx.Web.AssociatedOwnerGroup.Title);

--- a/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/TokenParserTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/TokenParserTests.cs
@@ -71,6 +71,8 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                 var groupId = parser.ParseString($"{{groupid:{ownerGroupName}}}");
                 var siteOwner = parser.ParseString("{siteowner}");
                 var roleDefinitionId = parser.ParseString($"{{roledefinitionid:{roleDefinition.Name}}}");
+                var xamlEscapeString = "{}{0}Id";
+                var parsedXamlEscapeString = parser.ParseString(xamlEscapeString);
 
                 Assert.IsTrue(site == $"{ctx.Web.ServerRelativeUrl}/test");
                 Assert.IsTrue(sitecol == $"{ctx.Site.ServerRelativeUrl}/test");
@@ -93,8 +95,8 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                 Assert.IsTrue(int.Parse(associatedVisitorGroupId) == ctx.Web.AssociatedVisitorGroup.Id);
                 Assert.IsTrue(associatedOwnerGroupId == groupId);
                 Assert.IsTrue(siteOwner == ctx.Site.Owner.LoginName);
-
                 Assert.IsTrue(roleDefinitionId == expectedRoleDefinitionId.ToString(), $"Role Definition Id was not parsed correctly (expected:{expectedRoleDefinitionId};returned:{roleDefinitionId})");
+                Assert.IsTrue(parsedXamlEscapeString == xamlEscapeString);
             }
         }
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
@@ -654,7 +654,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         hasMatch = true;
                         return match.Groups[0].Value == tokenString ? val : match.Groups[0].Value.Replace(tokenString, val);
                     }
-                    return tokenString;
+                    return match.Groups[0].Value;
                 });
             } while (hasMatch && input != output);
 
@@ -731,7 +731,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         hasMatch = true;
                         return match.Groups[0].Value == tokenString ? val : match.Groups[0].Value.Replace(tokenString, val);
                     }
-                    return match.Groups["token"].Value;
+                    return match.Groups[0].Value;
                 });
             } while (hasMatch && input != output);
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #1953

#### What's in this Pull Request?

In Workflow XAML definition `{}` is used as escape sequence. In case described in #1953, we have `{}{0}Id` in one of attributes. After token parsing it is changed to `{0}Id` which is wrong. It is effect of a bug in `TokenParser.ParseString()` method. This PR fixes it and removes ~ tokens tests as they are not supported anymore.