### PR TITLE
Provision and extract associated groups

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectSiteSecurityTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectSiteSecurityTests.cs
@@ -6,6 +6,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OfficeDevPnP.Core.Entities;
 using OfficeDevPnP.Core.Framework.Provisioning.Model;
 using OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers;
+using OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitions;
 using OfficeDevPnP.Core.Utilities;
 using User = OfficeDevPnP.Core.Framework.Provisioning.Model.User;
 
@@ -14,8 +15,27 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
     [TestClass]
     public class ObjectSiteSecurityTests
     {
-
         private List<UserEntity> admins;
+        private readonly string ownerGroupName;
+        private readonly string memberGroupName;
+        private readonly string visitorGroupName;
+        private readonly string testWebName;
+
+        private int ownerGroupId;
+        private int memberGroupId;
+        private int visitorGroupId;
+
+        private int originalAssociatedOwnerGroupId;
+        private int originalAssociatedMemberGroupId;
+        private int originalAssociatedVisitorGroupId;
+
+        public ObjectSiteSecurityTests()
+        {
+            ownerGroupName = string.Format("Test_Owner Group_{0}", DateTime.Now.Ticks);
+            memberGroupName = string.Format("Test_Member Group_{0}", DateTime.Now.Ticks);
+            visitorGroupName = string.Format("Test_Visitor Group_{0}", DateTime.Now.Ticks);
+            testWebName = string.Format("Test_{0:yyyyMMddTHHmmss}", DateTimeOffset.Now);
+        }
 
         [TestInitialize]
         public void Initialize()
@@ -24,7 +44,48 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
             using (var ctx = TestCommon.CreateClientContext())
             {
                 admins = ctx.Web.GetAdministrators();
+
+                Web web = ctx.Web;
+
+                ctx.Load(web,
+                    w => w.AssociatedOwnerGroup.Id,
+                    w => w.AssociatedMemberGroup.Id,
+                    w => w.AssociatedVisitorGroup.Id);
+                ctx.ExecuteQuery();
+
+                originalAssociatedOwnerGroupId = web.AssociatedOwnerGroup.ServerObjectIsNull == true ? -1 : web.AssociatedOwnerGroup.Id;
+                originalAssociatedMemberGroupId = web.AssociatedMemberGroup.ServerObjectIsNull == true ? -1 : web.AssociatedMemberGroup.Id;
+                originalAssociatedVisitorGroupId = web.AssociatedVisitorGroup.ServerObjectIsNull == true ? -1 : web.AssociatedVisitorGroup.Id;
             }
+        }
+
+        public void InitializeAssociatedGroups(ClientContext ctx)
+        {
+            Web web = ctx.Web;
+
+            Group ownerGroup = web.SiteGroups.Add(new GroupCreationInformation
+            {
+                Title = ownerGroupName
+            });
+
+            Group memberGroup = web.SiteGroups.Add(new GroupCreationInformation
+            {
+                Title = memberGroupName
+            });
+
+            Group visitorGroup = web.SiteGroups.Add(new GroupCreationInformation
+            {
+                Title = visitorGroupName
+            });
+
+            ctx.Load(ownerGroup, og => og.Id);
+            ctx.Load(memberGroup, mg => mg.Id);
+            ctx.Load(visitorGroup, vg => vg.Id);
+            ctx.ExecuteQuery();
+
+            ownerGroupId = ownerGroup.Id;
+            memberGroupId = memberGroup.Id;
+            visitorGroupId = visitorGroup.Id;
         }
 
         [TestCleanup]
@@ -35,15 +96,18 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                 var memberGroup = ctx.Web.AssociatedMemberGroup;
                 ctx.Load(memberGroup);
                 ctx.ExecuteQueryRetry();
-                foreach (var user in admins)
+                if (memberGroup.ServerObjectIsNull == false)
                 {
-                    try
+                    foreach (var user in admins)
                     {
-                        ctx.Web.RemoveUserFromGroup(memberGroup.Title, user.LoginName);
-                    }
-                    catch (ServerException)
-                    {
+                        try
+                        {
+                            ctx.Web.RemoveUserFromGroup(memberGroup.Title, user.LoginName);
+                        }
+                        catch (ServerException)
+                        {
 
+                        }
                     }
                 }
 
