### PR TITLE
Added UpdateChildren property to FieldRef to update/not-update inheriting content types

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/FieldAndContentTypeExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/FieldAndContentTypeExtensions.cs
@@ -987,13 +987,14 @@ namespace Microsoft.SharePoint.Client
         /// <param name="fieldId">The Id of the field</param>
         /// <param name="required">True if the field is required</param>
         /// <param name="hidden">True if the field is hidden</param>
-        public static void AddFieldById(this ContentType contentType, Guid fieldId, bool required = false, bool hidden = false)
+        /// <param name="updateChildren">True to update content types that inherit from the content type; otherwise, false.</param>
+        public static void AddFieldById(this ContentType contentType, Guid fieldId, bool required = false, bool hidden = false, bool updateChildren = true)
         {
             var ctx = contentType.Context as ClientContext;
             var field = ctx.Web.Fields.GetById(fieldId);
             ctx.Load(field);
             ctx.ExecuteQueryRetry();
-            AddFieldToContentType(ctx.Web, contentType, field, required, hidden);
+            AddFieldToContentType(ctx.Web, contentType, field, required, hidden, updateChildren);
         }
 
         /// <summary>
@@ -1003,14 +1004,15 @@ namespace Microsoft.SharePoint.Client
         /// <param name="fieldName">The title or internal name of the field</param>
         /// <param name="required">True if the field is required</param>
         /// <param name="hidden">True if the field is hidden</param>
-        public static void AddFieldByName(this ContentType contentType, string fieldName, bool required = false, bool hidden = false)
+        /// <param name="updateChildren">True to update content types that inherit from the content type; otherwise, false.</param>
+        public static void AddFieldByName(this ContentType contentType, string fieldName, bool required = false, bool hidden = false, bool updateChildren = true)
         {
             var ctx = contentType.Context as ClientContext;
             var field = ctx.Web.Fields.GetByInternalNameOrTitle(fieldName);
             ctx.Load(field);
             ctx.ExecuteQueryRetry();
 
-            AddFieldToContentType(ctx.Web, contentType, field, required, hidden);
+            AddFieldToContentType(ctx.Web, contentType, field, required, hidden, updateChildren);
         }
 
         /// <summary>
@@ -1021,7 +1023,8 @@ namespace Microsoft.SharePoint.Client
         /// <param name="fieldId">String representation of the field ID (=guid)</param>
         /// <param name="required">True if the field is required</param>
         /// <param name="hidden">True if the field is hidden</param>
-        public static void AddFieldToContentTypeById(this Web web, string contentTypeID, string fieldId, bool required = false, bool hidden = false)
+        /// <param name="updateChildren">True to update content types that inherit from the content type; otherwise, false.</param>
+        public static void AddFieldToContentTypeById(this Web web, string contentTypeID, string fieldId, bool required = false, bool hidden = false, bool updateChildren = true)
         {
             // Get content type
             var ct = web.GetContentTypeById(contentTypeID);
@@ -1033,7 +1036,7 @@ namespace Microsoft.SharePoint.Client
             var fld = web.Fields.GetById(new Guid(fieldId));
 
             // Add field association to content type
-            AddFieldToContentType(web, ct, fld, required, hidden);
+            AddFieldToContentType(web, ct, fld, required, hidden, updateChildren);
         }
 
         /// <summary>
@@ -1044,7 +1047,8 @@ namespace Microsoft.SharePoint.Client
         /// <param name="fieldID">Guid representation of the field ID</param>
         /// <param name="required">True if the field is required</param>
         /// <param name="hidden">True if the field is hidden</param>
-        public static void AddFieldToContentTypeByName(this Web web, string contentTypeName, Guid fieldID, bool required = false, bool hidden = false)
+        /// <param name="updateChildren">True to update content types that inherit from the content type; otherwise, false.</param>
+        public static void AddFieldToContentTypeByName(this Web web, string contentTypeName, Guid fieldID, bool required = false, bool hidden = false, bool updateChildren = true)
         {
             // Get content type
             var ct = web.GetContentTypeByName(contentTypeName);
@@ -1056,7 +1060,7 @@ namespace Microsoft.SharePoint.Client
             var fld = web.Fields.GetById(fieldID);
 
             // Add field association to content type
-            AddFieldToContentType(web, ct, fld, required, hidden);
+            AddFieldToContentType(web, ct, fld, required, hidden, updateChildren);
         }
 
         /// <summary>
@@ -1067,7 +1071,8 @@ namespace Microsoft.SharePoint.Client
         /// <param name="field">Field to associate to the content type</param>
         /// <param name="required">Optionally make this a required field</param>
         /// <param name="hidden">Optionally make this a hidden field</param>
