### PR TITLE
Update ClientContextExtensions.cs

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/ClientContextExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/ClientContextExtensions.cs
@@ -195,6 +195,11 @@ namespace Microsoft.SharePoint.Client
                             if (!Int32.TryParse(retryAfterHeader, out retryAfterInterval))
                             {
                                 retryAfterInterval = backoffInterval;
+                            } 
+                            else 
+                            {
+                                // The Retry-After is in seconds, so we need to convert to ms to use inside Task.Delay
+                                retryAfterInterval *= 1000;
                             }
                         }
                         else
@@ -219,7 +224,7 @@ namespace Microsoft.SharePoint.Client
                     }
                 }
             }
-            throw new MaximumRetryAttemptedException($"Maximum retry attempts {retryCount}, has be attempted.");
+            throw new MaximumRetryAttemptedException($"Maximum retry attempts {retryCount}, have been attempted.");
         }
 
         /// <summary>


### PR DESCRIPTION
The Retry-After header contains the back off time in seconds, so we need to transform them into ms if we received it.
Fixed exception message spelling

| Q               | A
| --------------- | ---
| Bug fix?        | yes?
| New feature?    | no?
| New sample?      | no?
| Related issues?  | fixes not waiting correct back off time

#### What's in this Pull Request?

Converts the Retry-After value to ms as long as is a valid integer.