@@ -66,6 +130,80 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                         ctx.Web.SiteGroups.Remove(group);
                     }
                     ctx.ExecuteQueryRetry();
+                }
+                Web web = ctx.Web;
+
+                //ConditionalScope associatedOwnerScope = new ConditionalScope(ctx, () => web.AssociatedOwnerGroup.ServerObjectIsNull == false);
+                //using (associatedOwnerScope.StartScope())
+                //{
+                //    ctx.Load(web, w => w.AssociatedOwnerGroup.Id);
+                //}
+
+                //ConditionalScope associatedMemberScope = new ConditionalScope(ctx, () => web.AssociatedMemberGroup.ServerObjectIsNull == false);
+                //using (associatedMemberScope.StartScope())
+                //{
+                //    ctx.Load(web, w => w.AssociatedMemberGroup.Id);
+                //}
+
+                //ConditionalScope associatedVisitorScope = new ConditionalScope(ctx, () => web.AssociatedVisitorGroup.ServerObjectIsNull == false);
+                //using (associatedVisitorScope.StartScope())
+                //{
+                //    ctx.Load(web, w => w.AssociatedVisitorGroup.Id);
+                //}
+
+                //ctx.ExecuteQuery();
+
+                bool webIsDirty = false;
+
+                if (originalAssociatedOwnerGroupId > 0)
+                {
+                    web.AssociatedOwnerGroup = web.SiteGroups.GetById(originalAssociatedOwnerGroupId);
+                    webIsDirty = true;
+                }
+
+                if (originalAssociatedMemberGroupId > 0)
+                {
+                    web.AssociatedMemberGroup = web.SiteGroups.GetById(originalAssociatedMemberGroupId);
+                    webIsDirty = true;
+                }
+
+                if (originalAssociatedVisitorGroupId > 0)
+                {
+                    web.AssociatedVisitorGroup = web.SiteGroups.GetById(originalAssociatedVisitorGroupId);
+                    webIsDirty = true;
+                }
+
+                if (webIsDirty)
+                {
+                    web.Update();
+                }
+
+                var subWebs = ctx.Web.Webs;
+                ctx.Load(subWebs, wc => wc.Include(w => w.Title, w => w.ServerRelativeUrl));
+                ctx.ExecuteQueryRetry();
+
+                var websToDelete = new List<Web>();
+
+                foreach (var subWeb in subWebs)
+                {
+                    if (subWeb.Title.StartsWith("Test_"))
+                    {
+                        websToDelete.Add(subWeb);
+                    }
+                }
+
+                foreach (var webToDelete in websToDelete)
+                {
+                    Console.WriteLine("Deleting site {0}", webToDelete.ServerRelativeUrl);
+                    webToDelete.DeleteObject();
+                    try
+                    {
+                        ctx.ExecuteQueryRetry();
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.WriteLine("Exception cleaning up: {0}", ex);
+                    }
                 }
             }
         }
@@ -111,6 +249,13 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
         {
             using (var ctx = TestCommon.CreateClientContext())
             {
+                Web web = ctx.Web;
+                ctx.Load(web,
+                    w => w.AssociatedOwnerGroup.Title,
+                    w => w.AssociatedMemberGroup.Title,
+                    w => w.AssociatedVisitorGroup.Title);
+                ctx.ExecuteQuery();
+
                 // Load the base template which will be used for the comparison work
                 var creationInfo = new ProvisioningTemplateCreationInformation(ctx.Web) { BaseTemplate = ctx.Web.GetBaseTemplate() };
 
@@ -118,6 +263,9 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                 template = new ObjectSiteSecurity().ExtractObjects(ctx.Web, template, creationInfo);
 
                 Assert.IsTrue(template.Security.AdditionalAdministrators.Any());
+                Assert.AreEqual(web.AssociatedOwnerGroup.Title, template.Security.AssociatedOwnerGroup);
+                Assert.AreEqual(web.AssociatedMemberGroup.Title, template.Security.AssociatedMemberGroup);
+                Assert.AreEqual(web.AssociatedVisitorGroup.Title, template.Security.AssociatedVisitorGroup);
             }
         }
 
