### PR TITLE
Replace associated group title with site title token during extraction

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectSiteSecurityTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectSiteSecurityTests.cs
@@ -269,6 +269,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                 // Load the base template which will be used for the comparison work
                 var creationInfo = new ProvisioningTemplateCreationInformation(web) { BaseTemplate = web.GetBaseTemplate() };
                 creationInfo.IncludeSiteGroups = true;
+                creationInfo.IncludeDefaultAssociatedGroups = true;
                 var template = new ProvisioningTemplate();
                 template = new ObjectSiteSecurity().ExtractObjects(web, template, creationInfo);
 
@@ -305,10 +306,23 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                 var template = new ProvisioningTemplate();
                 template = new ObjectSiteSecurity().ExtractObjects(web, template, creationInfo);
 
+                Assert.IsFalse(template.Security.SiteGroups.Any());
+            }
+        }
+
+        public void CanSkipExtractAssociatedGroups()
+        {
+            using (var clientContext = TestCommon.CreateClientContext())
+            {
+                Web web = clientContext.Web;
+                var creationInfo = new ProvisioningTemplateCreationInformation(web) { BaseTemplate = web.GetBaseTemplate() };
+                creationInfo.IncludeDefaultAssociatedGroups = false;
+                var template = new ProvisioningTemplate();
+                template = new ObjectSiteSecurity().ExtractObjects(web, template, creationInfo);
+
                 Assert.IsNull(template.Security.AssociatedOwnerGroup);
                 Assert.IsNull(template.Security.AssociatedMemberGroup);
                 Assert.IsNull(template.Security.AssociatedVisitorGroup);
-                Assert.IsFalse(template.Security.SiteGroups.Any());
             }
         }
 

--- a/Core/OfficeDevPnP.Core/Extensions/SecurityExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/SecurityExtensions.cs
@@ -1134,6 +1134,16 @@ namespace Microsoft.SharePoint.Client
         /// <returns>True if the group exists, false otherwise</returns>
         public static bool GroupExists(this Web web, string groupName)
         {
+            if (web == null)
+            {
+                throw new ArgumentNullException(nameof(web));
+            }
+
+            if (string.IsNullOrEmpty(groupName))
+            {
+                throw new ArgumentNullException(nameof(groupName));
+            }
+
 #if SP2013
             IEnumerable<Group> groups;
             groups = web.Context.LoadQuery(web.SiteGroups.Include(g => g.LoginName));
@@ -1149,21 +1159,21 @@ namespace Microsoft.SharePoint.Client
 #else
             return PnPCoreUtilities.RunWithDisableReturnValueCache(web.Context, () =>
             {
-                ExceptionHandlingScope groupexistsScope = new ExceptionHandlingScope(web.Context);
+                ExceptionHandlingScope groupExistsScope = new ExceptionHandlingScope(web.Context);
 
-                using (groupexistsScope.StartScope())
+                using (groupExistsScope.StartScope())
                 {
-                    using (groupexistsScope.StartTry())
+                    using (groupExistsScope.StartTry())
                     {
                         web.SiteGroups.GetByName(groupName);
                     }
 
-                    using (groupexistsScope.StartCatch())
+                    using (groupExistsScope.StartCatch())
                     {
                     }
                 }
                 web.Context.ExecuteQuery();
-                return !groupexistsScope.HasException;
+                return !groupExistsScope.HasException;
             });
 #endif            
         }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
@@ -629,7 +629,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                 if (!ownerGroup.ServerObjectIsNull.Value)
                 {
-                    if (creationInfo.IncludeSiteGroups)
+                    if (creationInfo.IncludeDefaultAssociatedGroups)
                     {
                         siteSecurity.AssociatedOwnerGroup = SiteTitleToken.GetReplaceToken(ownerGroup.Title, web);
                     }
@@ -641,7 +641,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 }
                 if (!memberGroup.ServerObjectIsNull.Value)
                 {
-                    if (creationInfo.IncludeSiteGroups)
+                    if (creationInfo.IncludeDefaultAssociatedGroups)
                     {
                         siteSecurity.AssociatedMemberGroup = SiteTitleToken.GetReplaceToken(memberGroup.Title, web);
                     }
@@ -653,7 +653,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 }
                 if (!visitorGroup.ServerObjectIsNull.Value)
                 {
-                    if (creationInfo.IncludeSiteGroups)
+                    if (creationInfo.IncludeDefaultAssociatedGroups)
                     {
                         siteSecurity.AssociatedVisitorGroup = SiteTitleToken.GetReplaceToken(visitorGroup.Title, web);
                     }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
@@ -57,34 +57,13 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         if (string.IsNullOrEmpty(parsedAssociatedOwnerGroupName))
                         {
                             web.AssociatedOwnerGroup = null;
-                            webNeedsUpdate = true;
                         }
                         else
                         {
-                            if (!web.GroupExists(parsedAssociatedOwnerGroupName))
-                            {
-                                web.AssociatedOwnerGroup = EnsureGroup(web, parsedAssociatedOwnerGroupName);
-                                webNeedsUpdate = true;
-                            }
-                            else if (!web.AssociatedOwnerGroup.ServerObjectIsNull.Value)
-                            {
-                                if (web.AssociatedOwnerGroup.Title != parsedAssociatedOwnerGroupName)
-                                {
-                                    var updatedOwnerGroup = web.SiteGroups.GetByName(parsedAssociatedOwnerGroupName);
-                                    web.Context.Load(updatedOwnerGroup);
-                                    web.Context.ExecuteQueryRetry();
+                            web.AssociatedOwnerGroup = EnsureGroup(web, parsedAssociatedOwnerGroupName);
+                        }
 
-                                    web.AssociatedOwnerGroup = updatedOwnerGroup;
-                                    webNeedsUpdate = true;
-                                }
-                            }
-                        }
-                        if (webNeedsUpdate)
-                        {
-                            // Trigger the creation and setting of the associated owner group
-                            web.Update();
-                            web.Context.ExecuteQueryRetry();
-                        }
+                        webNeedsUpdate = true;
                     }
 
                     if (parsedAssociatedMemberGroupName != null)
