### PR TITLE
Fix #2088 - Provisioning template doesnt publish the app

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Utilities/TenantHelper.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Utilities/TenantHelper.cs
@@ -133,11 +133,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
                                         .FirstOrDefault(a => a.Id == Guid.Parse(parser.ParseString(app.PackageId)));
                                 }
                                 if (appMetadata != null)
-                                {
-                                    if (appMetadata.Deployed == false)
-                                    {
-                                        manager.Deploy(appMetadata, app.SkipFeatureDeployment);
-                                    }
+                                {                                    
+                                    manager.Deploy(appMetadata, app.SkipFeatureDeployment);
                                 }
                                 else
                                 {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #2088 

#### What's in this Pull Request?

Removes the additional check `appMetadata.Deployed == false` check while publishing the app. 
Because of this `if` condition, while we are able to upload and overwrite the app package, we are unable to actually publish the latest updates if it was already deployed.