-        public static void AddFieldToContentType(this Web web, ContentType contentType, Field field, bool required = false, bool hidden = false)
+        /// <param name="updateChildren">True to update content types that inherit from the content type; otherwise, false.</param>
+        public static void AddFieldToContentType(this Web web, ContentType contentType, Field field, bool required = false, bool hidden = false, bool updateChildren = true)
         {
             //// Forcibly include Ids of FieldLinks
             //web.Context.Load(contentType, c => c.FieldLinks.Include(fl => fl.Id, fl => fl.Required, fl => fl.Hidden));
@@ -1104,7 +1109,7 @@ namespace Microsoft.SharePoint.Client
                 // Update FieldLink
                 flink.Required = required;
                 flink.Hidden = hidden;
-                contentType.Update(true);
+                contentType.Update(updateChildren);
                 web.Context.ExecuteQueryRetry();
             }
         }

--- a/Core/OfficeDevPnP.Core/Extensions/FieldAndContentTypeExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/FieldAndContentTypeExtensions.cs
@@ -1095,7 +1095,7 @@ namespace Microsoft.SharePoint.Client
                 var fldInfo = new FieldLinkCreationInformation();
                 fldInfo.Field = field;
                 contentType.FieldLinks.Add(fldInfo);
-                contentType.Update(true);
+                contentType.Update(updateChildren);
                 web.Context.ExecuteQueryRetry();
 
                 flink = contentType.FieldLinks.GetById(field.Id);

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/FieldRef.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/FieldRef.cs
@@ -48,6 +48,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model
         /// </summary>
         public bool Remove { get; set; }
 
+        /// <summary>
+        /// Used in ContentType.FieldRef. True to update content types that inherit from the content type; otherwise, false.
+        /// </summary>
+        public bool UpdateChildren { get; set; }
+
         #endregion
 
         #region Constructors

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
@@ -260,7 +260,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     }
 
                     scope.LogDebug(CoreResources.Provisioning_ObjectHandlers_ContentTypes_Adding_field__0__to_content_type, fieldId);
-                    web.AddFieldToContentType(existingContentType, field, fieldRef.Required, fieldRef.Hidden);
+                    web.AddFieldToContentType(existingContentType, field, fieldRef.Required, fieldRef.Hidden, fieldRef.UpdateChildren);
                 }
             }
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/ProvisioningSchema-2018-07.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/ProvisioningSchema-2018-07.cs
@@ -5802,10 +5802,13 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml.V201807 {
         private bool requiredField;
         
         private bool hiddenField;
-        
+
+        private bool updateChildrenField;
+
         public FieldRefFull() {
             this.requiredField = false;
             this.hiddenField = false;
+            this.updateChildrenField = true;
         }
         
         /// <remarks/>
@@ -5840,6 +5843,21 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml.V201807 {
             }
             set {
                 this.hiddenField = value;
+            }
+        }
+
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        [System.ComponentModel.DefaultValueAttribute(true)]
+        public bool UpdateChildren
+        {
+            get
+            {
+                return this.updateChildrenField;
+            }
+            set
+            {
+                this.updateChildrenField = value;
             }
         }
     }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/ProvisioningSchema-2018-07.xsd
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/ProvisioningSchema-2018-07.xsd
@@ -3513,6 +3513,14 @@
       </xsd:annotation>
     </xsd:attribute>
 
+    <xsd:attribute name="UpdateChildren" type="xsd:boolean" use="optional" default="true">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The UpdateChildren flag for field to update content types that inherit from the content type.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
   </xsd:attributeGroup>
 
   <xsd:complexType name="ListInstanceFieldRef">


### PR DESCRIPTION
…contenttypes, fieldref

| Q               | A
| --------------- | ---
| Bug fix?        | yes?
| New feature?    | yes?
| New sample?      | no
| Related issues?  | fixes #2045 

#### What's in this Pull Request?

Added `UpdateChildren` property to FieldRef. This allows to update/not update inheriting content types as in the [documentation](https://docs.microsoft.com/en-us/previous-versions/office/sharepoint-server/ee544078(v%3Doffice.15)).

Currently if you update FieldRef in `Document` or `Item` content types as of version 3.5.1901, you get an error like this: 
![image](https://user-images.githubusercontent.com/1834466/51769538-a63a1480-20e3-11e9-8209-cf6ac4956b34.png)

This is because [contentType.update(true)](https://github.com/SharePoint/PnP-Sites-Core/blob/14aaea787a160edbfa89e6ab132340da6eb7a5cf/Core/OfficeDevPnP.Core/Extensions/FieldAndContentTypeExtensions.cs#L1038) is hard-coded to pass `true` to parameter `updateChildren`. This will always force SharePoint to update inheriting content types which can be read-only or sealed. 

This PR gives the flexibility to send `UpdateChildren="False"` parameter for such content types.

Example:
```xml
        <pnp:ContentType ID="0x0101" Name="Document" Description="Create new document">
          <pnp:FieldRefs>
            <pnp:FieldRef ID="{61e031fe-3c5e-4bbb-b451-868721fbbc5a}" UpdateChildren="false" Required="false" Name="CustomField1" />
          </pnp:FieldRefs>
        </pnp:ContentType>
```
