### PR TITLE
Add support for Kerberos authentication against ADFS

### DIFF
--- a/Core/OfficeDevPnP.Core/AuthenticationManager.cs
+++ b/Core/OfficeDevPnP.Core/AuthenticationManager.cs
@@ -59,7 +59,7 @@ namespace OfficeDevPnP.Core
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
 #endif
         }
-        #endregion  
+        #endregion
 
 
         #region Authenticating against SharePoint Online using credentials or app-only
@@ -883,6 +883,64 @@ namespace OfficeDevPnP.Core
 
         }
 
+        /// <summary>
+        /// Returns a SharePoint on-premises ClientContext for sites secured via ADFS
+        /// </summary>
+        /// <param name="siteUrl">Url of the SharePoint site that's secured via ADFS</param>
+        /// <param name="sts">Hostname of the ADFS server (e.g. sts.company.com)</param>
+        /// <param name="idpId">Identifier of the ADFS relying party that we're hitting</param>
+        /// <param name="logonTokenCacheExpirationWindow">Optioanlly provide the value of the SharePoint STS logonTokenCacheExpirationWindow. Defaults to 10 minutes.</param>
+        /// <returns>ClientContext to be used by CSOM code</returns>
+        public ClientContext GetADFSKerberosMixedAuthenticationContext(string siteUrl, string sts, string idpId, int logonTokenCacheExpirationWindow = 10)
+        {
+            ClientContext clientContext = new ClientContext(siteUrl);
+            clientContext.ExecutingWebRequest += delegate (object oSender, WebRequestEventArgs webRequestEventArgs)
+            {
+                if (fedAuth != null)
+                {
+                    Cookie fedAuthCookie = fedAuth.GetCookies(new Uri(siteUrl))["FedAuth"];
+                    // If cookie is expired a new fedAuth cookie needs to be requested
+                    if (fedAuthCookie == null || fedAuthCookie.Expires < DateTime.Now)
+                    {
+                        fedAuth = new KerberosMixed().GetFedAuthCookie(siteUrl,
+                            new Uri($"https://{sts}/adfs/services/trust/13/kerberosmixed"),
+                            idpId,
+                            logonTokenCacheExpirationWindow);
+                    }
+                }
+                else
+                {
+                    fedAuth = new KerberosMixed().GetFedAuthCookie(siteUrl,
+                        new Uri($"https://{sts}/adfs/services/trust/13/certificatemixed"),
+                        idpId,
+                        logonTokenCacheExpirationWindow);
+                }
+
+                if (fedAuth == null)
+                {
+                    throw new Exception("No fedAuth cookie acquired");
+                }
+
+                webRequestEventArgs.WebRequestExecutor.WebRequest.CookieContainer = fedAuth;
+            };
+            return clientContext;
+        }
+
+        /// <summary>
+        /// Refreshes the SharePoint FedAuth cookie
+        /// </summary>
+        /// <param name="siteUrl">Url of the SharePoint site that's secured via ADFS</param>
+        /// <param name="sts">Hostname of the ADFS server (e.g. sts.company.com)</param>
+        /// <param name="idpId">Identifier of the ADFS relying party that we're hitting</param>
+        /// <param name="logonTokenCacheExpirationWindow">Optioanlly provide the value of the SharePoint STS logonTokenCacheExpirationWindow. Defaults to 10 minutes.</param>
+        /// <returns>ClientContext to be used by CSOM code</returns>
+        public void RefreshADFSKerberosMixedAuthenticationContext(string siteUrl, string serialNumber, string sts, string idpId, int logonTokenCacheExpirationWindow = 10)
+        {
+            fedAuth = new KerberosMixed().GetFedAuthCookie(siteUrl,
+                new Uri($"https://{sts}/adfs/services/trust/13/kerberosmixed"),
+                idpId,
+                logonTokenCacheExpirationWindow);
+        }
 
         #endregion
 #endif

--- a/Core/OfficeDevPnP.Core/AuthenticationManager.cs
+++ b/Core/OfficeDevPnP.Core/AuthenticationManager.cs
@@ -911,7 +911,7 @@ namespace OfficeDevPnP.Core
                 else
                 {
                     fedAuth = new KerberosMixed().GetFedAuthCookie(siteUrl,
-                        new Uri($"https://{sts}/adfs/services/trust/13/certificatemixed"),
+                        new Uri($"https://{sts}/adfs/services/trust/13/kerberosmixed"),
                         idpId,
                         logonTokenCacheExpirationWindow);
                 }

