### PR TITLE
ALM functions for SharePoint 2019 on premises

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/ALM/ALMTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/ALM/ALMTests.cs
@@ -1,4 +1,4 @@
-﻿#if !ONPREMISES
+﻿#if !SP2013 && !SP2016
 using Microsoft.Online.SharePoint.TenantAdministration;
 using Microsoft.SharePoint.Client;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -31,69 +31,60 @@ namespace OfficeDevPnP.Core.Tests.Sites
         }
 
         [TestMethod]
-        public async Task GetAvailableTestAsync()
-        {
-            using (var clientContext = TestCommon.CreateClientContext())
-            {
-                AppManager manager = new AppManager(clientContext);
-                var results = await manager.GetAvailableAsync();
-
-                Assert.IsNotNull(results);
-
-                var singleResults = await manager.GetAvailableAsync(results.FirstOrDefault().Id);
-
-                Assert.IsNotNull(singleResults);
-            }
-        }
-
-        [TestMethod]
-        public void GetAvailable()
-        {
-            using (var clientContext = TestCommon.CreateClientContext())
-            {
-                AppManager manager = new AppManager(clientContext);
-                var results = manager.GetAvailable();
-
-                Assert.IsNotNull(results);
-
-                var singleResult = manager.GetAvailable(results.FirstOrDefault().Id);
-
-                Assert.IsNotNull(results);
-            }
-        }
-
-        [TestMethod]
-        public async Task AddRemoveAppTestAsync()
+        public async Task AddCheckRemoveAppTestAsync()
         {
             using (var clientContext = TestCommon.CreateClientContext())
             {
                 AppManager manager = new AppManager(clientContext);
                 var appBytes = OfficeDevPnP.Core.Tests.Properties.Resources.alm;
 
-                var results = await manager.AddAsync(appBytes, $"app-{appGuid}.sppkg");
+                //Test adding app
+                var addedApp = await manager.AddAsync(appBytes, $"app-{appGuid}.sppkg", true);
 
-                Assert.IsNotNull(results);
+                Assert.IsNotNull(addedApp);
 
-                var removeResults = await manager.RemoveAsync(results.Id);
+
+                //Test availability of apps
+                var availableApps = await manager.GetAvailableAsync();
+
+                Assert.IsNotNull(availableApps);
+                CollectionAssert.Contains(availableApps.Select(app => app.Id).ToList(), addedApp.Id);
+
+                var retrievedApp = await manager.GetAvailableAsync(addedApp.Id);
+                Assert.AreEqual(addedApp.Id, retrievedApp.Id);
+
+                //Test removal
+                var removeResults = await manager.RemoveAsync(addedApp.Id);
 
                 Assert.IsTrue(removeResults);
             }
         }
 
         [TestMethod]
-        public void AddRemoveAppTest()
+        public void AddCheckRemoveAppTest()
         {
             using (var clientContext = TestCommon.CreateClientContext())
             {
                 AppManager manager = new AppManager(clientContext);
                 var appBytes = OfficeDevPnP.Core.Tests.Properties.Resources.alm;
 
-                var results = manager.Add(appBytes, $"app-{appGuid}.sppkg", true);
+                //Test adding app
+                var addedApp = manager.Add(appBytes, $"app-{appGuid}.sppkg", true);
 
-                Assert.IsNotNull(results);
+                Assert.IsNotNull(addedApp);
 
-                var removeResults = manager.Remove(results.Id);
+                //Test availability of apps
+                var availableApps = manager.GetAvailable();
 
+                Assert.IsNotNull(availableApps);
+                CollectionAssert.Contains(availableApps.Select(app => app.Id).ToList(), addedApp.Id);
+
+                var retrievedApp = manager.GetAvailable(addedApp.Id);
+                Assert.AreEqual(addedApp.Id, retrievedApp.Id);
+
+                //Test removal
+                var removeResults = manager.Remove(addedApp.Id);
+                
                 Assert.IsTrue(removeResults);
             }
         }

--- a/Core/OfficeDevPnP.Core/ALM/AppManager.cs
+++ b/Core/OfficeDevPnP.Core/ALM/AppManager.cs
@@ -14,7 +14,7 @@ using System.Threading.Tasks;
 
 namespace OfficeDevPnP.Core.ALM
 {
-#if !ONPREMISES
+#if !SP2013 && !SP2016
     /// <summary>
     /// Allows Application Lifecycle Management for Apps
     /// </summary>
@@ -762,7 +762,7 @@ namespace OfficeDevPnP.Core.ALM
                 {
                     handler.SetAuthenticationCookies(context);
                 }
-
+                
                 using (var httpClient = new PnPHttpProvider(handler))
                 {
 
@@ -831,7 +831,7 @@ namespace OfficeDevPnP.Core.ALM
             }
             return await Task.Run(() => returnValue);
         }