@@ -188,6 +336,133 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
 
                 Assert.AreEqual(richHtmlDescriptionPlainTextVersion, htmlGroup.Description);
                 Assert.AreEqual(richHtmlDescription, htmlGroupItem["Notes"]);
+            }
+        }
+
+        [TestMethod()]
+        public void CanProvisionAssociatedGroups()
+        {
+            ProvisioningTemplate template = new ProvisioningTemplate();
+            template.Security.AssociatedOwnerGroup = ownerGroupName;
+            template.Security.AssociatedMemberGroup = memberGroupName;
+            template.Security.AssociatedVisitorGroup = visitorGroupName;
+            foreach (var user in admins)
+            {
+                template.Security.AdditionalMembers.Add(new User() { Name = user.LoginName });
+            }
+
+            using (var ctx = TestCommon.CreateClientContext())
+            {
+                InitializeAssociatedGroups(ctx);
+                Web web = ctx.Web;
+
+                var parser = new TokenParser(ctx.Web, template);
+                new ObjectSiteSecurity().ProvisionObjects(web, template, parser, new ProvisioningTemplateApplyingInformation());
+
+                ctx.Load(web,
+                    w => w.AssociatedOwnerGroup.Id,
+                    w => w.AssociatedMemberGroup.Id,
+                    w => w.AssociatedVisitorGroup.Id);
+                ctx.ExecuteQuery();
+
+                Assert.AreEqual(ownerGroupId, web.AssociatedOwnerGroup.Id, "Associated owner group ID mismatch.");
+                Assert.AreEqual(memberGroupId, web.AssociatedMemberGroup.Id, "Associated member group ID mismatch.");
+                Assert.AreEqual(visitorGroupId, web.AssociatedVisitorGroup.Id, "Associated visitor group ID mismatch.");
+                IEnumerable<AssociatedGroupToken> associatedGroupTokens = parser.Tokens.Where(t => t.GetType() == typeof(AssociatedGroupToken)).Cast<AssociatedGroupToken>();
+
+                AssociatedGroupToken associatedOwnerGroupToken = associatedGroupTokens.FirstOrDefault(t => t.GroupType == AssociatedGroupToken.AssociatedGroupType.owners);
+                AssociatedGroupToken associatedMemberGroupToken = associatedGroupTokens.FirstOrDefault(t => t.GroupType == AssociatedGroupToken.AssociatedGroupType.members);
+                AssociatedGroupToken associatedVisitorGroupToken = associatedGroupTokens.FirstOrDefault(t => t.GroupType == AssociatedGroupToken.AssociatedGroupType.visitors);
+
+                Assert.IsNotNull(associatedOwnerGroupToken);
+                Assert.IsNotNull(associatedMemberGroupToken);
+                Assert.IsNotNull(associatedVisitorGroupToken);
+
+                Assert.AreEqual(ownerGroupName, associatedOwnerGroupToken.GetReplaceValue());
+                Assert.AreEqual(memberGroupName, associatedMemberGroupToken.GetReplaceValue());
+                Assert.AreEqual(visitorGroupName, associatedVisitorGroupToken.GetReplaceValue());
+
+                foreach (var user in admins)
+                {
+                    var existingUser = web.AssociatedMemberGroup.Users.GetByLoginName(user.LoginName);
+                    ctx.Load(existingUser);
+                    ctx.ExecuteQueryRetry();
+                    Assert.IsNotNull(existingUser);
+                }
+
+            }
+        }
+
+        [TestMethod()]
+        public void CanProvisionAssociatedGroupsInSubSite()
+        {
+            ProvisioningTemplate template = new ProvisioningTemplate();
+            template.Security.AssociatedOwnerGroup = ownerGroupName;
+            template.Security.AssociatedMemberGroup = memberGroupName;
+            template.Security.AssociatedVisitorGroup = visitorGroupName;
+            template.Security.BreakRoleInheritance = true;
+            template.Security.CopyRoleAssignments = false;
+            template.Security.ClearSubscopes = true;
+
+            using (var clientContext = TestCommon.CreateClientContext())
+            {
+                InitializeAssociatedGroups(clientContext);
+
+                Web web = clientContext.Web;
+                Web subWeb = web.CreateWeb(testWebName, testWebName, "Test", "STS#0", 1033);
+                clientContext.ExecuteQuery();
+
+                var parser = new TokenParser(clientContext.Web, template);
+                new ObjectSiteSecurity().ProvisionObjects(subWeb, template, parser, new ProvisioningTemplateApplyingInformation());
+
+                subWeb.Context.Load(subWeb,
+                    w => w.AssociatedOwnerGroup.Id,
+                    w => w.AssociatedMemberGroup.Id,
+                    w => w.AssociatedVisitorGroup.Id);
+                clientContext.ExecuteQuery();
+
+                Assert.AreEqual(ownerGroupId, subWeb.AssociatedOwnerGroup.Id, "Associated owner group ID mismatch.");
+                Assert.AreEqual(memberGroupId, subWeb.AssociatedMemberGroup.Id, "Associated member group ID mismatch.");
+                Assert.AreEqual(visitorGroupId, subWeb.AssociatedVisitorGroup.Id, "Associated visitor group ID mismatch.");
+            }
+        }
+
+        [TestMethod()]
+        public void CanProvisionNewAssociatedGroup()
+        {
+            ProvisioningTemplate template = new ProvisioningTemplate();
+
+            SiteGroup membersGroup = new SiteGroup()
+            {
+                Title = string.Format("Test_New Group_{0}", DateTime.Now.Ticks),
+            };
+            string ownersGroupTitle = string.Format("Test_New Group2_{0}", DateTime.Now.Ticks);
+
+            template.Security.SiteGroups.Add(membersGroup);
+            template.Security.AssociatedMemberGroup = membersGroup.Title;
+            template.Security.AssociatedOwnerGroup = ownersGroupTitle;
+            template.Security.AssociatedVisitorGroup = "";
+
+            using (var clientContext = TestCommon.CreateClientContext())
+            {
+                Web web = clientContext.Web;
+
+                var parser = new TokenParser(clientContext.Web, template);
+                new ObjectSiteSecurity().ProvisionObjects(web, template, parser, new ProvisioningTemplateApplyingInformation());
+            }
+            using (var clientContext = TestCommon.CreateClientContext())
+            {
+                Web web = clientContext.Web;
+
+                clientContext.Load(web,
+                    w => w.AssociatedOwnerGroup.Title,
+                    w => w.AssociatedMemberGroup.Title,
+                    w => w.AssociatedVisitorGroup);
+                clientContext.ExecuteQuery();
+
+                Assert.AreEqual(ownersGroupTitle, web.AssociatedOwnerGroup.Title, "Associated owner group ID mismatch.");
+                Assert.AreEqual(membersGroup.Title, web.AssociatedMemberGroup.Title, "Associated member group ID mismatch.");
+                Assert.IsTrue(web.AssociatedVisitorGroup.ServerObjectIsNull.Value);
             }
         }
     }

