### PR TITLE
Add token parsing in `targetFileName` property of file object

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
@@ -51,7 +51,9 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 foreach (var file in filesToProcess)
                 {
                     file.Src = parser.ParseString(file.Src);
-                    var targetFileName = !String.IsNullOrEmpty(file.TargetFileName) ? file.TargetFileName : file.Src;
+                    var targetFileName = parser.ParseString(
+                        !String.IsNullOrEmpty(file.TargetFileName) ? file.TargetFileName : file.Src
+                        );
 
                     currentFileIndex++;
                     WriteMessage($"File|{targetFileName}|{currentFileIndex}|{filesToProcess.Length}", ProvisioningMessageType.Progress);
@@ -92,7 +94,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                             using (var stream = GetFileStream(template, file))
                             {
-                                targetFile = UploadFile(template, file, folder, stream);
+                                targetFile = UploadFile(folder, stream, targetFileName, file.Overwrite);
                             }
                         }
                         else
@@ -105,7 +107,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         using (var stream = GetFileStream(template, file))
                         {
                             scope.LogDebug(CoreResources.Provisioning_ObjectHandlers_Files_Uploading_file__0_, targetFileName);
-                            targetFile = UploadFile(template, file, folder, stream);
+                            targetFile = UploadFile(folder, stream, targetFileName, file.Overwrite);
                         }
 
                         checkedOut = CheckOutIfNeeded(web, targetFile);
@@ -415,13 +417,15 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             return _willExtract.Value;
         }
 
-        private static File UploadFile(ProvisioningTemplate template, Model.File file, Microsoft.SharePoint.Client.Folder folder, Stream stream)
+        private static File UploadFile(Microsoft.SharePoint.Client.Folder folder, Stream stream, string fileName, bool overwrite)
         {
+            if (folder == null) throw new ArgumentNullException(nameof(folder));
+            if (stream == null) throw new ArgumentNullException(nameof(stream));
+
             File targetFile = null;
-            var fileName = !String.IsNullOrEmpty(file.TargetFileName) ? file.TargetFileName : template.Connector.GetFilenamePart(file.Src);
             try
             {
-                targetFile = folder.UploadFile(fileName, stream, file.Overwrite);
+                targetFile = folder.UploadFile(fileName, stream, overwrite);
             }
             catch (ServerException ex)
             {
@@ -431,7 +435,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     fileName = WebUtility.UrlDecode(fileName);
                     try
                     {
-                        targetFile = folder.UploadFile(fileName, stream, file.Overwrite);
+                        targetFile = folder.UploadFile(fileName, stream, overwrite);
                     }
                     catch (Exception)
                     {
@@ -441,7 +445,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             }
             return targetFile;
         }
-
         /// <summary>
         /// Retrieves <see cref="Stream"/> from connector. If the file name contains special characters (e.g. "%20") and cannot be retrieved, a workaround will be performed
         /// </summary>
@@ -558,7 +561,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                 directory.Folder,
                                 directory.Overwrite,
                                 null, // No WebPartPages are supported with this technique
-                                metadataProperties != null && metadataProperties.ContainsKey(directory.Src + @"\" + file) ? 
+                                metadataProperties != null && metadataProperties.ContainsKey(directory.Src + @"\" + file) ?
                                     metadataProperties[directory.Src + @"\" + file] : null,
                                 directory.Security,
                                 directory.Level

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
@@ -52,7 +52,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 {
                     file.Src = parser.ParseString(file.Src);
                     var targetFileName = parser.ParseString(
-                        !String.IsNullOrEmpty(file.TargetFileName) ? file.TargetFileName : file.Src
+                        !String.IsNullOrEmpty(file.TargetFileName) ? file.TargetFileName : template.Connector.GetFilenamePart(file.Src)
                         );
 
                     currentFileIndex++;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no 
| New feature?    |  yes
| New sample?      | no 
| Related issues?  | 

#### What's in this Pull Request?

This PR contains a small adjustement to the `ObjectFilesHandler`. Its purpose is to allow token in file names.

For example, it allows setting filenames like:

```
<pnp:Files>
    <pnp:File Src="SiteAssets" 
              TargetFileName="logo-{parameter:CustomerNameEncoded}.png" 
              Folder="Assets/default-logo.png" 
              />
</pnp:Files>
```