-        #endregion
+#endregion
     }
 #endif
-}
+            }

--- a/Core/OfficeDevPnP.Core/ALM/AppManager.cs
+++ b/Core/OfficeDevPnP.Core/ALM/AppManager.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
@@ -617,6 +618,13 @@ namespace OfficeDevPnP.Core.ALM
                     {
                         request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", accessToken);
                     }
+                    else
+                    {
+                        if (_context.Credentials is NetworkCredential networkCredential)
+                        {
+                            handler.Credentials = networkCredential;
+                        }
+                    }
                     request.Headers.Add("X-RequestDigest", await _context.GetRequestDigest());
 
                     // Perform actual post operation
@@ -700,6 +708,13 @@ namespace OfficeDevPnP.Core.ALM
                     {
                         request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", accessToken);
                     }
+                    else
+                    {
+                        if (context.Credentials is NetworkCredential networkCredential)
+                        {
+                            handler.Credentials = networkCredential;
+                        }
+                    }
                     request.Headers.Add("X-RequestDigest", await context.GetRequestDigest());
 
                     if (postObject != null)
@@ -774,6 +789,13 @@ namespace OfficeDevPnP.Core.ALM
                     if (!string.IsNullOrEmpty(accessToken))
                     {
                         request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", accessToken);
+                    }
+                    else
+                    {
+                        if (context.Credentials is NetworkCredential networkCredential)
+                        {
+                            handler.Credentials = networkCredential;
+                        }
                     }
                     request.Headers.Add("X-RequestDigest", requestDigest);
                     request.Headers.Add("binaryStringRequestBody", "true");

--- a/Core/OfficeDevPnP.Core/ALM/AppMetadata.cs
+++ b/Core/OfficeDevPnP.Core/ALM/AppMetadata.cs
@@ -1,4 +1,4 @@
-﻿#if !ONPREMISES
+﻿#if !SP2013 && !SP2016
 using Newtonsoft.Json;
 using System;
 

--- a/Core/OfficeDevPnP.Core/Extensions/ClientContextExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/ClientContextExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Net;
@@ -638,6 +638,14 @@ namespace Microsoft.SharePoint.Client
                     {
                         request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", accessToken);
                     }
+                    else
+                    {
+                        if (context.Credentials is NetworkCredential networkCredential)
+                        {
+                            handler.Credentials = networkCredential;
+                        }
+                    }
+
                     HttpResponseMessage response = await httpClient.SendAsync(request);
 
                     if (response.IsSuccessStatusCode)

--- a/Core/OfficeDevPnP.Core/Extensions/TenantExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/TenantExtensions.cs
@@ -728,26 +728,6 @@ namespace Microsoft.SharePoint.Client
 
         #endregion
 
-        #region ClientSide Package Deployment
-
-        /// <summary>
-        /// Gets the Uri for the tenant's app catalog site (if that one has already been created)
-        /// </summary>
-        /// <param name="tenant">Tenant to operate against</param>
-        /// <returns>The Uri holding the app catalog site URL</returns>
-        public static Uri GetAppCatalog(this Tenant tenant)
-        {
-            // Assume there's only one appcatalog site
-            var results = ((tenant.Context) as ClientContext).Web.SiteSearch("contentclass:STS_Site AND SiteTemplate:APPCATALOG");
-            foreach (var site in results)
-            {
-                return new Uri(site.Url);
-            }
-
-            return null;
-        }
-        #endregion
-
         #region Private helper methods
         private static bool WaitForIsComplete(Tenant tenant, SpoOperation op, Func<TenantOperationMessage, bool> timeoutFunction = null, TenantOperationMessage operationMessage = TenantOperationMessage.None)
         {
@@ -966,6 +946,31 @@ namespace Microsoft.SharePoint.Client
         #endregion
 
 #else
+
+#if !SP2013 && !SP2016
+
+        #region ClientSide Package Deployment
+
+        /// <summary>
+        /// Gets the Uri for the tenant's app catalog site (if that one has already been created)
+        /// </summary>
+        /// <param name="tenant">Tenant to operate against</param>
+        /// <returns>The Uri holding the app catalog site URL</returns>
+        public static Uri GetAppCatalog(this Tenant tenant)
+        {
+            // Assume there's only one appcatalog site
+            var results = ((tenant.Context) as ClientContext).Web.SiteSearch("contentclass:STS_Site AND SiteTemplate:APPCATALOG");
+            foreach (var site in results)
+            {
+                return new Uri(site.Url);
+            }
+
+            return null;
+        }
+        #endregion
+
+#endif
+
         #region Site collection creation
         /// <summary>
         /// Adds a SiteEntity by launching site collection creation and waits for the creation to finish

--- a/Core/OfficeDevPnP.Core/Extensions/WebExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/WebExtensions.cs
@@ -1345,7 +1345,7 @@ namespace Microsoft.SharePoint.Client
             return webName;
         }
 