--- a/Core/OfficeDevPnP.Core/Extensions/ClientObjectExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/ClientObjectExtensions.cs
@@ -19,9 +19,13 @@ namespace Microsoft.SharePoint.Client
         /// <returns>True if the server object is null, otherwise false</returns>
         public static bool ServerObjectIsNull<T>(this T clientObject) where T : ClientObject
         {
-            return (!(clientObject.ServerObjectIsNull != null && 
-                clientObject.ServerObjectIsNull.HasValue && 
-                !clientObject.ServerObjectIsNull.Value));
+            if (clientObject == null)
+            {
+                return true;
+            }
+            return (!(clientObject.ServerObjectIsNull != null &&
+            clientObject.ServerObjectIsNull.HasValue &&
+            !clientObject.ServerObjectIsNull.Value));
         }
 
         /// <summary>

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
@@ -35,21 +35,94 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 {
                     web.BreakRoleInheritance(template.Security.CopyRoleAssignments, template.Security.ClearSubscopes);
                     web.Update();
+                    web.Context.Load(web, w => w.HasUniqueRoleAssignments);
                     web.Context.ExecuteQueryRetry();
                 }
 
                 var siteSecurity = template.Security;
 
+                if (web.EnsureProperty(w => w.HasUniqueRoleAssignments))
+                {
+                    string parsedAssociatedOwnerGroupName = parser.ParseString(template.Security.AssociatedOwnerGroup);
+                    string parsedAssociatedMemberGroupName = parser.ParseString(template.Security.AssociatedMemberGroup);
+                    string parsedAssociatedVisitorGroupName = parser.ParseString(template.Security.AssociatedVisitorGroup);
+
+                    bool webNeedsUpdate = false;
+
+                    if (parsedAssociatedOwnerGroupName != null)
+                    {
+                        if (string.IsNullOrEmpty(parsedAssociatedOwnerGroupName))
+                        {
+                            web.AssociatedOwnerGroup = null;
+                        }
+                        else
+                        {
+                            web.AssociatedOwnerGroup = EnsureGroup(web, parsedAssociatedOwnerGroupName);
+                        }
+
+                        webNeedsUpdate = true;
+                    }
+
+                    if (parsedAssociatedMemberGroupName != null)
+                    {
+                        if (string.IsNullOrEmpty(parsedAssociatedMemberGroupName))
+                        {
+                            web.AssociatedMemberGroup = null;
+                        }
+                        else
+                        {
+                            web.AssociatedMemberGroup = EnsureGroup(web, parsedAssociatedMemberGroupName);
+                        }
+
+                        webNeedsUpdate = true;
+                    }
+
+                    if (parsedAssociatedVisitorGroupName != null)
+                    {
+                        if (string.IsNullOrEmpty(parsedAssociatedVisitorGroupName))
+                        {
+                            web.AssociatedVisitorGroup = null;
+                        }
+                        else
+                        {
+                            web.AssociatedVisitorGroup = EnsureGroup(web, parsedAssociatedVisitorGroupName);
+                        }
+
+                        webNeedsUpdate = true;
+                    }
+
+                    if (webNeedsUpdate)
+                    {
+                        web.Update();
+                    }
+                }
+
                 var ownerGroup = web.AssociatedOwnerGroup;
                 var memberGroup = web.AssociatedMemberGroup;
                 var visitorGroup = web.AssociatedVisitorGroup;
 
