### PR TITLE
BuildTokenCache bug

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -389,7 +389,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 var fieldsRefsToProcess = listInfo.TemplateList.FieldRefs.Select(fr => new
                 {
                     FieldRef = fr,
-                    TemplateField = template.SiteFields.FirstOrDefault(tf => (Guid)XElement.Parse(parser.ParseString(tf.SchemaXml)).Attribute("ID") == fr.Id)
+                    TemplateField = template.SiteFields.FirstOrDefault(tf => (Guid)XElement.Parse(tf.SchemaXml).Attribute("ID") == fr.Id)
                 }).Where(frData =>
                     frData.TemplateField == null // Process fields refs if the target is not defined in the current template
                     || frData.TemplateField.GetFieldProvisioningStep(parser) == step // or process field ref only if the current step is matching

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
@@ -667,7 +667,9 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             {
                 foreach (string token in tokenDefinition.GetTokens())
                 {
-                    if (TokenDictionary.ContainsKey(token)) continue;
+                    var tokenKey = Regex.Unescape(token);
+
+                    if (TokenDictionary.ContainsKey(tokenKey)) continue;
 
                     int before = _web.Context.PendingRequestCount();
                     string value = tokenDefinition.GetReplaceValue();
@@ -678,10 +680,10 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         throw new Exception($"Token {token} triggered an ExecuteQuery on the 'current' context. Please refactor this token to use the TokenContext class.");
                     }
 
-                    TokenDictionary[Regex.Unescape(token)] = value;
+                    TokenDictionary[tokenKey] = value;
                     if (tokenDefinition is ListIdToken)
                     {
-                        ListTokenDictionary[Regex.Unescape(token)] = tokenDefinition;
+                        ListTokenDictionary[tokenKey] = tokenDefinition;
                     }
                 }
             }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | N/A

#### What's in this Pull Request?

BuildTokenCache is storing values in the TokenDictionary with an unescaped key, but checking using a key which is not unescaped.

Furthermore ObjectListInstance.ProcessFieldRefs has become extremely slow as the LINQ is calling ParseString. ParseString is removed as I cannot see that it should be necessary to just get the ID attribute.