-#if !ONPREMISES
+#if !SP2013 && !SP2016
         #region ClientSide Package Deployment
         /// <summary>
         /// Gets the Uri for the tenant's app catalog site (if that one has already been created)

--- a/Core/OfficeDevPnP.Core/Utilities/RESTUtilities.cs
+++ b/Core/OfficeDevPnP.Core/Utilities/RESTUtilities.cs
@@ -3,9 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
 namespace OfficeDevPnP.Core.Utilities
 {
@@ -18,12 +16,12 @@ namespace OfficeDevPnP.Core.Utilities
         /// <param name="context"></param>
         public static void SetAuthenticationCookies(this HttpClientHandler handler, ClientContext context)
         {
-            if (context.Credentials is SharePointOnlineCredentials spCred )
+            if (context.Credentials is SharePointOnlineCredentials spCred)
             {
                 handler.Credentials = context.Credentials;
                 handler.CookieContainer.SetCookies(new Uri(context.Web.Url), spCred.GetAuthenticationCookie(new Uri(context.Web.Url)));
             }
-            else if(context.Credentials == null)
+            else if (context.Credentials == null)
             {
                 var cookieString = CookieReader.GetCookie(context.Web.Url).Replace("; ", ",").Replace(";", ",");
                 var authCookiesContainer = new System.Net.CookieContainer();

--- a/Core/OfficeDevPnP.Core/Utilities/RESTUtilities.cs
+++ b/Core/OfficeDevPnP.Core/Utilities/RESTUtilities.cs
@@ -18,12 +18,12 @@ namespace OfficeDevPnP.Core.Utilities
         /// <param name="context"></param>
         public static void SetAuthenticationCookies(this HttpClientHandler handler, ClientContext context)
         {
-            if (context.Credentials != null)
+            if (context.Credentials is SharePointOnlineCredentials spCred )
             {
                 handler.Credentials = context.Credentials;
-                handler.CookieContainer.SetCookies(new Uri(context.Web.Url), (context.Credentials as SharePointOnlineCredentials).GetAuthenticationCookie(new Uri(context.Web.Url)));
+                handler.CookieContainer.SetCookies(new Uri(context.Web.Url), spCred.GetAuthenticationCookie(new Uri(context.Web.Url)));
             }
-            else
+            else if(context.Credentials == null)
             {
                 var cookieString = CookieReader.GetCookie(context.Web.Url).Replace("; ", ",").Replace(";", ",");
                 var authCookiesContainer = new System.Net.CookieContainer();


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no
| Related issues?  | partially SharePoint/PnP-PowerShell#1812, successor of #2071 

#### What's in this Pull Request?

As we needed the ALM functions in SharePoint 2019, I built upon the partially prepared code to include it. Changes are:
- Fixed error in RESTUtilities.SetAuthenticationCookies for on premises environments, as the credentials passed are not of type SharePointOnlineCredentials but NetworkCredentials. 
- Added additional authentication data in `AppManager` and `ClientContextExtensions` for on premises scenarios with NetworkCredentials. This was sufficient for my scenarios, however, I am not sure, if it is completley sufficient for all possible scenarios.
- The GetAvailable* tests in the ALMTests class assumed that at least one app is already in the App Catalog. I merged this check with the AddRemove* tests to be sure that at least one app has been added to the App Catalog before the methods are tested.

This is the successor of PR #2071 that also included updated SP2019 assemblies. As this was not deemed to be necessary, I created a new pull request that does not contain the assemblies to remove the binary blob from the public history (otherwise, it would be forever part of the Git repository even though it is never used).