--- a/Core/OfficeDevPnP.Core/IdentityModel/TokenProviders/ADFS/KerberosMixed.cs
+++ b/Core/OfficeDevPnP.Core/IdentityModel/TokenProviders/ADFS/KerberosMixed.cs
@@ -1,0 +1,89 @@
+#if !NETSTANDARD2_0
+using OfficeDevPnP.Core.IdentityModel.WSTrustBindings;
+using System;
+using System.IdentityModel.Protocols.WSTrust;
+using System.IdentityModel.Tokens;
+using System.Net;
+using System.Security.Cryptography.X509Certificates;
+using System.ServiceModel;
+using System.ServiceModel.Security;
+
+namespace OfficeDevPnP.Core.IdentityModel.TokenProviders.ADFS
+{
+    /// <summary>
+    /// ADFS Active authentication based on username + password. Uses the trust/13/usernamemixed ADFS endpoint.
+    /// </summary>
+    public class KerberosMixed : BaseProvider
+    {
+        /// <summary>
+        /// Performs active authentication against ADFS using the trust/13/usernamemixed ADFS endpoint.
+        /// </summary>
+        /// <param name="siteUrl">Url of the SharePoint site that's secured via ADFS</param>
+        /// <param name="certificateMixed">Uri to the ADFS certificatemixed endpoint</param>
+        /// <param name="relyingPartyIdentifier">Identifier of the ADFS relying party that we're hitting</param>
+        /// <param name="logonTokenCacheExpirationWindow">Logon TokenCache expiration window integer value</param>
+        /// <returns>A cookiecontainer holding the FedAuth cookie</returns>
+        public CookieContainer GetFedAuthCookie(string siteUrl, Uri kerberosMixed, string relyingPartyIdentifier, int logonTokenCacheExpirationWindow)
+        {
+            KerberosMixed adfsTokenProvider = new KerberosMixed();
+
+            var token = adfsTokenProvider.RequestToken(kerberosMixed, relyingPartyIdentifier);
+            string fedAuthValue = TransformSamlTokenToFedAuth(token.TokenXml.OuterXml, siteUrl, relyingPartyIdentifier);
+
+            // Construct the cookie expiration date
+            TimeSpan lifeTime = SamlTokenlifeTime(token.TokenXml.OuterXml);
+            if (lifeTime == TimeSpan.Zero)
+            {
+                lifeTime = new TimeSpan(0, 60, 0);
+            }
+
+            int cookieLifeTime = Math.Min((lifeTime.Hours * 60 + lifeTime.Minutes), logonTokenCacheExpirationWindow);
+            DateTime expiresOn = DateTime.Now.AddMinutes(cookieLifeTime);
+
+            CookieContainer cc = null;
+
+            if (!string.IsNullOrEmpty(fedAuthValue))
+            {
+                cc = new CookieContainer();
+                Cookie samlAuth = new Cookie("FedAuth", fedAuthValue);
+                samlAuth.Expires = expiresOn;
+                samlAuth.Path = "/";
+                samlAuth.Secure = true;
+                samlAuth.HttpOnly = true;
+                Uri samlUri = new Uri(siteUrl);
+                samlAuth.Domain = samlUri.Host;
+                cc.Add(samlAuth);
+            }
+
+            return cc;
+        }
+
+        /// <summary>
+        /// Returns Generic XML Security Token from ADFS to generated FedAuth
+        /// </summary>
+        /// <param name="kerberosMixed">ADFS Endpoint for Kerberos Mixed Authentication</param>
+        /// <param name="relyingPartyIdentifier">Identifier of the ADFS relying party that we're hitting</param>
+        /// <returns></returns>
+        private GenericXmlSecurityToken RequestToken(Uri kerberosMixed, string relyingPartyIdentifier)
+        {
+            GenericXmlSecurityToken genericToken = null;
+            using (var factory = new WSTrustChannelFactory(new KerberosWSTrustBinding(SecurityMode.TransportWithMessageCredential), new EndpointAddress(kerberosMixed)))
+            {
+                factory.TrustVersion = TrustVersion.WSTrust13;
+                var requestSecurityToken = new RequestSecurityToken
+                {
+                    RequestType = RequestTypes.Issue,
+                    AppliesTo = new EndpointReference(relyingPartyIdentifier),
+                    KeyType = KeyTypes.Bearer
+                };
+
+                IWSTrustChannelContract channel = factory.CreateChannel();
+                genericToken = channel.Issue(requestSecurityToken) as GenericXmlSecurityToken;
+                factory.Close();
+            }
+            return genericToken;
+        }
+
+    }
+}
+#endif

