### PR TITLE
Fixed schema xml parsing

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectFieldTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectFieldTests.cs
@@ -12,7 +12,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
     [TestClass]
     public class ObjectFieldTests
     {
-        private const string ElementSchema = @"<Field xmlns=""http://schemas.microsoft.com/sharepoint/v3"" StaticName=""DemoField"" DisplayName=""Test Field"" Type=""Text"" ID=""{7E5E53E4-86C2-4A64-9F2E-FDFECE6219E0}"" Group=""PnP"" Required=""true""/>";
+        private const string ElementSchema = @"<Field xmlns=""http://schemas.microsoft.com/sharepoint/v3"" StaticName=""DemoField"" DisplayName=""Test Field"" Description=""Description with &quot;quoutes&quot;"" Type=""Text"" ID=""{7E5E53E4-86C2-4A64-9F2E-FDFECE6219E0}"" Group=""PnP"" Required=""true""/>";
         private Guid fieldId = Guid.Parse("{7E5E53E4-86C2-4A64-9F2E-FDFECE6219E0}");
 
         private const string CalculatedFieldElementSchema = @"<Field Name=""CalculatedField"" StaticName=""CalculatedField"" DisplayName=""Test Calculated Field"" Type=""Calculated"" ResultType=""Text"" ID=""{D1A33456-9FEB-4D8E-AFFA-177EACCE4B70}"" Group=""PnP"" ReadOnly=""TRUE"" ><Formula>=DemoField&amp;""DemoField""</Formula><FieldRefs><FieldRef Name=""DemoField"" ID=""{7E5E53E4-86C2-4A64-9F2E-FDFECE6219E0}"" /></FieldRefs></Field>";

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/FieldAndListProvisioningStepHelper.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/FieldAndListProvisioningStepHelper.cs
@@ -12,7 +12,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         {
             XElement schemaElement;
             if (!_fieldXmlDictionary.TryGetValue(templateField, out schemaElement)) {
-                schemaElement = XElement.Parse(parser.ParseString(templateField.SchemaXml));
+                schemaElement = XElement.Parse(parser.ParseXmlString(templateField.SchemaXml));
                 _fieldXmlDictionary[templateField] = schemaElement;
             }
             var type = (string)schemaElement.Attribute("Type");
@@ -28,7 +28,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             XElement schemaElement;
             if (!_fieldXmlDictionary.TryGetValue(templateField, out schemaElement))
             {
-                schemaElement = XElement.Parse(parser.ParseString(templateField.SchemaXml));
+                schemaElement = XElement.Parse(parser.ParseXmlString(templateField.SchemaXml));
                 _fieldXmlDictionary[templateField] = schemaElement;
             }
             var id = (Guid)schemaElement.Attribute("ID");
@@ -40,7 +40,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             XElement schemaElement;
             if (!_fieldXmlDictionary.TryGetValue(templateField, out schemaElement))
             {
-                schemaElement = XElement.Parse(parser.ParseString(templateField.SchemaXml, tokensToSkip));
+                schemaElement = XElement.Parse(parser.ParseXmlString(templateField.SchemaXml, tokensToSkip));
                 _fieldXmlDictionary[templateField] = schemaElement;
             }
             return schemaElement;

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
@@ -69,12 +69,12 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                 SortedList<string,Field> fieldDict = new SortedList<string, Field>(new DuplicateKeyComparer<string>());
                 foreach (Field siteField in template.SiteFields)
-                {                    
+                {
                     var step = siteField.GetFieldProvisioningStep(parser);
 
                     if (step == _step)
                     {
-                        var fieldRef = (string)XElement.Parse(parser.ParseString(siteField.SchemaXml)).Attribute("FieldRef") + "";
+                        var fieldRef = (string)XElement.Parse(parser.ParseXmlString(siteField.SchemaXml)).Attribute("FieldRef") + "";
                         fieldDict.Add(fieldRef,siteField);
                     }
                 }
@@ -85,7 +85,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 foreach (var field in fields)
                 {
                     currentFieldIndex++;
-                    var fieldSchemaElement = XElement.Parse(parser.ParseString(field.SchemaXml));
+                    var fieldSchemaElement = XElement.Parse(parser.ParseXmlString(field.SchemaXml));
                     var fieldId = fieldSchemaElement.Attribute("ID").Value;
                     var fieldInternalName = (string)fieldSchemaElement.Attribute("InternalName") != null ? (string)fieldSchemaElement.Attribute("InternalName") : "";
                     WriteMessage($"Field|{(!string.IsNullOrWhiteSpace(fieldInternalName) ? fieldInternalName : fieldId)}|{currentFieldIndex}|{fields.Count}", ProvisioningMessageType.Progress);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | N/A

#### What's in this Pull Request?

This small PR changes token parsing to use ParseXmlString when parsing SchemaXml.
ParseString can result in invalid xml that cannot be parsed by XElement.Parse.
