### PR TITLE
FixLookupField. If target list is not found, just return fieldXml

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectListInstanceTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectListInstanceTests.cs
@@ -307,7 +307,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                 var listInstance = new Core.Framework.Provisioning.Model.ListInstance();
                 listInstance.Url = $"lists/{listName}";
                 listInstance.Title = listName;
-                // An asset must be created by using the 
+                // An asset must be created by using the
                 // template type AND the template feature id
                 listInstance.TemplateType = 851;
                 listInstance.TemplateFeatureID = new Guid("4bcccd62-dcaf-46dc-a7d4-e38277ef33f4");
@@ -351,7 +351,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                 listId = list.Id.ToString();
             }
 
-            // Update list Title using a provisioning template 
+            // Update list Title using a provisioning template
             // - Using a clean clientcontext to catch all possible "property not loaded" problems
             using (var ctx = TestCommon.CreateClientContext())
             {
@@ -1040,6 +1040,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
             string detailsFieldSchema = @"<Field Name=""DetailsField"" StaticName=""DetailsField"" DisplayName=""Details Field"" Type=""Text"" ID=""" + detailsFieldId.ToString("B") + @""" Group=""PnP"" Required=""true""/>";
             string lookupFieldSchema = @"<Field Name=""LookupField"" StaticName=""LookupField"" DisplayName=""Test Lookup Field"" Type=""Lookup"" List=""Lists\" + detailsListName + @""" ShowField=""DetailsField"" ID=""" + lookupFieldId.ToString("B") + @""" Group=""PnP""></Field>";
             string lookupMultiFieldSchema = @"<Field Name=""LookupMultiField"" StaticName=""LookupMultiField"" DisplayName=""Test LookupMulti Field"" Type=""LookupMulti"" Mult=""TRUE"" List=""Lists\" + detailsListName + @""" ShowField=""DetailsField"" ID=""" + lookupMultiFieldId.ToString("B") + @""" Group=""PnP""></Field>";
+            string lookupFieldToInternalListSchema = @"<Field ID=""{6bfaba20-36bf-44b5-a1b2-eb6346d49716}"" ColName=""tp_AppAuthor"" RowOrdinal=""0"" ReadOnly=""TRUE"" Hidden=""FALSE"" Type=""Lookup"" List=""AppPrincipals"" Name=""AppAuthor"" DisplayName=""App Created By"" ShowField=""Title"" JoinColName=""Id"" SourceID=""http://schemas.microsoft.com/sharepoint/v3"" StaticName=""AppAuthor"" FromBaseType=""TRUE"" />";
 
             var template = new ProvisioningTemplate();
             var detailsList = new ListInstance();
@@ -1055,6 +1056,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
             masterList.TemplateType = (int)ListTemplateType.GenericList;
             masterList.Fields.Add(new Core.Framework.Provisioning.Model.Field() { SchemaXml = lookupFieldSchema });
             masterList.Fields.Add(new Core.Framework.Provisioning.Model.Field() { SchemaXml = lookupMultiFieldSchema });
+            masterList.Fields.Add(new Core.Framework.Provisioning.Model.Field() { SchemaXml = lookupFieldToInternalListSchema });
             template.Lists.Add(masterList);
 
             return template;

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Utilities/FieldUtilities.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Utilities/FieldUtilities.cs
@@ -13,12 +13,14 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
             if (fieldType == "Lookup" || fieldType == "LookupMulti")
             {
                 var listAttr = (string)fieldElement.Attribute("List");
-                Guid g;
-                if (!Guid.TryParse(listAttr, out g))
+                if (!Guid.TryParse(listAttr, out Guid g))
                 {
-                    var targetList = web.GetList($"{web.EnsureProperty(w => w.ServerRelativeUrl).TrimEnd('/')}/{listAttr}");
-                    fieldElement.SetAttributeValue("List", targetList.EnsureProperty(l => l.Id).ToString("B"));
-                    return fieldElement.ToString();
+                    var targetList = web.GetListByUrl($"/{listAttr}");
+                    if (targetList != null)
+                    {
+                        fieldElement.SetAttributeValue("List", targetList.Id.ToString("B"));
+                        return fieldElement.ToString();
+                    }
                 }
             }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | N/A

#### What's in this Pull Request?

If a template contains a OOTB lookup field where the target list is an internal SharePoint list, applying the template will fail with "File not found" because the target list cannot be found.

Eg.
```xml
<Field ID="{6bfaba20-36bf-44b5-a1b2-eb6346d49716}" ColName="tp_AppAuthor" RowOrdinal="0" ReadOnly="TRUE" Hidden="FALSE" Type="Lookup" List="AppPrincipals" Name="AppAuthor" DisplayName="App Created By" ShowField="Title" JoinColName="Id" SourceID="http://schemas.microsoft.com/sharepoint/v3" StaticName="AppAuthor" FromBaseType="TRUE" />
```
This change will just return schemaXml in case the target list cannot be found.
Included above field in test creating lookup fields.