--- a/Core/OfficeDevPnP.Core/IdentityModel/WSTrustBindings/KerberosWSTrustBinding.cs
+++ b/Core/OfficeDevPnP.Core/IdentityModel/WSTrustBindings/KerberosWSTrustBinding.cs
@@ -1,0 +1,37 @@
+/* Based on reflectored code coming from Microsoft.IdentityModel.Protocols.WSTrust.Bindings.KerberosWSTrustBinding class */
+#if !NETSTANDARD2_0
+using System;
+using System.Net;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+
+namespace OfficeDevPnP.Core.IdentityModel.WSTrustBindings
+{
+    public class KerberosWSTrustBinding : WSTrustBinding
+    {
+        public KerberosWSTrustBinding()
+          : this(SecurityMode.TransportWithMessageCredential)
+        {
+        }
+
+        public KerberosWSTrustBinding(SecurityMode mode)
+          : base(mode)
+        {
+        }
+
+        protected override SecurityBindingElement CreateSecurityBindingElement()
+        {
+            if (SecurityMode.Message == this.SecurityMode)
+                return (SecurityBindingElement)SecurityBindingElement.CreateKerberosBindingElement();
+            if (SecurityMode.TransportWithMessageCredential == this.SecurityMode)
+                return (SecurityBindingElement)SecurityBindingElement.CreateKerberosOverTransportBindingElement();
+            return (SecurityBindingElement)null;
+        }
+
+        protected override void ApplyTransportSecurity(HttpTransportBindingElement transport)
+        {
+            transport.AuthenticationScheme = AuthenticationSchemes.Negotiate;
+        }
+    }
+}
+#endif

--- a/Core/OfficeDevPnP.Core/IdentityModel/WSTrustBindings/WindowsWSTrustBinding.cs
+++ b/Core/OfficeDevPnP.Core/IdentityModel/WSTrustBindings/WindowsWSTrustBinding.cs
@@ -1,0 +1,37 @@
+/* Based on reflectored code coming from Microsoft.IdentityModel.Protocols.WSTrust.Bindings.WindowsWSTrustBinding class */
+#if !NETSTANDARD2_0
+using System;
+using System.Net;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+
+namespace OfficeDevPnP.Core.IdentityModel.WSTrustBindings
+{
+    public class WindowsWSTrustBinding : WSTrustBinding
+    {
+        public WindowsWSTrustBinding()
+          : this(SecurityMode.Message)
+        {
+        }
+
+        public WindowsWSTrustBinding(SecurityMode securityMode)
+          : base(securityMode)
+        {
+        }
+
+        protected override SecurityBindingElement CreateSecurityBindingElement()
+        {
+            if (SecurityMode.Message == this.SecurityMode)
+                return (SecurityBindingElement)SecurityBindingElement.CreateSspiNegotiationBindingElement(true);
+            if (SecurityMode.TransportWithMessageCredential == this.SecurityMode)
+                return (SecurityBindingElement)SecurityBindingElement.CreateSspiNegotiationOverTransportBindingElement(true);
+            return (SecurityBindingElement)null;
+        }
+
+        protected override void ApplyTransportSecurity(HttpTransportBindingElement transport)
+        {
+            transport.AuthenticationScheme = AuthenticationSchemes.Negotiate;
+        }
+    }
+}
+#endif

--- a/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
+++ b/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
@@ -1054,7 +1054,10 @@
     <Compile Include="Framework\TimerJobs\TimerJobRunEventArgs.cs" />
     <Compile Include="Extensions\PnPClientContext.cs" />
     <Compile Include="IdentityModel\TokenProviders\ADFS\CertificateMixed.cs" />
+    <Compile Include="IdentityModel\TokenProviders\ADFS\KerberosMixed.cs" />
     <Compile Include="IdentityModel\WSTrustBindings\CertificateWSTrustBinding.cs" />
+    <Compile Include="IdentityModel\WSTrustBindings\KerberosWSTrustBinding.cs" />
+    <Compile Include="IdentityModel\WSTrustBindings\WindowsWSTrustBinding.cs" />
     <Compile Include="Pages\ClientSideSectionEmphasis.cs" />
     <Compile Include="Pages\ClientSideText.cs" />
     <Compile Include="Pages\ClientSideTextControlData.cs" />
@@ -1368,7 +1371,7 @@ del $(ProjectDir)\obj\*.json</PreBuildEvent>
     <PostBuildEvent>
     </PostBuildEvent>
   </PropertyGroup>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    |  yes
| New sample?      | no
| Related issues?  | none

#### What's in this Pull Request?

This pull request contains an enhancement with which the authentication to a SharePoint server using an ADFS instance is possible by using kerberos authentication. Currently authenticating via ADFS is only possible with login/password and using a X.509 certificate.

##### Justification

In an on premises environment it's common that service accounts authenticate to other backend systems via Kerberos including the Kerberos Delegation mechanism, in which the service account can act as an specific user account. 

This PR provides three new public methods to the AuthenticationManager with which developers can at first determine the required relying party identifier for an ADFS authentication using a SharePoint Url (`GetAdfsConfigurationFromTargetUri`). Secondly requesting a CSOM ClientContext using ADFS with (integrated) Kerberos authentication using `GetADFSKerberosMixedAuthenticationContext`. And at last the method `RefreshADFSKerberosMixedAuthenticationContext` is provided to refresh a the `FedAuth` cookie via ADFS using Kerberos.

