### PR TITLE
Create groups with owners and members using single API call

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Graph/Model/GroupExtended.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Graph/Model/GroupExtended.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Graph;
+using Newtonsoft.Json;
+
+namespace OfficeDevPnP.Core.Framework.Graph.Model
+{
+    public class GroupExtended : Group
+    {
+        [JsonProperty("owners@odata.bind", NullValueHandling = NullValueHandling.Ignore)]
+        public string[] OwnersODataBind { get; set; }
+        [JsonProperty("members@odata.bind", NullValueHandling = NullValueHandling.Ignore)]
+        public string[] MembersODataBind { get; set; }
+    }
+}

--- a/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
+++ b/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
@@ -436,6 +436,7 @@
     <Compile Include="Framework\Graph\GraphHttpClient.cs" />
     <Compile Include="Framework\Graph\Model\DirectorySettingValue.cs" />
     <Compile Include="Framework\Graph\Model\SiteClassificationsSettings.cs" />
+    <Compile Include="Framework\Graph\Model\GroupExtended.cs" />
     <Compile Include="Framework\Provisioning\Model\BaseHierarchyModel.cs" />
     <Compile Include="Framework\Provisioning\Model\BaseProvisioningTemplateObjectCollection.cs" />
     <Compile Include="Framework\Provisioning\Model\CommunicationSiteCollection.cs" />


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no
| Related issues?  | fixes https://github.com/SharePoint/PnP-Sites-Core/issues/1987

#### What's in this Pull Request?

Allows to create groups with owners and members using single API call. It helps to avoid "Resource provisioning is in progress. Please try again" error during groups provisioning.