### PR TITLE
Feature/Fix: Added ensureSiteAssetsLibrary method to prevent access denied 

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
@@ -47,6 +47,15 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 }
 
                 var filesToProcess = template.Files.Union(directoryFiles).ToArray();
+
+                var siteAssetsFiles = filesToProcess.Where(f => f.Folder.ToLower().Contains("siteassets")).FirstOrDefault();
+                if (siteAssetsFiles != null)
+                {
+                    // Need this so that we dont have access denied error during the first time upload, especially for modern sites
+                    web.Lists.EnsureSiteAssetsLibrary();
+                    web.Context.ExecuteQueryRetry();
+                }
+
                 var currentFileIndex = 0;
                 var originalWeb = web; // Used to store and re-store context in case files are deployed to masterpage gallery
                 foreach (var file in filesToProcess)
@@ -469,13 +478,13 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
             if (!String.IsNullOrEmpty(directory.IncludedExtensions) && directory.IncludedExtensions != "*.*")
             {
-                var includedExtensions = directory.IncludedExtensions.Split(new [] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                var includedExtensions = directory.IncludedExtensions.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
                 files = files.Where(f => includedExtensions.Contains($"*{Path.GetExtension(f).ToLower()}")).ToList();
             }
 
             if (!String.IsNullOrEmpty(directory.ExcludedExtensions))
             {
-                var excludedExtensions = directory.ExcludedExtensions.Split(new [] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                var excludedExtensions = directory.ExcludedExtensions.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
                 files = files.Where(f => !excludedExtensions.Contains($"*{Path.GetExtension(f).ToLower()}")).ToList();
             }
 


### PR DESCRIPTION
for modern sites while uploading files to siteAssets library.

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| New sample?      | no
| Related issues?  | NA

#### What's in this Pull Request?

This PR adds `web.Lists.EnsureSiteAssetsLibrary();` method to the files handler while uploading files.
If this is not present, then we get an access denied error while provisioning the files.

Consider a scenario as below, we use the below snippet to create a communication site and apply the template:

```
CommunicationSiteCollectionCreationInformation communicationSiteCollectionCreationInformation = new CommunicationSiteCollectionCreationInformation
{
	Title = "Test Title comm site 1001",
	Description = "Test desc",
	Lcid = 1033,
	ShareByEmailEnabled = true,
	Url = "https://gautamsheth.sharepoint.com/sites/TestCommsite1047"
};

var commSite = clientContext.CreateSiteAsync(communicationSiteCollectionCreationInformation).GetAwaiter().GetResult();
commSite.Web.ApplyProvisioningTemplate(template1, ptai);
```

It will give access denied error while provisioning the below template:

```
<?xml version="1.0"?>
<pnp:Provisioning xmlns:pnp="http://schemas.dev.office.com/PnP/2018/07/ProvisioningSchema">
  <pnp:Preferences Generator="OfficeDevPnP.Core, Version=3.7.1903.0, Culture=neutral, PublicKeyToken=null" />  
  <pnp:Templates ID="CONTAINER-TEMPLATE-6E0D3038EFAB476EA75D8F7D73A27523">
    <pnp:ProvisioningTemplate ID="TEMPLATE-6E0D3038EFAB476EA75D8F7D73A27523" Version="1" BaseSiteTemplate="SITEPAGEPUBLISHING#0" Scope="RootSite">     
		<pnp:Files>				
		   <pnp:File Src="Capture1.PNG" Folder="SiteAssets" Overwrite="true" />				
		</pnp:Files>		
    </pnp:ProvisioningTemplate>
  </pnp:Templates>
</pnp:Provisioning>
```

This also fixes the issue of ensuring that Site Assets library in the pnp templates, for example, we can get rid of the below snippet:

```
<pnp:Lists>
        <pnp:ListInstance Title="Site Assets" Description="Use this library to store files which are included on pages within this site, such as images on Wiki pages." DocumentTemplate="{site}/SiteAssets/Forms/template.doc" TemplateType="101" Url="SiteAssets" EnableVersioning="true" MinorVersionLimit="0" MaxVersionLimit="500" DraftVersionVisibility="0" TemplateFeatureID="00bfea71-e717-4e80-aa17-d0c71b360101" EnableAttachments="false" DefaultDisplayFormUrl="{site}/SiteAssets/Forms/DispForm.aspx" DefaultEditFormUrl="{site}/SiteAssets/Forms/EditForm.aspx" DefaultNewFormUrl="{site}/SiteAssets/Forms/Upload.aspx" ImageUrl="/_layouts/15/images/itdl.png?rev=44" IrmExpire="false" IrmReject="false" IsApplicationList="true" ValidationFormula="" ValidationMessage="">
          <pnp:ContentTypeBindings>
            <pnp:ContentTypeBinding ContentTypeID="0x0101" Default="true" />
            <pnp:ContentTypeBinding ContentTypeID="0x0120" />
          </pnp:ContentTypeBindings>
        </pnp:ListInstance>
</pnp:Lists>
```