-                web.Context.Load(ownerGroup, o => o.Title, o => o.Users);
-                web.Context.Load(memberGroup, o => o.Title, o => o.Users);
-                web.Context.Load(visitorGroup, o => o.Title, o => o.Users);
+                if (!PnPUtility.ServerObjectIsNull(ownerGroup))
+                {
+                    web.Context.Load(ownerGroup, o => o.Title, o => o.Users);
+                }
+                if (!PnPUtility.ServerObjectIsNull(memberGroup))
+                {
+                    web.Context.Load(memberGroup, o => o.Title, o => o.Users);
+                }
+                if (!PnPUtility.ServerObjectIsNull(visitorGroup))
+                {
+                    web.Context.Load(visitorGroup, o => o.Title, o => o.Users);
+                }
+
                 web.Context.Load(web.SiteUsers);
 
                 web.Context.ExecuteQueryRetry();
+
+                IEnumerable<AssociatedGroupToken> associatedGroupTokens = parser.Tokens.Where(t => t.GetType() == typeof(AssociatedGroupToken)).Cast<AssociatedGroupToken>();
+                foreach (AssociatedGroupToken associatedGroupToken in associatedGroupTokens)
+                {
+                    associatedGroupToken.ClearCache();
+                }
 
                 if (!ownerGroup.ServerObjectIsNull())
                 {
@@ -65,19 +138,19 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 }
 
                 foreach (var siteGroup in siteSecurity.SiteGroups
-                        .Sort<SiteGroup>(
-                            _grp => {
-                                string groupOwner = _grp.Owner;
-                                if (string.IsNullOrWhiteSpace(groupOwner)
-                                    || "SHAREPOINT\\system".Equals(groupOwner, StringComparison.OrdinalIgnoreCase)
-                                    || _grp.Title.Equals(groupOwner, StringComparison.OrdinalIgnoreCase)
-                                    || (groupOwner.StartsWith("{{associated") && groupOwner.EndsWith("group}}")))
-                                {
-                                    return Enumerable.Empty<SiteGroup>();
-                                }
-                                return siteSecurity.SiteGroups.Where(_item => _item.Title.Equals(groupOwner, StringComparison.OrdinalIgnoreCase));
-                            }
-                    ))
+        .Sort<SiteGroup>(
+            _grp => {
+                string groupOwner = _grp.Owner;
+                if (string.IsNullOrWhiteSpace(groupOwner)
+                    || "SHAREPOINT\\system".Equals(groupOwner, StringComparison.OrdinalIgnoreCase)
+                    || _grp.Title.Equals(groupOwner, StringComparison.OrdinalIgnoreCase)
+                    || (groupOwner.StartsWith("{{associated") && groupOwner.EndsWith("group}}")))
+                {
+                    return Enumerable.Empty<SiteGroup>();
+                }
+                return siteSecurity.SiteGroups.Where(_item => _item.Title.Equals(groupOwner, StringComparison.OrdinalIgnoreCase));
+            }
+    ))
                 {
                     Group group;
                     var allGroups = web.Context.LoadQuery(web.SiteGroups.Include(gr => gr.LoginName));
@@ -101,7 +174,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         group.OnlyAllowMembersViewMembership = siteGroup.OnlyAllowMembersViewMembership;
                         group.RequestToJoinLeaveEmailSetting = siteGroup.RequestToJoinLeaveEmailSetting;
 
-                        if (parsedGroupTitle != parsedGroupOwner)
+                        if (parsedGroupOwner != null && (parsedGroupTitle != parsedGroupOwner))
                         {
                             Principal ownerPrincipal = allGroups.FirstOrDefault(gr => gr.LoginName.Equals(parsedGroupOwner, StringComparison.OrdinalIgnoreCase));
                             if (ownerPrincipal == null)
@@ -109,8 +182,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                 ownerPrincipal = web.EnsureUser(parsedGroupOwner);
                             }
                             group.Owner = ownerPrincipal;
-
                         }
