### PR TITLE
Feature - set additional properties while provisioning modern sites + bug fix

### DIFF
--- a/Core/OfficeDevPnP.Core/Sites/SiteCollection.cs
+++ b/Core/OfficeDevPnP.Core/Sites/SiteCollection.cs
@@ -392,7 +392,11 @@ namespace OfficeDevPnP.Core.Sites
                         var responseJson = JObject.Parse(responseString);
 
                         // SiteStatus 1 = Provisioning, SiteStatus 2 = Ready
+#if !NETSTANDARD2_0
                         if (Convert.ToInt32(responseJson["SiteStatus"]) == 2 || Convert.ToInt32(responseJson["SiteStatus"]) == 1)
+#else
+                        if (responseJson["SiteStatus"].Value<int>() == 2 || responseJson["SiteStatus"].Value<int>() == 1)
+#endif                  
                         {
                             responseContext = clientContext;
                         }

--- a/Core/OfficeDevPnP.Core/Sites/SiteCollection.cs
+++ b/Core/OfficeDevPnP.Core/Sites/SiteCollection.cs
@@ -100,7 +100,7 @@ namespace OfficeDevPnP.Core.Sites
                     var siteDesignId = GetSiteDesignId(siteCollectionCreationInformation);
 
                     Dictionary<string, object> payload = new Dictionary<string, object>();
-                    payload.Add("__metadata", new { type = "Microsoft.SharePoint.Portal.SPSiteCreationRequest" });
+                    //payload.Add("__metadata", new { type = "Microsoft.SharePoint.Portal.SPSiteCreationRequest" });
                     payload.Add("Title", siteCollectionCreationInformation.Title);
                     payload.Add("Lcid", siteCollectionCreationInformation.Lcid);
                     payload.Add("ShareByEmailEnabled", siteCollectionCreationInformation.ShareByEmailEnabled);
@@ -111,10 +111,11 @@ namespace OfficeDevPnP.Core.Sites
                     {
                         payload.Add("SiteDesignId", siteDesignId);
                     }
-                    payload.Add("Classification", siteCollectionCreationInformation.Classification == null ? "" : siteCollectionCreationInformation.Classification);
-                    payload.Add("Description", siteCollectionCreationInformation.Description == null ? "" : siteCollectionCreationInformation.Description);
+                    payload.Add("Classification", siteCollectionCreationInformation.Classification ?? "");
+                    payload.Add("Description", siteCollectionCreationInformation.Description ?? "");
                     payload.Add("WebTemplate", "SITEPAGEPUBLISHING#0");
                     payload.Add("WebTemplateExtensionId", Guid.Empty);
+                    payload.Add("HubSiteId", siteCollectionCreationInformation.HubSiteId);
 
                     var body = new { request = payload };
 
@@ -125,9 +126,10 @@ namespace OfficeDevPnP.Core.Sites
                     // Build Http request
                     HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, requestUrl);
                     request.Content = requestBody;
-                    request.Headers.Add("accept", "application/json;odata=verbose");
+                    request.Headers.Add("accept", "application/json;odata.metadata=none");
+                    request.Headers.Add("odata-version", "4.0");
                     MediaTypeHeaderValue sharePointJsonMediaType = null;
-                    MediaTypeHeaderValue.TryParse("application/json;odata=verbose;charset=utf-8", out sharePointJsonMediaType);
+                    MediaTypeHeaderValue.TryParse("application/json;odata.metadata=none;charset=utf-8", out sharePointJsonMediaType);
                     requestBody.Headers.ContentType = sharePointJsonMediaType;
 
                     if (!string.IsNullOrEmpty(accessToken))
