### PR TITLE
Fix : Compile issues for OnPrem in the Site Header/Footer handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Support for provisioning Site Footer links 
 - New PnPProvisioningContext object for security scope management
 - New tenant extension method (tenant.EnableCommSite) to to convert the root site collection of a tenant into a communication site
+- Added support to extract and provision list propertybag entries #2201 [patrikhellgren]
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Support to export terms with a specific lcid in TaxonomyExtensions.ExportTermSet
 - Support for new page header and section backgrounds in the modern client side page provisioning [NicolajHedeager]
 - Support for provisioning client side page templates
+- Support for Provisioning Schema 201903
+- Support for provisioning Microsoft Teams
+- New PnPProvisioningContext object for security scope management
 
 ### Changed
 
@@ -21,6 +24,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fix loading of ClientSidePage contents if CanvasContent1 property is empty #2199 [heinrich-ulbricht]
 - Adding test for saving and loading of ClientSidePage header #2198 [heinrich-ulbricht]
 - Fix: conflict when provisioning client side pages with headers #2208 [heinrich-ulbricht]
+- Fix: fix for GlobalNavigation serialization in Provisioning Schema #2210 [patrikhellgren]
 
 ## [3.8.1904.0 - April 2019 release]
 

--- a/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectTeamsTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectTeamsTests.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
+using Microsoft.Online.SharePoint.TenantAdministration;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json.Linq;
 using OfficeDevPnP.Core.Framework.Provisioning.Model;