+
                         group.Update();
                         web.Context.Load(group, g => g.Id, g => g.Title);
                         web.Context.ExecuteQueryRetry();
@@ -139,7 +212,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         var groupNeedsUpdate = false;
                         var executeQuery = false;
 
-                        if (!String.IsNullOrEmpty(parsedGroupDescription))
+                        if (parsedGroupDescription != null)
                         {
                             var groupItem = web.SiteUserInfoList.GetItemById(group.Id);
                             web.Context.Load(groupItem, g => g["Notes"]);
@@ -187,7 +260,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                             group.RequestToJoinLeaveEmailSetting = siteGroup.RequestToJoinLeaveEmailSetting;
                             groupNeedsUpdate = true;
                         }
-                        if (group.Owner.LoginName != parsedGroupOwner)
+                        if (parsedGroupOwner != null && group.Owner.LoginName != parsedGroupOwner)
                         {
                             if (parsedGroupTitle != parsedGroupOwner)
                             {
@@ -363,6 +436,28 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             return parser;
         }
 
+        private static Group EnsureGroup(Web web, string groupName)
+        {
+            ExceptionHandlingScope ensureGroupScope = new ExceptionHandlingScope(web.Context);
+
+            using (ensureGroupScope.StartScope())
+            {
+                using (ensureGroupScope.StartTry())
+                {
+                    web.SiteGroups.GetByName(groupName);
+                }
+
+                using (ensureGroupScope.StartCatch())
+                {
+                    GroupCreationInformation groupCreationInfo = new GroupCreationInformation();
+                    groupCreationInfo.Title = groupName;
+                    web.SiteGroups.Add(groupCreationInfo);
+                }
+            }
+
+            return web.SiteGroups.GetByName(groupName);
+        }
+
         private static Principal GetPrincipal(Web web, TokenParser parser, PnPMonitoredScope scope, IEnumerable<Group> groups, Model.RoleAssignment roleAssignment)
         {
 
@@ -483,8 +578,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 var owners = new List<User>();
                 var members = new List<User>();
                 var visitors = new List<User>();
+                var siteSecurity = new SiteSecurity();
+
                 if (!ownerGroup.ServerObjectIsNull.Value)
                 {
+                    siteSecurity.AssociatedOwnerGroup = ownerGroup.Title;
                     associatedGroupIds.Add(ownerGroup.Id);
                     foreach (var member in ownerGroup.Users)
                     {
@@ -493,6 +591,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 }
                 if (!memberGroup.ServerObjectIsNull.Value)
                 {
+                    siteSecurity.AssociatedMemberGroup = memberGroup.Title;
                     associatedGroupIds.Add(memberGroup.Id);
                     foreach (var member in memberGroup.Users)
                     {
@@ -501,13 +600,13 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 }
                 if (!visitorGroup.ServerObjectIsNull.Value)
                 {
+                    siteSecurity.AssociatedVisitorGroup = visitorGroup.Title;
                     associatedGroupIds.Add(visitorGroup.Id);
                     foreach (var member in visitorGroup.Users)
                     {
                         visitors.Add(new User() { Name = member.LoginName });
                     }
                 }
-                var siteSecurity = new SiteSecurity();
                 siteSecurity.AdditionalOwners.AddRange(owners);
                 siteSecurity.AdditionalMembers.AddRange(members);
                 siteSecurity.AdditionalVisitors.AddRange(visitors);

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/AssociatedGroupToken.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/AssociatedGroupToken.cs
@@ -28,6 +28,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitio
             _groupType = groupType;
         }
 
+        internal AssociatedGroupType GroupType { get => _groupType; set => _groupType = value; }
+
         public override string GetReplaceValue()
         {
 

--- a/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
+++ b/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
@@ -1011,6 +1011,7 @@
     <Compile Include="Utilities\PnPCoreUtilities.cs" />
     <Compile Include="Utilities\PnPHttpProvider.cs" />
     <Compile Include="Utilities\PnPHttpUtility.cs" />
+    <Compile Include="Utilities\PnPUtility.cs" />
     <Compile Include="Utilities\RESTUtilities.cs" />
     <Compile Include="Utilities\Webhooks\ResponseModel.cs" />
     <Compile Include="Utilities\Webhooks\WebhookUtility.cs" />

--- a/Core/OfficeDevPnP.Core/Utilities/PnPUtility.cs
+++ b/Core/OfficeDevPnP.Core/Utilities/PnPUtility.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.SharePoint.Client;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OfficeDevPnP.Core.Utilities
+{
+    internal static class PnPUtility
+    {
+        /// <summary>
+        /// Checks if the ClientObject is null
+        /// </summary>        
+        /// <param name="clientObject">Object to check</param>
+        /// <returns>True if the server object is null, otherwise false</returns>
+        internal static bool ServerObjectIsNull(ClientObject clientObject)
+        {
+            if (clientObject == null)
+            {
+                return true;
+            }
+            else if (!clientObject.ServerObjectIsNull.HasValue)
+            {
+                return false;
+            }
+
+            return clientObject.ServerObjectIsNull.Value;
+        }
+    }
+}


### PR DESCRIPTION
…member/visitor groups

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?

Added support for provisioning and extracting associated owner, member, and visitor group.

I have changed the creation of groups in ObjectSiteSecurity to not require a group owner. This is not enforced by SharePoint, and will result in the current user to be the group owner. This needs to be changed in the schema too to be fully supported.

Changed group creation to support clearing description if it's an empty string in the schema.

I believe ClientObjectExtensions.ServerObjectIsNull is incorrectly implemented. I added a null check as the method could throw null reference exception. It also returns true when ClientObject.ServerObjectIsNull is null. This is undefined and should not return true as it can not be determined if the server object in fact is null. In order to not change the behaviour of this public method I was forced to create a new one in PnPUtility.