@@ -150,12 +152,12 @@ namespace OfficeDevPnP.Core.Sites
                             {
                                 var responseJson = JObject.Parse(responseString);
 #if !NETSTANDARD2_0
-                                if (Convert.ToInt32(responseJson["d"]["Create"]["SiteStatus"]) == 2)
+                                if (Convert.ToInt32(responseJson["SiteStatus"]) == 2)
 #else
-                                if(responseJson["d"]["Create"]["SiteStatus"].Value<int>() == 2)
+                                if(responseJson["SiteStatus"].Value<int>() == 2)
 #endif
                                 {
-                                    responseContext = clientContext.Clone(responseJson["d"]["Create"]["SiteUrl"].ToString());
+                                    responseContext = clientContext.Clone(responseJson["SiteUrl"].ToString());
                                 }
                                 else
                                 {
@@ -220,9 +222,20 @@ namespace OfficeDevPnP.Core.Sites
                     payload.Add("isPublic", siteCollectionCreationInformation.IsPublic);
 
                     var optionalParams = new Dictionary<string, object>();
-                    optionalParams.Add("Description", siteCollectionCreationInformation.Description != null ? siteCollectionCreationInformation.Description : "");
-                    optionalParams.Add("CreationOptions", new { results = siteCollectionCreationInformation.Lcid != 0 ? new[] { $"SPSiteLanguage:{siteCollectionCreationInformation.Lcid}" } : new object[0], Classification = siteCollectionCreationInformation.Classification != null ? siteCollectionCreationInformation.Classification : "" });
+                    optionalParams.Add("Description", siteCollectionCreationInformation.Description ?? "");
+                    optionalParams.Add("Classification", siteCollectionCreationInformation.Classification ?? "");
+                    var creationOptionsValues = new List<string>();
+                    if (siteCollectionCreationInformation.Lcid != 0)
+                    {
+                        creationOptionsValues.Add($"SPSiteLanguage:{siteCollectionCreationInformation.Lcid}");
+                    }
+                    creationOptionsValues.Add($"HubSiteId:{siteCollectionCreationInformation.HubSiteId}");
+                    optionalParams.Add("CreationOptions", creationOptionsValues);
 
+                    if (siteCollectionCreationInformation.Owners != null && siteCollectionCreationInformation.Owners.Length > 0)
+                    {
+                        optionalParams.Add("Owners", siteCollectionCreationInformation.Owners);
+                    }
                     payload.Add("optionalParams", optionalParams);
 
                     var body = payload;
@@ -234,9 +247,10 @@ namespace OfficeDevPnP.Core.Sites
                     // Build Http request
                     HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, requestUrl);
                     request.Content = requestBody;
-                    request.Headers.Add("accept", "application/json;odata=verbose");
+                    request.Headers.Add("accept", "application/json;odata.metadata=none");
+                    request.Headers.Add("odata-version", "4.0");
                     MediaTypeHeaderValue sharePointJsonMediaType = null;
-                    MediaTypeHeaderValue.TryParse("application/json;odata=verbose;charset=utf-8", out sharePointJsonMediaType);
+                    MediaTypeHeaderValue.TryParse("application/json;odata.metadata=none;charset=utf-8", out sharePointJsonMediaType);
                     requestBody.Headers.ContentType = sharePointJsonMediaType;
 
                     if (!string.IsNullOrEmpty(accessToken))
@@ -255,12 +269,12 @@ namespace OfficeDevPnP.Core.Sites
                         var responseString = await response.Content.ReadAsStringAsync();
                         var responseJson = JObject.Parse(responseString);
 #if !NETSTANDARD2_0
-                        if (Convert.ToInt32(responseJson["d"]["CreateGroupEx"]["SiteStatus"]) == 2)
+                        if (Convert.ToInt32(responseJson["SiteStatus"]) == 2)
 #else
-                        if (responseJson["d"]["CreateGroupEx"]["SiteStatus"].Value<int>() == 2)
+                        if (responseJson["SiteStatus"].Value<int>() == 2)
 #endif
                         {
-                            responseContext = clientContext.Clone(responseJson["d"]["CreateGroupEx"]["SiteUrl"].ToString());
+                            responseContext = clientContext.Clone(responseJson["SiteUrl"].ToString());
                         }
                         else
                         {
@@ -329,19 +343,20 @@ namespace OfficeDevPnP.Core.Sites
                     payload.Add("isPublic", siteCollectionGroupifyInformation.IsPublic);
 
                     var optionalParams = new Dictionary<string, object>();
-                    optionalParams.Add("Description", siteCollectionGroupifyInformation.Description != null ? siteCollectionGroupifyInformation.Description : "");
-
+                    optionalParams.Add("Description", siteCollectionGroupifyInformation.Description ?? "");
+                    optionalParams.Add("Classification", siteCollectionGroupifyInformation.Classification ?? "");
                     // Handle groupify options
                     var creationOptionsValues = new List<string>();
                     if (siteCollectionGroupifyInformation.KeepOldHomePage)
                     {
                         creationOptionsValues.Add("SharePointKeepOldHomepage");
                     }
-                    var creationOptions = new Dictionary<string, object>();
-                    creationOptions.Add("results", creationOptionsValues.ToArray());
-                    optionalParams.Add("CreationOptions", creationOptions);
-
-                    optionalParams.Add("Classification", siteCollectionGroupifyInformation.Classification != null ? siteCollectionGroupifyInformation.Classification : "");
+                    creationOptionsValues.Add($"HubSiteId:{siteCollectionGroupifyInformation.HubSiteId}");
+                    optionalParams.Add("CreationOptions", creationOptionsValues);
+                    if (siteCollectionGroupifyInformation.Owners != null && siteCollectionGroupifyInformation.Owners.Length > 0)
+                    {
+                        optionalParams.Add("Owners", siteCollectionGroupifyInformation.Owners);
+                    }
 
                     payload.Add("optionalParams", optionalParams);
 
@@ -354,9 +369,10 @@ namespace OfficeDevPnP.Core.Sites
                     // Build Http request
                     HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, requestUrl);
                     request.Content = requestBody;
-                    request.Headers.Add("accept", "application/json;odata=verbose");
+                    request.Headers.Add("accept", "application/json;odata.metadata=none");
+                    request.Headers.Add("odata-version", "4.0");
                     MediaTypeHeaderValue sharePointJsonMediaType = null;
-                    MediaTypeHeaderValue.TryParse("application/json;odata=verbose;charset=utf-8", out sharePointJsonMediaType);
+                    MediaTypeHeaderValue.TryParse("application/json;odata.metadata=none;charset=utf-8", out sharePointJsonMediaType);
                     requestBody.Headers.ContentType = sharePointJsonMediaType;
 
                     if (!string.IsNullOrEmpty(accessToken))
@@ -376,7 +392,7 @@ namespace OfficeDevPnP.Core.Sites
                         var responseJson = JObject.Parse(responseString);
 
                         // SiteStatus 1 = Provisioning, SiteStatus 2 = Ready
-                        if (Convert.ToInt32(responseJson["d"]["CreateGroupForSite"]["SiteStatus"]) == 2 || Convert.ToInt32(responseJson["d"]["CreateGroupForSite"]["SiteStatus"]) == 1)
+                        if (Convert.ToInt32(responseJson["SiteStatus"]) == 2 || Convert.ToInt32(responseJson["SiteStatus"]) == 1)
                         {
                             responseContext = clientContext;
                         }
@@ -451,7 +467,7 @@ namespace OfficeDevPnP.Core.Sites
                 {
                     string requestUrl = String.Format("{0}/_api/SP.Directory.DirectorySession/Group(alias='{1}')", context.Web.Url, alias);
                     HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, requestUrl);
-                    request.Headers.Add("accept", "application/json;odata.metadata=minimal");
+                    request.Headers.Add("accept", "application/json;odata.metadata=none");
                     httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
                     request.Headers.Add("odata-version", "4.0");
 
@@ -509,7 +525,7 @@ namespace OfficeDevPnP.Core.Sites
                 {
                     string requestUrl = String.Format("{0}/_api/SP.Directory.DirectorySession/Group(alias='{1}')", context.Web.Url, alias);
                     HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, requestUrl);
-                    request.Headers.Add("accept", "application/json;odata.metadata=minimal");
+                    request.Headers.Add("accept", "application/json;odata.metadata=none");
                     httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
                     request.Headers.Add("odata-version", "4.0");
 
@@ -599,7 +615,7 @@ namespace OfficeDevPnP.Core.Sites
                 {
                     string requestUrl = String.Format("{0}/_api/GroupSiteManager/GetValidSiteUrlFromAlias?alias='{1}'", context.Web.Url, alias);
                     HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, requestUrl);
-                    request.Headers.Add("accept", "application/json;odata.metadata=minimal");
+                    request.Headers.Add("accept", "application/json;odata.metadata=none");
                     httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
                     request.Headers.Add("odata-version", "4.0");
 

--- a/Core/OfficeDevPnP.Core/Sites/SiteCollectionCreationInformation.cs
+++ b/Core/OfficeDevPnP.Core/Sites/SiteCollectionCreationInformation.cs
@@ -73,6 +73,11 @@ namespace OfficeDevPnP.Core.Sites
         public uint Lcid { get; set; }
 
         /// <summary>
+        /// The Guid of the hub site to be used. If specified will associate the communication site to the hub site
+        /// </summary>
+        public Guid HubSiteId { get; set; }
+
+        /// <summary>
         /// Default constructor
         /// </summary>
         public CommunicationSiteCollectionCreationInformation()
@@ -181,6 +186,16 @@ namespace OfficeDevPnP.Core.Sites
         public string Classification { get; set; }
 
         public uint Lcid { get; set; }
+
+        /// <summary>
+        /// Set the owners of the modern team site. Just specify the UPN values in a string array
+        /// </summary>
+        public string[] Owners { get; set; }
+
+        /// <summary>
+        /// The Guid of the hub site to be used. If specified will associate the modern team site to the hub site
+        /// </summary>
+        public Guid HubSiteId { get; set; }
 
         public SiteCreationInformation()
         {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| New sample?      | no
| Related issues?  | fixes https://github.com/SharePoint/PnP-PowerShell/issues/1688 , #2016 

#### What's in this Pull Request?

1) Added support for HubSiteId in Modern sites
2) Added support to add additional owners for Modern team site and while Groupifying classic sites
3) Fixed site classification issue for Modern team sites and Groupified sites
4) Changed OData JSON format specification to v4 while provisioning modern sites
5) Made use of JSON light to reduce payload