@@ -78,10 +79,11 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
 
             using (new PnPProvisioningContext((resource, scope) => Task.FromResult(TestCommon.AcquireTokenAsync(resource, scope))))
             {
-                using (var ctx = TestCommon.CreateClientContext())
+                using (var ctx = TestCommon.CreateTenantClientContext())
                 {
+                    var tenant = new Tenant(ctx);
                     var parser = new TokenParser(ctx.Web, template);
-                    new ObjectTeams().ProvisionObjects(ctx.Web, template, parser, new ProvisioningTemplateApplyingInformation());
+                    new ObjectTeams().ProvisionObjects(tenant, template.ParentHierarchy, null, parser, new ProvisioningTemplateApplyingInformation());
                 }
 
                 Assert.IsTrue(TeamsHaveBeenProvisioned());

--- a/Core/OfficeDevPnP.Core/CoreResources.Designer.cs
+++ b/Core/OfficeDevPnP.Core/CoreResources.Designer.cs
@@ -19,7 +19,7 @@ namespace OfficeDevPnP.Core {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class CoreResources {
@@ -1686,6 +1686,15 @@ namespace OfficeDevPnP.Core {
         internal static string Provisioning_ObjectHandlers_ListInstances_SkipAddingOrUpdatingCustomActions {
             get {
                 return ResourceManager.GetString("Provisioning_ObjectHandlers_ListInstances_SkipAddingOrUpdatingCustomActions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Skip adding/updating list property bag because the site has &quot;noscript&quot; enabled..
+        /// </summary>
+        internal static string Provisioning_ObjectHandlers_ListInstances_SkipAddingOrUpdatingPropertyBag {
+            get {
+                return ResourceManager.GetString("Provisioning_ObjectHandlers_ListInstances_SkipAddingOrUpdatingPropertyBag", resourceCulture);
             }
         }
         

--- a/Core/OfficeDevPnP.Core/CoreResources.Designer.cs
+++ b/Core/OfficeDevPnP.Core/CoreResources.Designer.cs
@@ -19,7 +19,7 @@ namespace OfficeDevPnP.Core {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class CoreResources {
@@ -2008,6 +2008,168 @@ namespace OfficeDevPnP.Core {
             get {
                 return ResourceManager.GetString("Provisioning_ObjectHandlers_SiteSecurity_Context_web_is_subweb__skipping_site_sec" +
                         "urity_provisioning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to add member to team..
+        /// </summary>
+        internal static string Provisioning_ObjectHandlers_Teams_Team_AddingMemberError {
+            get {
+                return ResourceManager.GetString("Provisioning_ObjectHandlers_Teams_Team_AddingMemberError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to add owner to team..
+        /// </summary>
+        internal static string Provisioning_ObjectHandlers_Teams_Team_AddingOwnerError {
+            get {
+                return ResourceManager.GetString("Provisioning_ObjectHandlers_Teams_Team_AddingOwnerError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Team already exists.
+        /// </summary>
+        internal static string Provisioning_ObjectHandlers_Teams_Team_AlreadyExists {
+            get {
+                return ResourceManager.GetString("Provisioning_ObjectHandlers_Teams_Team_AlreadyExists", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot register App for Team..
+        /// </summary>
+        internal static string Provisioning_ObjectHandlers_Teams_Team_AppProvisioningError {
+            get {
+                return ResourceManager.GetString("Provisioning_ObjectHandlers_Teams_Team_AppProvisioningError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot send a message to the target Channel..
+        /// </summary>
+        internal static string Provisioning_ObjectHandlers_Teams_Team_CannotSendMessage {
+            get {
+                return ResourceManager.GetString("Provisioning_ObjectHandlers_Teams_Team_CannotSendMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Channel already exists..
+        /// </summary>
+        internal static string Provisioning_ObjectHandlers_Teams_Team_ChannelAlreadyExists {
+            get {
+                return ResourceManager.GetString("Provisioning_ObjectHandlers_Teams_Team_ChannelAlreadyExists", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to create group for team.
+        /// </summary>
+        internal static string Provisioning_ObjectHandlers_Teams_Team_CreatingGroupError {
+            get {
+                return ResourceManager.GetString("Provisioning_ObjectHandlers_Teams_Team_CreatingGroupError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Exception while archiving/unarchiving Team with ID {0}. Details: {1}..
+        /// </summary>
+        internal static string Provisioning_ObjectHandlers_Teams_Team_FailedArchiveUnarchive {
+            get {
+                return ResourceManager.GetString("Provisioning_ObjectHandlers_Teams_Team_FailedArchiveUnarchive", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to get team information after provisioning..
+        /// </summary>
+        internal static string Provisioning_ObjectHandlers_Teams_Team_FetchingError {
+            get {
+                return ResourceManager.GetString("Provisioning_ObjectHandlers_Teams_Team_FetchingError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to get user by upn information..
+        /// </summary>
+        internal static string Provisioning_ObjectHandlers_Teams_Team_FetchingUserError {
+            get {
+                return ResourceManager.GetString("Provisioning_ObjectHandlers_Teams_Team_FetchingUserError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Group already exists.
+        /// </summary>
+        internal static string Provisioning_ObjectHandlers_Teams_Team_GroupAlreadyExists {
+            get {
+                return ResourceManager.GetString("Provisioning_ObjectHandlers_Teams_Team_GroupAlreadyExists", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Group with ID {0} does not exist..
+        /// </summary>
+        internal static string Provisioning_ObjectHandlers_Teams_Team_GroupDoesNotExists {
+            get {
+                return ResourceManager.GetString("Provisioning_ObjectHandlers_Teams_Team_GroupDoesNotExists", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to list team members..
+        /// </summary>
+        internal static string Provisioning_ObjectHandlers_Teams_Team_ListingMembersError {
+            get {
+                return ResourceManager.GetString("Provisioning_ObjectHandlers_Teams_Team_ListingMembersError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to list team owners..
+        /// </summary>
+        internal static string Provisioning_ObjectHandlers_Teams_Team_ListingOwnersError {
+            get {
+                return ResourceManager.GetString("Provisioning_ObjectHandlers_Teams_Team_ListingOwnersError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Provisioning a team failed..
+        /// </summary>
+        internal static string Provisioning_ObjectHandlers_Teams_Team_ProvisioningError {
+            get {
+                return ResourceManager.GetString("Provisioning_ObjectHandlers_Teams_Team_ProvisioningError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to remove member from team..
+        /// </summary>
+        internal static string Provisioning_ObjectHandlers_Teams_Team_RemovingMemberError {
+            get {
+                return ResourceManager.GetString("Provisioning_ObjectHandlers_Teams_Team_RemovingMemberError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to remove owner from team..
+        /// </summary>
+        internal static string Provisioning_ObjectHandlers_Teams_Team_RemovingOwnerError {
+            get {
+                return ResourceManager.GetString("Provisioning_ObjectHandlers_Teams_Team_RemovingOwnerError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Tab already exists..
+        /// </summary>
+        internal static string Provisioning_ObjectHandlers_Teams_Team_TabAlreadyExists {
+            get {
+                return ResourceManager.GetString("Provisioning_ObjectHandlers_Teams_Team_TabAlreadyExists", resourceCulture);
             }
         }
         

--- a/Core/OfficeDevPnP.Core/CoreResources.Designer.cs
+++ b/Core/OfficeDevPnP.Core/CoreResources.Designer.cs
@@ -1524,6 +1524,15 @@ namespace OfficeDevPnP.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Added property bag entry {0} to list {1}.
+        /// </summary>
+        internal static string Provisioning_ObjectHandlers_ListInstances_Added_PropertyBagEntry__0__To_List__1 {
+            get {
+                return ResourceManager.GetString("Provisioning_ObjectHandlers_ListInstances_Added_PropertyBagEntry__0__To_List__1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Adding list: {0} - {1}.
         /// </summary>
         internal static string Provisioning_ObjectHandlers_ListInstances_Adding_list___0_____1_ {

--- a/Core/OfficeDevPnP.Core/CoreResources.resx
+++ b/Core/OfficeDevPnP.Core/CoreResources.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -1135,61 +1135,10 @@
   <data name="Provisioning_ObjectHandlers_Teams_TeamTemplate_FetchingError" xml:space="preserve">
     <value>Failed to get team information after provisioning.</value>
   </data>
-  <data name="Provisioning_ObjectHandlers_Teams_Team_AddingMemberError" xml:space="preserve">
-    <value>Failed to add member to team.</value>
-  </data>
-  <data name="Provisioning_ObjectHandlers_Teams_Team_AddingOwnerError" xml:space="preserve">
-    <value>Failed to add owner to team.</value>
-  </data>
-  <data name="Provisioning_ObjectHandlers_Teams_Team_FetchingError" xml:space="preserve">
-    <value>Failed to get team information after provisioning.</value>
-  </data>
-  <data name="Provisioning_ObjectHandlers_Teams_Team_FetchingUserError" xml:space="preserve">
-    <value>Failed to get user by upn information.</value>
-  </data>
-  <data name="Provisioning_ObjectHandlers_Teams_Team_ListingMembersError" xml:space="preserve">
-    <value>Failed to list team members.</value>
-  </data>
-  <data name="Provisioning_ObjectHandlers_Teams_Team_ListingOwnersError" xml:space="preserve">
-    <value>Failed to list team owners.</value>
-  </data>
-  <data name="Provisioning_ObjectHandlers_Teams_Team_ProvisioningError" xml:space="preserve">
-    <value>Provisioning a team failed.</value>
-  </data>
-  <data name="Provisioning_ObjectHandlers_Teams_Team_RemovingMemberError" xml:space="preserve">
-    <value>Failed to remove member from team.</value>
-  </data>
-  <data name="Provisioning_ObjectHandlers_Teams_Team_RemovingOwnerError" xml:space="preserve">
-    <value>Failed to remove owner from team.</value>
-  </data>
-  <data name="Provisioning_ObjectHandlers_Teams_Team_CreatingGroupError" xml:space="preserve">
-    <value>Failed to create group for team</value>
-  </data>
-  <data name="Provisioning_ObjectHandlers_Teams_Team_AlreadyExists" xml:space="preserve">
-    <value>Team already exists</value>
-  </data>
-  <data name="Provisioning_ObjectHandlers_Teams_Team_GroupAlreadyExists" xml:space="preserve">
-    <value>Group already exists</value>
-  </data>
   <data name="TermGroup_No_Access" xml:space="preserve">
     <value>Login context does not have access to the TermGroup. If using app context, add app@sharepoint to the term group access list.</value>
   </data>
-  <data name="Provisioning_ObjectHandlers_Teams_Team_GroupDoesNotExists" xml:space="preserve">
-    <value>Group with ID {0} does not exist.</value>
-  </data>
-  <data name="Provisioning_ObjectHandlers_Teams_Team_AppProvisioningError" xml:space="preserve">
-    <value>Cannot register App for Team.</value>
-  </data>
-  <data name="Provisioning_ObjectHandlers_Teams_Team_CannotSendMessage" xml:space="preserve">
-    <value>Cannot send a message to the target Channel.</value>
-  </data>
-  <data name="Provisioning_ObjectHandlers_Teams_Team_ChannelAlreadyExists" xml:space="preserve">
-    <value>Channel already exists.</value>
-  </data>
-  <data name="Provisioning_ObjectHandlers_Teams_Team_FailedArchiveUnarchive" xml:space="preserve">
-    <value>Exception while archiving/unarchiving Team with ID {0}. Details: {1}.</value>
-  </data>
-  <data name="Provisioning_ObjectHandlers_Teams_Team_TabAlreadyExists" xml:space="preserve">
-    <value>Tab already exists.</value>
+  <data name="Provisioning_ObjectHandlers_ListInstances_Added_PropertyBagEntry__0__To_List__1" xml:space="preserve">
+    <value>Added property bag entry {0} to list {1}</value>
   </data>
 </root>

--- a/Core/OfficeDevPnP.Core/CoreResources.resx
+++ b/Core/OfficeDevPnP.Core/CoreResources.resx
@@ -1135,10 +1135,67 @@
   <data name="Provisioning_ObjectHandlers_Teams_TeamTemplate_FetchingError" xml:space="preserve">
     <value>Failed to get team information after provisioning.</value>
   </data>
+  <data name="Provisioning_ObjectHandlers_Teams_Team_AddingMemberError" xml:space="preserve">
+    <value>Failed to add member to team.</value>
+  </data>
+  <data name="Provisioning_ObjectHandlers_Teams_Team_AddingOwnerError" xml:space="preserve">
+    <value>Failed to add owner to team.</value>
+  </data>
+  <data name="Provisioning_ObjectHandlers_Teams_Team_FetchingError" xml:space="preserve">
+    <value>Failed to get team information after provisioning.</value>
+  </data>
+  <data name="Provisioning_ObjectHandlers_Teams_Team_FetchingUserError" xml:space="preserve">
+    <value>Failed to get user by upn information.</value>
+  </data>
+  <data name="Provisioning_ObjectHandlers_Teams_Team_ListingMembersError" xml:space="preserve">
+    <value>Failed to list team members.</value>
+  </data>
+  <data name="Provisioning_ObjectHandlers_Teams_Team_ListingOwnersError" xml:space="preserve">
+    <value>Failed to list team owners.</value>
+  </data>
+  <data name="Provisioning_ObjectHandlers_Teams_Team_ProvisioningError" xml:space="preserve">
+    <value>Provisioning a team failed.</value>
+  </data>
+  <data name="Provisioning_ObjectHandlers_Teams_Team_RemovingMemberError" xml:space="preserve">
+    <value>Failed to remove member from team.</value>
+  </data>
+  <data name="Provisioning_ObjectHandlers_Teams_Team_RemovingOwnerError" xml:space="preserve">
+    <value>Failed to remove owner from team.</value>
+  </data>
+  <data name="Provisioning_ObjectHandlers_Teams_Team_CreatingGroupError" xml:space="preserve">
+    <value>Failed to create group for team</value>
+  </data>
+  <data name="Provisioning_ObjectHandlers_Teams_Team_AlreadyExists" xml:space="preserve">
+    <value>Team already exists</value>
+  </data>
+  <data name="Provisioning_ObjectHandlers_Teams_Team_GroupAlreadyExists" xml:space="preserve">
+    <value>Group already exists</value>
+  </data>
   <data name="TermGroup_No_Access" xml:space="preserve">
     <value>Login context does not have access to the TermGroup. If using app context, add app@sharepoint to the term group access list.</value>
   </data>
+  <data name="Provisioning_ObjectHandlers_Teams_Team_GroupDoesNotExists" xml:space="preserve">
+    <value>Group with ID {0} does not exist.</value>
+  </data>
+  <data name="Provisioning_ObjectHandlers_Teams_Team_AppProvisioningError" xml:space="preserve">
+    <value>Cannot register App for Team.</value>
+  </data>
+  <data name="Provisioning_ObjectHandlers_Teams_Team_CannotSendMessage" xml:space="preserve">
+    <value>Cannot send a message to the target Channel.</value>
+  </data>
+  <data name="Provisioning_ObjectHandlers_Teams_Team_ChannelAlreadyExists" xml:space="preserve">
+    <value>Channel already exists.</value>
+  </data>
+  <data name="Provisioning_ObjectHandlers_Teams_Team_FailedArchiveUnarchive" xml:space="preserve">
+    <value>Exception while archiving/unarchiving Team with ID {0}. Details: {1}.</value>
+  </data>
+  <data name="Provisioning_ObjectHandlers_Teams_Team_TabAlreadyExists" xml:space="preserve">
+    <value>Tab already exists.</value>
+  </data>
   <data name="Provisioning_ObjectHandlers_ListInstances_Added_PropertyBagEntry__0__To_List__1" xml:space="preserve">
     <value>Added property bag entry {0} to list {1}</value>
+  </data>
+  <data name="Provisioning_ObjectHandlers_ListInstances_SkipAddingOrUpdatingPropertyBag" xml:space="preserve">
+    <value>Skip adding/updating list property bag because the site has "noscript" enabled.</value>
   </data>
 </root>

--- a/Core/OfficeDevPnP.Core/CoreResources.resx
+++ b/Core/OfficeDevPnP.Core/CoreResources.resx
@@ -1135,7 +1135,61 @@
   <data name="Provisioning_ObjectHandlers_Teams_TeamTemplate_FetchingError" xml:space="preserve">
     <value>Failed to get team information after provisioning.</value>
   </data>
+  <data name="Provisioning_ObjectHandlers_Teams_Team_AddingMemberError" xml:space="preserve">
+    <value>Failed to add member to team.</value>
+  </data>
+  <data name="Provisioning_ObjectHandlers_Teams_Team_AddingOwnerError" xml:space="preserve">
+    <value>Failed to add owner to team.</value>
+  </data>
+  <data name="Provisioning_ObjectHandlers_Teams_Team_FetchingError" xml:space="preserve">
+    <value>Failed to get team information after provisioning.</value>
+  </data>
+  <data name="Provisioning_ObjectHandlers_Teams_Team_FetchingUserError" xml:space="preserve">
+    <value>Failed to get user by upn information.</value>
+  </data>
+  <data name="Provisioning_ObjectHandlers_Teams_Team_ListingMembersError" xml:space="preserve">
+    <value>Failed to list team members.</value>
+  </data>
+  <data name="Provisioning_ObjectHandlers_Teams_Team_ListingOwnersError" xml:space="preserve">
+    <value>Failed to list team owners.</value>
+  </data>
+  <data name="Provisioning_ObjectHandlers_Teams_Team_ProvisioningError" xml:space="preserve">
+    <value>Provisioning a team failed.</value>
+  </data>
+  <data name="Provisioning_ObjectHandlers_Teams_Team_RemovingMemberError" xml:space="preserve">
+    <value>Failed to remove member from team.</value>
+  </data>
+  <data name="Provisioning_ObjectHandlers_Teams_Team_RemovingOwnerError" xml:space="preserve">
+    <value>Failed to remove owner from team.</value>
+  </data>
+  <data name="Provisioning_ObjectHandlers_Teams_Team_CreatingGroupError" xml:space="preserve">
+    <value>Failed to create group for team</value>
+  </data>
+  <data name="Provisioning_ObjectHandlers_Teams_Team_AlreadyExists" xml:space="preserve">
+    <value>Team already exists</value>
+  </data>
+  <data name="Provisioning_ObjectHandlers_Teams_Team_GroupAlreadyExists" xml:space="preserve">
+    <value>Group already exists</value>
+  </data>
   <data name="TermGroup_No_Access" xml:space="preserve">
     <value>Login context does not have access to the TermGroup. If using app context, add app@sharepoint to the term group access list.</value>
+  </data>
+  <data name="Provisioning_ObjectHandlers_Teams_Team_GroupDoesNotExists" xml:space="preserve">
+    <value>Group with ID {0} does not exist.</value>
+  </data>
+  <data name="Provisioning_ObjectHandlers_Teams_Team_AppProvisioningError" xml:space="preserve">
+    <value>Cannot register App for Team.</value>
+  </data>
+  <data name="Provisioning_ObjectHandlers_Teams_Team_CannotSendMessage" xml:space="preserve">
+    <value>Cannot send a message to the target Channel.</value>
+  </data>
+  <data name="Provisioning_ObjectHandlers_Teams_Team_ChannelAlreadyExists" xml:space="preserve">
+    <value>Channel already exists.</value>
+  </data>
+  <data name="Provisioning_ObjectHandlers_Teams_Team_FailedArchiveUnarchive" xml:space="preserve">
+    <value>Exception while archiving/unarchiving Team with ID {0}. Details: {1}.</value>
+  </data>
+  <data name="Provisioning_ObjectHandlers_Teams_Team_TabAlreadyExists" xml:space="preserve">
+    <value>Tab already exists.</value>
   </data>
 </root>

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteFooterSettings.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteFooterSettings.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !ONPREMISES
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -12,7 +13,6 @@ using Newtonsoft.Json;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 {
-#if !ONPREMISES
     internal class ObjectSiteFooterSettings : ObjectHandlerBase
     {
         //const string footerNodeKey = "13b7c916-4fea-4bb2-8994-5cf274aeb530";
@@ -28,7 +28,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
         public override ProvisioningTemplate ExtractObjects(Web web, ProvisioningTemplate template, ProvisioningTemplateCreationInformation creationInfo)
         {
-#if !ONPREMISES
             using (var scope = new PnPMonitoredScope(this.Name))
             {
                 web.EnsureProperties(w => w.FooterEnabled, w => w.ServerRelativeUrl);
@@ -59,10 +58,10 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         }
                     }
                     // find the logo node
-                    if(string.IsNullOrEmpty(footer.Logo))
+                    if (string.IsNullOrEmpty(footer.Logo))
                     {
                         var logoNode = menuState.Nodes.FirstOrDefault(n => n.Title == Constants.SITEFOOTER_LOGONODEKEY);
-                        if(logoNode != null)
+                        if (logoNode != null)
                         {
                             footer.Logo = Tokenize(logoNode.SimpleUrl, web.ServerRelativeUrl);
                         }
@@ -79,7 +78,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 }
                 template.Footer = footer;
             }
-#endif
             return template;
         }
 
@@ -102,7 +100,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
         public override TokenParser ProvisionObjects(Web web, ProvisioningTemplate template, TokenParser parser, ProvisioningTemplateApplyingInformation applyingInformation)
         {
-#if !ONPREMISES
             using (var scope = new PnPMonitoredScope(this.Name))
             {
                 if (template.Footer != null)
@@ -212,14 +209,12 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     }
                 }
             }
-#endif
             return parser;
         }
 
         public override bool WillExtract(Web web, ProvisioningTemplate template, ProvisioningTemplateCreationInformation creationInfo)
         {
-            var baseTemplateValue = web.GetBaseTemplateId();
-            if (baseTemplateValue.Equals("SITEPAGEPUBLISHING#0", StringComparison.InvariantCultureIgnoreCase))
+            if ((web.Context as ClientContext).Site.IsCommunicationSite())
             {
                 return true;
             }
@@ -231,8 +226,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
         public override bool WillProvision(Web web, ProvisioningTemplate template, ProvisioningTemplateApplyingInformation applyingInformation)
         {
-            var baseTemplateValue = web.GetBaseTemplateId();
-            if (baseTemplateValue.Equals("SITEPAGEPUBLISHING#0", StringComparison.InvariantCultureIgnoreCase))
+            if ((web.Context as ClientContext).Site.IsCommunicationSite())
             {
                 return template.Footer != null;
             }
@@ -283,5 +277,5 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             public MenuState MenuState { get; set; }
         }
     }
-#endif
 }
+#endif

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTeams.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTeams.cs
@@ -7,76 +7,582 @@ using System.Net.Http.Headers;
 using Newtonsoft.Json.Linq;
 using OfficeDevPnP.Core.Framework.Provisioning.Model.Teams;
 using OfficeDevPnP.Core.Utilities;
+using System.Net;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Web;
+using System.Net.Http;
+using Microsoft.Online.SharePoint.TenantAdministration;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 {
     /// <summary>
     /// Object Handler to manage Microsoft Teams stuff
     /// </summary>
-    internal class ObjectTeams : ObjectHandlerBase
+    internal class ObjectTeams : ObjectHierarchyHandlerBase
     {
+        private static String jsonContentType = "application/json";
+
         public override string Name => "Teams";
-        public override string InternalName => "Teams";
 
-        public override TokenParser ProvisionObjects(Web web, ProvisioningTemplate template, TokenParser parser, ProvisioningTemplateApplyingInformation applyingInformation)
+        /// <summary>
+        /// Creates a new Team from a PnP Provisioning Schema definition
+        /// </summary>
+        /// <param name="scope">The PnP Provisioning Scope</param>
+        /// <param name="parser">The PnP Token Parser</param>
+        /// <param name="team">The Team to provision</param>
+        /// <param name="accessToken">The OAuth 2.0 Access Token</param>
+        /// <returns>The provisioned Team as a JSON object</returns>
+        private static JToken CreateTeamFromProvisioningSchema(PnPMonitoredScope scope, TokenParser parser, Team team, string accessToken)
         {
-#if !ONPREMISES
-            using (var scope = new PnPMonitoredScope(Name))
-            {
-                var accessToken = PnPProvisioningContext.Current.AcquireToken("https://graph.microsoft.com/", "Group.ReadWrite.All");
+            String teamId = null;
 
-                // - Teams Templates
-                var teamTemplates = template.ParentHierarchy.Teams?.TeamTemplates;
-                if (teamTemplates != null && teamTemplates.Any())
+            // If we have to Clone an existing Team
+            if (!String.IsNullOrWhiteSpace(team.CloneFrom))
+            {
+                // TODO: handle cloning
+                scope.LogError("Cloning not supported yet");
+                return null;
+            }
+            // If we start from an already existing Group
+            else if (!String.IsNullOrEmpty(team.GroupId))
+            {
+                // Check if the Group exists
+                if (GroupExists(scope, team.GroupId, accessToken))
                 {
-                    foreach (var teamTemplate in teamTemplates)
+                    // Then promote the Group into a Team or update it, if it already exists
+                    teamId = CreateOrUpdateTeamFromGroup(scope, team, accessToken);
+                }
+                else
+                {
+                    // Log the exception and return NULL (i.e. cancel)
+                    scope.LogError(CoreResources.Provisioning_ObjectHandlers_Teams_Team_GroupDoesNotExists, team.GroupId);
+                    return null;
+                }
+            }
+            // Otherwise create a Team from scratch
+            else
+            {
+                teamId = CreateOrUpdateTeam(scope, team, accessToken);
+            }
+
+            if (!String.IsNullOrEmpty(teamId))
+            {
+                // Wait for the Team to be ready
+                Boolean wait = true;
+                Int32 iterations = 0;
+                while (wait)
+                {
+                    iterations++;
+
+                    try
                     {
-                        var team = CreateByTeamTemplate(scope, parser, teamTemplate, accessToken);
-                        // possible further processing...
+                        var jsonOwners = HttpHelper.MakeGetRequestForString($"https://graph.microsoft.com/v1.0/groups/{teamId}/owners?$select=id", accessToken);
+                        if (!String.IsNullOrEmpty(jsonOwners))
+                        {
+                            wait = false;
+                        }
+                    }
+                    catch (Exception)
+                    {
+                        // In case of exception wait for 5 secs
+                        System.Threading.Thread.Sleep(TimeSpan.FromSeconds(5));
+                    }
+
+                    // Don't wait more than 1 minute
+                    if (iterations > 12)
+                    {
+                        wait = false;
                     }
                 }
 
-                // - Teams
-                // - Apps
-            }
-#endif
+                // Call Archive or Unarchive for the current Team
+                ArchiveTeam(scope, teamId, team.Archived, accessToken);
 
-            return parser;
+                // And now we configure security, channels, and apps
+                if (!SetGroupSecurity(scope, team, teamId, accessToken)) return null;
+                if (!SetTeamChannels(scope, parser, team, teamId, accessToken)) return null;
+                if (!SetTeamApps(scope, team, teamId, accessToken)) return null;
+
+                try
+                {
+                    // Get the whole Team that we just created and return it back as the method result
+                    return JToken.Parse(HttpHelper.MakeGetRequestForString($"https://graph.microsoft.com/v1.0/teams/{teamId}", accessToken));
+                }
+                catch (Exception ex)
+                {
+                    scope.LogError(CoreResources.Provisioning_ObjectHandlers_Teams_Team_FetchingError, ex.Message);
+                }
+            }
+
+            return null;
         }
 
-        public override ProvisioningTemplate ExtractObjects(Web web, ProvisioningTemplate template, ProvisioningTemplateCreationInformation creationInfo)
+        /// <summary>
+        /// Checks if a Group exists
+        /// </summary>
+        /// <param name="scope">The PnP Provisioning Scope</param>
+        /// <param name="groupId">The ID of the Group</param>
+        /// <param name="accessToken">The OAuth 2.0 Access Token</param>
+        /// <returns>Whether the Group exists or not</returns>
+        private static Boolean GroupExists(PnPMonitoredScope scope, string groupId, string accessToken)
         {
-            // So far, no extraction
-            return template;
+            try
+            {
+                var existingGroup = JToken.Parse(HttpHelper.MakeGetRequestForString($"https://graph.microsoft.com/v1.0/groups/{groupId}", accessToken));
+                if (existingGroup.Value<String>("id") == groupId)
+                {
+                    return (true);
+                }
+                else
+                {
+                    return (false);
+                }
+            }
+            catch (Exception)
+            {
+                return (false);
+            }
+
         }
 
-        public override bool WillProvision(Web web, ProvisioningTemplate template, ProvisioningTemplateApplyingInformation applyingInformation)
+        /// <summary>
+        /// Creates or updates a Team object via Graph
+        /// </summary>
+        /// <param name="scope">The PnP Provisioning Scope</param>
+        /// <param name="team">The Team to create</param>
+        /// <param name="accessToken">The OAuth 2.0 Access Token</param>
+        /// <returns>The ID of the created or update Team</returns>
+        private static string CreateOrUpdateTeam(PnPMonitoredScope scope, Team team, string accessToken)
         {
-#if !ONPREMISES
-            if (!_willProvision.HasValue)
-            {
-                _willProvision = template.ParentHierarchy.Teams?.TeamTemplates?.Any() |
-                    template.ParentHierarchy.Teams?.Teams?.Any();
-            }
-#else
-            if (!_willProvision.HasValue)
-            {
-                _willProvision = false;
-            }
-#endif            
-            return _willProvision.Value;
+            var content = PrepareTeamRequestContent(team);
+
+            var teamId = CreateOrUpdateGraphObject(scope,
+                HttpMethodVerb.POST_WITH_RESPONSE_HEADERS,
+                $"https://graph.microsoft.com/beta/teams",
+                content,
+                jsonContentType,
+                accessToken,
+                "Conflict",
+                CoreResources.Provisioning_ObjectHandlers_Teams_Team_AlreadyExists,
+                "id",
+                team.GroupId,
+                CoreResources.Provisioning_ObjectHandlers_Teams_Team_ProvisioningError,
+                canPatch: true);
+
+            return (teamId);
         }
 
-        public override bool WillExtract(Web web, ProvisioningTemplate template, ProvisioningTemplateCreationInformation creationInfo)
+        /// <summary>
+        /// Creates or updates a Team object via Graph promoting an existing Group
+        /// </summary>
+        /// <param name="scope">The PnP Provisioning Scope</param>
+        /// <param name="team">The Team to create</param>
+        /// <param name="accessToken">The OAuth 2.0 Access Token</param>
+        /// <returns>The ID of the created or updated Team</returns>
+        private static string CreateOrUpdateTeamFromGroup(PnPMonitoredScope scope, Team team, string accessToken)
         {
-            if (!_willExtract.HasValue)
-            {
-                _willExtract = false;
-            }
-            return _willExtract.Value;
+            var content = PrepareTeamRequestContent(team);
+
+            var teamId = CreateOrUpdateGraphObject(scope,
+                HttpMethodVerb.POST,
+                $"https://graph.microsoft.com/beta/groups/{team.GroupId}/team",
+                content,
+                jsonContentType,
+                accessToken,
+                "Conflict",
+                CoreResources.Provisioning_ObjectHandlers_Teams_Team_AlreadyExists,
+                "id",
+                team.GroupId,
+                CoreResources.Provisioning_ObjectHandlers_Teams_Team_ProvisioningError,
+                canPatch: true);
+
+            return (teamId);
         }
 
-        private static JToken CreateByTeamTemplate(PnPMonitoredScope scope, TokenParser parser, TeamTemplate teamTemplate, string accessToken)
+        /// <summary>
+        /// Prepares the JSON object for the request to create/update a Team
+        /// </summary>
+        /// <param name="team">The Domain Model Team object</param>
+        /// <returns>The JSON object ready to be serialized into the JSON request</returns>
+        private static Object PrepareTeamRequestContent(Team team)
+        {
+            var content = new
+            {
+                template_odata_bind = "https://graph.microsoft.com/beta/teamsTemplates('standard')",
+                team.DisplayName,
+                team.Description,
+                //team.Classification,
+                //team.Specialization,
+                //team.Visibility,
+                funSettings = new
+                {
+                    team.FunSettings.AllowGiphy,
+                    team.FunSettings.GiphyContentRating,
+                    team.FunSettings.AllowStickersAndMemes,
+                    team.FunSettings.AllowCustomMemes,
+                },
+                guestSettings = new
+                {
+                    team.GuestSettings.AllowCreateUpdateChannels,
+                    team.GuestSettings.AllowDeleteChannels,
+                },
+                memberSettings = new
+                {
+                    team.MemberSettings.AllowCreateUpdateChannels,
+                    team.MemberSettings.AllowAddRemoveApps,
+                    team.MemberSettings.AllowDeleteChannels,
+                    team.MemberSettings.AllowCreateUpdateRemoveTabs,
+                    team.MemberSettings.AllowCreateUpdateRemoveConnectors
+                },
+                messagingSettings = new
+                {
+                    team.MessagingSettings.AllowUserEditMessages,
+                    team.MessagingSettings.AllowUserDeleteMessages,
+                    team.MessagingSettings.AllowOwnerDeleteMessages,
+                    team.MessagingSettings.AllowTeamMentions,
+                    team.MessagingSettings.AllowChannelMentions
+                }
+            };
+
+            return (content);
+        }
+
+        /// <summary>
+        /// Creates or updates a Team object via Graph
+        /// </summary>
+        /// <param name="scope">The PnP Provisioning Scope</param>
+        /// <param name="teamId">The ID of the target Team</param>
+        /// <param name="archived">A flag to declare to archive or unarchive the Team</param>
+        /// <param name="accessToken">The OAuth 2.0 Access Token</param>
+        private static void ArchiveTeam(PnPMonitoredScope scope, String teamId, Boolean archived, String accessToken)
+        {
+            try
+            {
+                if (archived)
+                {
+                    // Archive the Team
+                    HttpHelper.MakePostRequest(
+                        $"https://graph.microsoft.com/beta/teams/{teamId}/archive", accessToken: accessToken);
+                }
+                else
+                {
+                    // Unarchive the Team
+                    HttpHelper.MakePostRequest(
+                        $"https://graph.microsoft.com/beta/teams/{teamId}/unarchive", accessToken: accessToken);
+                }
+            }
+            catch (Exception ex)
+            {
+                scope.LogError(CoreResources.Provisioning_ObjectHandlers_Teams_Team_FailedArchiveUnarchive, teamId, ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Synchronizes Owners and Members with Team settings
+        /// </summary>
+        /// <param name="scope">The PnP Provisioning Scope</param>
+        /// <param name="team">The Team settings, including security settings</param>
+        /// <param name="teamId">The ID of the target Team</param>
+        /// <param name="accessToken">The OAuth 2.0 Access Token</param>
+        /// <returns>Whether the Security settings have been provisioned or not</returns>
+        private static bool SetGroupSecurity(PnPMonitoredScope scope, Team team, string teamId, string accessToken)
+        {
+            String[] desideredOwnerIds;
+            String[] desideredMemberIds;
+            try
+            {
+                var userIdsByUPN = team.Security.Owners
+                    .Select(o => o.UserPrincipalName)
+                    .Concat(team.Security.Members.Select(m => m.UserPrincipalName))
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToDictionary(k => k, k =>
+                    {
+                        var jsonUser = HttpHelper.MakeGetRequestForString($"https://graph.microsoft.com/v1.0/users/{k}?$select=id", accessToken);
+                        return JToken.Parse(jsonUser).Value<string>("id");
+                    });
+
+                desideredOwnerIds = team.Security.Owners.Select(o => userIdsByUPN[o.UserPrincipalName]).ToArray();
+                desideredMemberIds = team.Security.Members.Select(o => userIdsByUPN[o.UserPrincipalName]).ToArray();
+            }
+            catch (Exception ex)
+            {
+                scope.LogError(CoreResources.Provisioning_ObjectHandlers_Teams_Team_FetchingUserError, ex.Message);
+                return false;
+            }
+
+            String[] ownerIdsToAdd;
+            String[] ownerIdsToRemove;
+            try
+            {
+                // Get current group owners
+                var jsonOwners = HttpHelper.MakeGetRequestForString($"https://graph.microsoft.com/v1.0/groups/{teamId}/owners?$select=id", accessToken);
+
+                string[] currentOwnerIds = GetIdsFromList(jsonOwners);
+
+                // Exclude owners already into the group
+                ownerIdsToAdd = desideredOwnerIds.Except(currentOwnerIds).ToArray();
+
+                if (team.Security.ClearExistingOwners)
+                {
+                    ownerIdsToRemove = currentOwnerIds.Except(desideredOwnerIds).ToArray();
+                }
+                else
+                {
+                    ownerIdsToRemove = new string[0];
+                }
+            }
+            catch (Exception ex)
+            {
+                scope.LogError(CoreResources.Provisioning_ObjectHandlers_Teams_Team_ListingOwnersError, ex.Message);
+                return false;
+            }
+
+            // Add new owners
+            foreach (string ownerId in ownerIdsToAdd)
+            {
+                try
+                {
+                    object content = new JObject
+                    {
+                        ["@odata.id"] = $"https://graph.microsoft.com/v1.0/users/{ownerId}"
+                    };
+                    HttpHelper.MakePostRequest($"https://graph.microsoft.com/v1.0/groups/{teamId}/owners/$ref", content, "application/json", accessToken);
+                }
+                catch (Exception ex)
+                {
+                    scope.LogError(CoreResources.Provisioning_ObjectHandlers_Teams_Team_AddingOwnerError, ex.Message);
+                    return false;
+                }
+            }
+
+            // Remove exceeding owners
+            foreach (string ownerId in ownerIdsToRemove)
+            {
+                try
+                {
+                    HttpHelper.MakeDeleteRequest($"https://graph.microsoft.com/v1.0/groups/{teamId}/owners/{ownerId}/$ref", accessToken);
+                }
+                catch (Exception ex)
+                {
+                    scope.LogError(CoreResources.Provisioning_ObjectHandlers_Teams_Team_RemovingOwnerError, ex.Message);
+                    return false;
+                }
+            }
+
+            String[] memberIdsToAdd;
+            String[] memberIdsToRemove;
+            try
+            {
+                // Get current group members
+                var jsonOwners = HttpHelper.MakeGetRequestForString($"https://graph.microsoft.com/v1.0/groups/{teamId}/members?$select=id", accessToken);
+
+                string[] currentMemberIds = GetIdsFromList(jsonOwners);
+
+                // Exclude members already into the group
+                memberIdsToAdd = desideredMemberIds.Except(currentMemberIds).ToArray();
+
+                if (team.Security.ClearExistingMembers)
+                {
+                    memberIdsToRemove = currentMemberIds.Except(desideredMemberIds).ToArray();
+                }
+                else
+                {
+                    memberIdsToRemove = new string[0];
+                }
+            }
+            catch (Exception ex)
+            {
+                scope.LogError(CoreResources.Provisioning_ObjectHandlers_Teams_Team_ListingMembersError, ex.Message);
+                return false;
+            }
+
+            // Add new members
+            foreach (string memberId in memberIdsToAdd)
+            {
+                try
+                {
+                    object content = new JObject
+                    {
+                        ["@odata.id"] = $"https://graph.microsoft.com/v1.0/users/{memberId}"
+                    };
+                    HttpHelper.MakePostRequest($"https://graph.microsoft.com/v1.0/groups/{teamId}/members/$ref", content, "application/json", accessToken);
+                }
+                catch (Exception ex)
+                {
+                    scope.LogError(CoreResources.Provisioning_ObjectHandlers_Teams_Team_AddingMemberError, ex.Message);
+                    return false;
+                }
+            }
+
+            // Remove exceeding members
+            foreach (string memberId in memberIdsToRemove)
+            {
+                try
+                {
+                    HttpHelper.MakeDeleteRequest($"https://graph.microsoft.com/v1.0/groups/{teamId}/members/{memberId}/$ref", accessToken);
+                }
+                catch (Exception ex)
+                {
+                    scope.LogError(CoreResources.Provisioning_ObjectHandlers_Teams_Team_RemovingMemberError, ex.Message);
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Synchronizes Team Channels settings
+        /// </summary>
+        /// <param name="scope">The PnP Provisioning Scope</param>
+        /// <param name="parser">The PnP Token Parser</param>
+        /// <param name="team">The Team settings, including security settings</param>
+        /// <param name="teamId">The ID of the target Team</param>
+        /// <param name="accessToken">The OAuth 2.0 Access Token</param>
+        /// <returns>Whether the Channels have been provisioned or not</returns>
+        private static bool SetTeamChannels(PnPMonitoredScope scope, TokenParser parser, Team team, string teamId, string accessToken)
+        {
+            // TODO: create resource strings for exceptions
+
+            if (team.Channels != null)
+            {
+                foreach (var channel in team.Channels)
+                {
+                    // Create the channel object for the API call
+                    var channelToCreate = new
+                    {
+                        channel.Description,
+                        channel.DisplayName,
+                        channel.IsFavoriteByDefault
+                    };
+
+                    var channelId = CreateOrUpdateGraphObject(scope,
+                        HttpMethodVerb.POST,
+                        $"https://graph.microsoft.com/beta/teams/{teamId}/channels",
+                        channelToCreate,
+                        jsonContentType,
+                        accessToken,
+                        "NameAlreadyExists",
+                        CoreResources.Provisioning_ObjectHandlers_Teams_Team_ChannelAlreadyExists,
+                        "displayName",
+                        channel.DisplayName,
+                        CoreResources.Provisioning_ObjectHandlers_Teams_Team_ProvisioningError,
+                        canPatch: false);
+
+                    if (channelId == null) return false;
+
+                    // If there are any Tabs for the current channel
+                    if (channel.Tabs == null || !channel.Tabs.Any()) continue;
+
+                    foreach (var tab in channel.Tabs)
+                    {
+                        // Create the object for the API call
+                        var tabToCreate = new
+                        {
+                            tab.DisplayName,
+                            tab.TeamsAppId,
+                            configuration = tab.Configuration != null ? new
+                            {
+                                tab.Configuration.EntityId,
+                                tab.Configuration.ContentUrl,
+                                tab.Configuration.RemoveUrl,
+                                tab.Configuration.WebsiteUrl
+                            } : null
+                        };
+
+                        var tabId = CreateOrUpdateGraphObject(scope,
+                            HttpMethodVerb.POST,
+                            $"https://graph.microsoft.com/beta/teams/{teamId}/channels/{channelId}/tabs",
+                            tabToCreate,
+                            jsonContentType,
+                            accessToken,
+                            "NameAlreadyExists",
+                            CoreResources.Provisioning_ObjectHandlers_Teams_Team_TabAlreadyExists,
+                            "displayName",
+                            tab.DisplayName,
+                            CoreResources.Provisioning_ObjectHandlers_Teams_Team_ProvisioningError,
+                            canPatch: false);
+
+                        if (tabId == null) return false;
+                    }
+
+                    // TODO: Handle TabResources
+                    // We need to define a "schema" for their settings
+
+                    // If there are any messages for the current channel
+                    if (channel.Messages == null || !channel.Messages.Any()) continue;
+
+                    foreach (var message in channel.Messages)
+                    {
+                        // Get and parse the CData
+                        var messageString = parser.ParseString(message.Message);
+                        var messageJson = JToken.Parse(messageString);
+
+                        var messageId = CreateOrUpdateGraphObject(scope,
+                            HttpMethodVerb.POST,
+                            $"https://graph.microsoft.com/beta/teams/{teamId}/channels/{channelId}/messages",
+                            messageJson,
+                            jsonContentType,
+                            accessToken,
+                            null,
+                            null,
+                            null,
+                            null,
+                            CoreResources.Provisioning_ObjectHandlers_Teams_Team_CannotSendMessage,
+                            canPatch: false);
+
+                        if (messageId == null) return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Synchronizes Team Apps settings
+        /// </summary>
+        /// <param name="scope">The PnP Provisioning Scope</param>
+        /// <param name="team">The Team settings, including security settings</param>
+        /// <param name="teamId">The ID of the target Team</param>
+        /// <param name="accessToken">The OAuth 2.0 Access Token</param>
+        /// <returns>Whether the Apps have been provisioned or not</returns>
+        private static bool SetTeamApps(PnPMonitoredScope scope, Team team, string teamId, string accessToken)
+        {
+            foreach (var app in team.Apps)
+            {
+                Object appToCreate = new JObject
+                {
+                    ["teamsApp@odata.bind"] = app.AppId
+                };
+
+                var id = CreateOrUpdateGraphObject(scope,
+                    HttpMethodVerb.POST,
+                    $"https://graph.microsoft.com/beta/teams/{teamId}/installedApps",
+                    appToCreate,
+                    jsonContentType,
+                    accessToken,
+                    null,
+                    null,
+                    null,
+                    null,
+                    CoreResources.Provisioning_ObjectHandlers_Teams_Team_AppProvisioningError,
+                    canPatch: false);
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Creates a Team starting from a JSON template
+        /// </summary>
+        /// <param name="scope">The PnP Provisioning Scope</param>
+        /// <param name="parser">The PnP Token Parser</param>
+        /// <param name="teamTemplate">The Team JSON template</param>
+        /// <param name="accessToken">The OAuth 2.0 Access Token</param>
+        /// <returns>The provisioned Team as a JSON object</returns>
+        private static JToken CreateTeamFromJsonTemplate(PnPMonitoredScope scope, TokenParser parser, TeamTemplate teamTemplate, string accessToken)
         {
             HttpResponseHeaders responseHeaders;
             try
@@ -104,6 +610,22 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             return null;
         }
 
+        /// <summary>
+        /// Retrieves the IDs of items in a JSON list
+        /// </summary>
+        /// <param name="json">The JSON list</param>
+        /// <returns>The array of IDs</returns>
+        private static string[] GetIdsFromList(string json)
+        {
+            return JsonConvert.DeserializeAnonymousType(json, new { value = new[] { new { id = "" } } }).value.Select(v => v.id).ToArray();
+        }
+
+        /// <summary>
+        /// Allows to overwrite some settings of the templates provisioned through JSON template
+        /// </summary>
+        /// <param name="parser">The PnP Token Parser</param>
+        /// <param name="teamTemplate">The Team JSON template</param>
+        /// <returns>The updated Team JSON template</returns>
         private static string OverwriteJsonTemplateProperties(TokenParser parser, TeamTemplate teamTemplate)
         {
             var jsonTemplate = parser.ParseString(teamTemplate.JsonTemplate);
@@ -111,10 +633,211 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
             if (teamTemplate.DisplayName != null) team["displayName"] = teamTemplate.DisplayName;
             if (teamTemplate.Description != null) team["description"] = teamTemplate.Description;
-            if (teamTemplate.Classification != null) team["classification"] = teamTemplate.Classification;
-            if (teamTemplate.Visibility != null) team["visibility"] = teamTemplate.Visibility.ToString();
+            // if (teamTemplate.Classification != null) team["classification"] = teamTemplate.Classification;
+            // team["visibility"] = teamTemplate.Visibility.ToString();
 
             return team.ToString();
         }
+
+        /// <summary>
+        /// Helper method to create or update an object through the Microsoft Graph
+        /// </summary>
+        /// <param name="scope">The PnP Provisioning Scope</param>
+        /// <param name="method">The HTTP method to use</param>
+        /// <param name="uri">The URI for the Graph request</param>
+        /// <param name="content">The content of the Graph request</param>
+        /// <param name="contentType">The content type of the Graph request</param>
+        /// <param name="accessToken">The OAuth 2.0 Access Token</param>
+        /// <param name="alreadyExistsErrorMessage">The error message token that identifies an already existing item</param>
+        /// <param name="warningMessage">The warning message to log when the target item already exists</param>
+        /// <param name="matchingFieldName">The name of a field to match an already existing instance of the target item</param>
+        /// <param name="matchingFieldValue">The value of a field to match an already existing instance of the target item</param>
+        /// <param name="errorMessage">The error message to log when the create or update action fails</param>
+        /// <param name="canPatch">Defines whether a Patch HTTP request can be executed to update an already existing target item</param>
+        /// <returns>The ID of the create or updated target item</returns>
+        private static String CreateOrUpdateGraphObject(
+            PnPMonitoredScope scope,
+            HttpMethodVerb method,
+            String uri,
+            Object content,
+            String contentType,
+            String accessToken,
+            String alreadyExistsErrorMessage,
+            String warningMessage,
+            String matchingFieldName,
+            String matchingFieldValue,
+            String errorMessage,
+            Boolean canPatch
+            )
+        {
+            try
+            {
+                String itemId = null;
+                String json = null;
+                HttpResponseHeaders responseHeaders;
+
+                // Try to create the Graph object
+                switch (method)
+                {
+                    case HttpMethodVerb.POST:
+                        json = HttpHelper.MakePostRequestForString(uri, content, contentType, accessToken);
+                        itemId = JToken.Parse(json).Value<String>("id");
+                        break;
+                    case HttpMethodVerb.PUT:
+                        json = HttpHelper.MakePutRequestForString(uri, content, contentType, accessToken);
+                        itemId = JToken.Parse(json).Value<String>("id");
+                        break;
+                    case HttpMethodVerb.POST_WITH_RESPONSE_HEADERS:
+                        responseHeaders = HttpHelper.MakePostRequestForHeaders(uri, content, contentType, accessToken);
+                        itemId = responseHeaders.Location.ToString().Split('\'')[1];
+                        break;
+                }
+
+                // Return the ID of the just created item
+                return itemId;
+            }
+            catch (Exception ex)
+            {
+                // In case of exception, let's see if the target item already exists
+                if (!String.IsNullOrEmpty(alreadyExistsErrorMessage) && 
+                    !String.IsNullOrEmpty(matchingFieldName) &&
+                    !String.IsNullOrEmpty(matchingFieldValue) &&
+                    ex.InnerException.Message.Contains(alreadyExistsErrorMessage))
+                {
+                    try
+                    {
+                        if (!String.IsNullOrEmpty(warningMessage))
+                        {
+                            scope.LogWarning(warningMessage);
+                        }
+
+                        // If it's a POST we need to look for any existing item
+                        String id = null;
+
+                        // In case of PUT we already have the id
+                        if (method == HttpMethodVerb.POST)
+                        {
+                            // Filter by field and value specified
+                            String json = HttpHelper.MakeGetRequestForString($"{uri}?$select=id&$filter={matchingFieldName}%20eq%20'{WebUtility.UrlEncode(matchingFieldValue)}'");
+                            // Get the id of existing item
+                            id = GetIdsFromList(json)[0];
+                            uri = $"{uri}/{id}";
+                        }
+
+                        // Patch the item, if supported
+                        if (canPatch)
+                        {
+                            HttpHelper.MakePatchRequestForString(uri, content, contentType, accessToken);
+                        }
+
+                        return id;
+                    }
+                    catch (Exception exUpdate)
+                    {
+                        if (!String.IsNullOrEmpty(errorMessage))
+                        {
+                            scope.LogError(errorMessage, exUpdate.Message);
+                        }
+                        return null;
+                    }
+                }
+                else
+                {
+                    return (null);
+                }
+            }
+        }
+
+        #region PnP Provisioning Engine infrastructural code
+
+        public override bool WillProvision(Tenant tenant, ProvisioningHierarchy hierarchy, string sequenceId, ProvisioningTemplateApplyingInformation applyingInformation)
+        {
+#if !ONPREMISES
+            if (!_willProvision.HasValue)
+            {
+                _willProvision = hierarchy.Teams?.TeamTemplates?.Any() |
+                    hierarchy.Teams?.Teams?.Any();
+            }
+#else
+            if (!_willProvision.HasValue)
+            {
+                _willProvision = false;
+            }
+#endif            
+            return _willProvision.Value;
+        }
+
+        public override bool WillExtract(Tenant tenant, ProvisioningHierarchy hierarchy, string sequenceId, ProvisioningTemplateCreationInformation creationInfo)
+        {
+            if (!_willExtract.HasValue)
+            {
+                _willExtract = false;
+            }
+            return _willExtract.Value;
+        }
+
+        public override TokenParser ProvisionObjects(Tenant tenant, ProvisioningHierarchy hierarchy, string sequenceId, TokenParser parser, ProvisioningTemplateApplyingInformation applyingInformation)
+        {
+#if !ONPREMISES
+            using (var scope = new PnPMonitoredScope(Name))
+            {
+                // Prepare a method global variable to store the Access Token
+                String accessToken = null;
+
+                // - Teams based on JSON templates
+                var teamTemplates = hierarchy.Teams?.TeamTemplates;
+                if (teamTemplates != null && teamTemplates.Any())
+                {
+                    foreach (var teamTemplate in teamTemplates)
+                    {
+                        // Get a fresh Access Token for every request
+                        accessToken = PnPProvisioningContext.Current.AcquireToken("https://graph.microsoft.com/", "Group.ReadWrite.All");
+
+                        // Create the Team starting from the JSON template
+                        var team = CreateTeamFromJsonTemplate(scope, parser, teamTemplate, accessToken);
+
+                        // TODO: possible further processing...
+                    }
+                }
+
+                // - Teams based on XML templates
+                var teams = hierarchy.Teams?.Teams;
+                if (teams != null && teams.Any())
+                {
+                    foreach (var team in teams)
+                    {
+                        // Get a fresh Access Token for every request
+                        accessToken = PnPProvisioningContext.Current.AcquireToken("https://graph.microsoft.com/", "Group.ReadWrite.All");
+
+                        // Create the Team starting from the XML PnP Provisioning Schema definition
+                        CreateTeamFromProvisioningSchema(scope, parser, team, accessToken);
+
+                        // TODO: possible further processing...
+                    }
+                }
+
+                // - Apps
+            }
+#endif
+
+            return parser;
+        }
+
+        public override ProvisioningHierarchy ExtractObjects(Tenant tenant, ProvisioningHierarchy hierarchy, ProvisioningTemplateCreationInformation creationInfo)
+        {
+            // So far, no extraction
+            return hierarchy;
+        }
+
+        #endregion
+    }
+
+    enum HttpMethodVerb
+    {
+        GET,
+        POST,
+        PUT,
+        PATCH,
+        POST_WITH_RESPONSE_HEADERS
     }
 }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTeams.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTeams.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.SharePoint.Client;
+﻿#if !ONPREMISES
+using Microsoft.SharePoint.Client;
 using OfficeDevPnP.Core.Diagnostics;
 using OfficeDevPnP.Core.Framework.Provisioning.Model;
 using System;
@@ -841,3 +842,4 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         POST_WITH_RESPONSE_HEADERS
     }
 }
+#endif

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/SiteToTemplateConversion.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/SiteToTemplateConversion.cs
@@ -175,7 +175,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 {
                     new ObjectHierarchyTenant(),
                     new ObjectHierarchySequenceTermGroups(),
-                    new ObjectHierarchySequenceSites()
+                    new ObjectHierarchySequenceSites(),
+                    new ObjectTeams()
                 };
 
                 var count = objectHandlers.Count(o => o.ReportProgress && o.WillProvision(tenant, hierarchy, sequenceId, provisioningInfo)) + 1;

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Utilities/ODataBindJsonResolver.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Utilities/ODataBindJsonResolver.cs
@@ -1,0 +1,24 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
+{
+    internal class ODataBindJsonResolver : CamelCasePropertyNamesContractResolver
+    {
+        protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+        {
+            var property = base.CreateProperty(member, memberSerialization);
+            if (property.PropertyName.Equals("template_odata_bind", StringComparison.OrdinalIgnoreCase))
+            {
+                property.PropertyName = "template@odata.bind";
+            }
+            return property;
+        }
+    }
+}

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/ProvisioningSchema-2019-03.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/ProvisioningSchema-2019-03.cs
@@ -920,8 +920,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml.V201903 {
         
         private BaseTeamVisibility visibilityField;
         
-        private bool visibilityFieldSpecified;
-        
         /// <remarks/>
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public string DisplayName {
@@ -963,17 +961,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml.V201903 {
             }
             set {
                 this.visibilityField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlIgnoreAttribute()]
-        public bool VisibilitySpecified {
-            get {
-                return this.visibilityFieldSpecified;
-            }
-            set {
-                this.visibilityFieldSpecified = value;
             }
         }
     }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/ProvisioningSchema-2019-03.xsd
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/ProvisioningSchema-2019-03.xsd
@@ -7234,7 +7234,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="Visibility" use="optional">
+    <xsd:attribute name="Visibility" use="required">
       <xsd:annotation>
         <xsd:appinfo>Added with schema version 201903</xsd:appinfo>
         <xsd:documentation xml:lang="en">

--- a/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
+++ b/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
@@ -682,6 +682,7 @@
     <Compile Include="Framework\Provisioning\ObjectHandlers\Utilities\ListItemUtilities.cs" />
     <Compile Include="Framework\Provisioning\ObjectHandlers\Utilities\ConnectorFileHelper.cs" />
     <Compile Include="Framework\Provisioning\ObjectHandlers\Utilities\FieldUtilities.cs" />
+    <Compile Include="Framework\Provisioning\ObjectHandlers\Utilities\ODataBindJsonResolver.cs" />
     <Compile Include="Framework\Provisioning\ObjectHandlers\Utilities\TenantHelper.cs" />
     <Compile Include="Framework\Provisioning\Providers\IProvisioningHierarchyFormatter.cs" />
     <Compile Include="Framework\Provisioning\ObjectHandlers\Utilities\TermGroupHelper.cs" />

--- a/Core/OfficeDevPnP.Core/Utilities/HttpHelper.cs
+++ b/Core/OfficeDevPnP.Core/Utilities/HttpHelper.cs
@@ -1,5 +1,6 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -306,7 +307,8 @@ namespace OfficeDevPnP.Core.Utilities
                     : JsonConvert.SerializeObject(content, Formatting.None, new JsonSerializerSettings
                     {
                         NullValueHandling = NullValueHandling.Ignore,
-                        ContractResolver = new CamelCasePropertyNamesContractResolver(),
+                        ContractResolver = new ODataBindJsonResolver(),
+                        
                     });
                 requestContent = new StringContent(jsonString, Encoding.UTF8, contentType);
             }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes NA

#### What's in this Pull Request?

1) This PR fixes compile issues while building the solution for all OnPrem environments
2) Used the helper method `web.GetBaseTemplateId();`  in both Footer and Site Header handlers
3) `ExecuteQueryRetry()` was missing in the Site Header handler, so added that 
4) Also added support for Site headers in Modern team site (STS#3) templates as they are supported there as well. 

To be fair, the site headers are supported in the Modern UI of even classic site collections, so can we remove this check and simply extract it for all templates ? Let me know your thoughts on this, if needed can modify my PR :) 