@@ -92,34 +71,13 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         if (string.IsNullOrEmpty(parsedAssociatedMemberGroupName))
                         {
                             web.AssociatedMemberGroup = null;
-                            webNeedsUpdate = true;
                         }
                         else
                         {
-                            if (!web.GroupExists(parsedAssociatedMemberGroupName))
-                            {
-                                web.AssociatedMemberGroup = EnsureGroup(web, parsedAssociatedMemberGroupName);
-                                webNeedsUpdate = true;
-                            }
-                            else if (!web.AssociatedMemberGroup.ServerObjectIsNull.Value)
-                            {
-                                if (web.AssociatedMemberGroup.Title != parsedAssociatedMemberGroupName)
-                                {
-                                    var updatedMemberGroup = web.SiteGroups.GetByName(parsedAssociatedMemberGroupName);
-                                    web.Context.Load(updatedMemberGroup);
-                                    web.Context.ExecuteQueryRetry();
+                            web.AssociatedMemberGroup = EnsureGroup(web, parsedAssociatedMemberGroupName);
+                        }
 
-                                    web.AssociatedMemberGroup = updatedMemberGroup;
-                                    webNeedsUpdate = true;
-                                }
-                            }
-                        }
-                        if (webNeedsUpdate)
-                        {
-                            // Trigger the creation and setting of the associated member group
-                            web.Update();
-                            web.Context.ExecuteQueryRetry();
-                        }
+                        webNeedsUpdate = true;
                     }
 
                     if (parsedAssociatedVisitorGroupName != null)
@@ -127,34 +85,20 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         if (string.IsNullOrEmpty(parsedAssociatedVisitorGroupName))
                         {
                             web.AssociatedVisitorGroup = null;
-                            webNeedsUpdate = true;
                         }
                         else
                         {
-                            if (!web.GroupExists(parsedAssociatedVisitorGroupName))
-                            {
-                                web.AssociatedVisitorGroup = EnsureGroup(web, parsedAssociatedVisitorGroupName);
-                                webNeedsUpdate = true;
-                            }
-                            else if (!web.AssociatedVisitorGroup.ServerObjectIsNull.Value)
-                            {
-                                if (web.AssociatedVisitorGroup.Title != parsedAssociatedVisitorGroupName)
-                                {
-                                    var updatedVisitorGroup = web.SiteGroups.GetByName(parsedAssociatedVisitorGroupName);
-                                    web.Context.Load(updatedVisitorGroup);
-                                    web.Context.ExecuteQueryRetry();
+                            web.AssociatedVisitorGroup = EnsureGroup(web, parsedAssociatedVisitorGroupName);
+                        }
 
-                                    web.AssociatedVisitorGroup = updatedVisitorGroup;
-                                    webNeedsUpdate = true;
-                                }
-                            }
-                        }
-                        if (webNeedsUpdate)
-                        {
-                            // Trigger the creation and setting of the associated visitor group
-                            web.Update();
-                            web.Context.ExecuteQueryRetry();
-                        }
+                        webNeedsUpdate = true;
+                    }
+
+                    if (webNeedsUpdate)
+                    {
+                        // Trigger the creation and setting of the associated groups
+                        web.Update();
+                        web.Context.ExecuteQueryRetry();
                     }
                 }
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ProvisioningTemplateCreationInformation.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ProvisioningTemplateCreationInformation.cs
@@ -19,6 +19,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         private bool includeAllTermGroups = false;
         private bool includeSiteCollectionTermGroup = false;
         private bool includeSiteGroups = false;
+        private bool includeDefaultAssociatedGroups = false;
         private bool includeTermGroupsSecurity = false;
         private bool includeSearchConfiguration = false;
         private List<String> propertyBagPropertiesToPreserve;
@@ -229,6 +230,19 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 return this.includeSiteGroups;
             }
             set { this.includeSiteGroups = value; }
+        }
+
+        /// <summary>
+        /// If true, includes configuration of associated owner, member, and visitor groups
+        /// in the template.
+        /// This does not affect the extraction of groups specified by IncludeSiteGroups,
+        /// but rather the configuration of what group should be the
+        /// associated owner, member, and visitor groups.
+        /// </summary>
+        public bool IncludeDefaultAssociatedGroups
+        {
+            get { return includeDefaultAssociatedGroups; }
+            set { includeDefaultAssociatedGroups = value; }
         }
 
         /// <summary>

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/SiteTitleToken.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/SiteTitleToken.cs
@@ -24,5 +24,25 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitio
             }
             return CacheValue;
         }
+
+        /// <summary>
+        /// Replaces the specified value with the Site Title token.
+        /// </summary>
+        /// <param name="value">String value to replace with site title token.</param>
+        /// <param name="web">The web used to match <paramref name="value"/> with the web's title.</param>
+        /// <returns></returns>
+        public static string GetReplaceToken(string value, Web web)
+        {
+            web.EnsureProperty(w => w.Title);
+
+            if (string.IsNullOrEmpty(web.Title))
+            {
+                return value;
+            }
+            else
+            {
+                return value.Replace(web.Title, "{sitetitle}");
+            }
+        }
     }
 }

--- a/Core/OfficeDevPnP.Core/Utilities/PnPCoreUtilities.cs
+++ b/Core/OfficeDevPnP.Core/Utilities/PnPCoreUtilities.cs
@@ -68,5 +68,53 @@ namespace OfficeDevPnP.Core.Utilities
                 return $"https://{uriParts[0]}-admin.{string.Join(".", uriParts.Skip(1))}";
             return null;
         }
+
+#if !SP2013
+        /// <summary>
+        /// Executes the specified method with Return Value Cache disabled on the Client Runtime Context.
+        /// </summary>
+        /// <typeparam name="TResult"></typeparam>
+        /// <param name="context"></param>
+        /// <param name="disabledReturnValueCacheCode">The code that is to run with Return Value Cache disabled.</param>
+        /// <returns>Returns value from the code specified by <paramref name="disabledReturnValueCacheCode"/></returns>
+        public static TResult RunWithDisableReturnValueCache<TResult>(ClientRuntimeContext context, Func<TResult> disabledReturnValueCacheCode)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (disabledReturnValueCacheCode == null)
+            {
+                throw new ArgumentNullException(nameof(disabledReturnValueCacheCode));
+            }
+
+            bool disableReturnValueCache = context.DisableReturnValueCache;
+
+            try
+            {
+                context.DisableReturnValueCache = true;
+                return disabledReturnValueCacheCode();
+            }
+            catch
+            {
+                throw;
+            }
+            finally
+            {
+                context.DisableReturnValueCache = disableReturnValueCache;
+            }
+        }
+
+        /// <summary>
+        /// Executes the specified method with Return Value Cache disabled on the Client Runtime Context.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="disabledReturnValueCacheCode">The code that is to run with Return Value Cache disabled.</param>
+        public static void RunWithDisableReturnValueCache(ClientRuntimeContext context, Action disabledReturnValueCacheCode)
+        {
+            RunWithDisableReturnValueCache<object>(context, () => { disabledReturnValueCacheCode(); return default; } );
+        }
+#endif
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #2127, reverts #2128

#### What's in this Pull Request?

Revert #2127 as it broke the functionality in SP2013 and blocked changing associated groups if the groups already existed in the site

Modifies the extraction of associated owner, member, and visitor groups to replace group title with site title token.
Adds option to include extraction of associated owner, member, and visitor groups. (IncludeDefaultAssociatedGroups)
I could not find a better naming for this property as I did not want to use IncludeAssociatedGroups. That name could in the future collide with the actual Associated Groups which is not the same as the associated owner, member, and visitor groups.
I'm open for other suggestions for naming this property differently.

Improved code checking for existence of a group to work properly on SharePoint 2013.

Added utility method to run code with DisableReturnValueCache on the specified ClientRuntimeContext object.
Setting DisableReturnValueCache in ClientContextExtensions.ExecuteQueryImplementation should not be done as this creates an unwanted side effect when for example using ExecuteQueryRetry, especially when using it outside the OfficeDevPnP.Core framework.
In addition setting the value of DisableReturnValueCache right before calling ExecuteQuery has no effect. It needs to be set prior to using any of the methods that caches the return value. I'll create a separate bug for discussing this further (#2175).

#### Important:
I'm unable to run tests for any of the on premises versions (debug15, debug16, and debug19) because of many recent changes that has made the code not build in those configurations anymore.