### PR TITLE
#2176 fixing test: reused term sets are not set up properly

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectTermGroupsTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectTermGroupsTests.cs
@@ -266,6 +266,8 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                 // note: this check that the IDs of the source and reused term are the same to document this behavior
                 Assert.AreEqual(sourceTerm.Id, newTermGroup.TermSets[0].Terms[0].Id);
                 Assert.AreEqual(sourceTerm.Id, newTermGroup.TermSets[1].Terms[0].Id);
+                Assert.IsTrue(newTermGroup.TermSets[0].Terms[0].IsReused);
+                Assert.IsTrue(newTermGroup.TermSets[1].Terms[0].IsReused);
             }
         }
 

--- a/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectTermGroupsTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectTermGroupsTests.cs
@@ -216,7 +216,6 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
 
             using (var ctx = TestCommon.CreateClientContext())
             {
-
                 var parser = new TokenParser(ctx.Web, template);
 
                 new ObjectTermGroups().ProvisionObjects(ctx.Web, template, parser, new ProvisioningTemplateApplyingInformation());
@@ -249,7 +248,25 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                 Assert.IsTrue(createdReusedTerm.IsReused);
             }
 
-
+            // check result by reading the template again
+            using (var ctx = TestCommon.CreateClientContext())
+            {
+                var result = ctx.Web.GetProvisioningTemplate(new ProvisioningTemplateCreationInformation(ctx.Web)
+                {
+                    HandlersToProcess = Handlers.TermGroups,
+                    IncludeAllTermGroups = true // without this being true no term groups will be returned
+                });
+                // note: cannot use TermGroupValidator class to validate the result as XML since the read template contains additional information like Description="", Owner="[...]", differing TermGroup ID etc. which makes the validation fail; so manually compare what's interesting
+                var newTermGroups = result.TermGroups.Where(tg => tg.Name == termGroup.Name);
+                Assert.AreEqual(1, newTermGroups.Count());
+                var newTermGroup = newTermGroups.First();
+                Assert.AreEqual(2, newTermGroup.TermSets.Count);
+                Assert.AreEqual(1, newTermGroup.TermSets[0].Terms.Count);
+                Assert.AreEqual(1, newTermGroup.TermSets[1].Terms.Count);
+                // note: this check that the IDs of the source and reused term are the same to document this behavior
+                Assert.AreEqual(sourceTerm.Id, newTermGroup.TermSets[0].Terms[0].Id);
+                Assert.AreEqual(sourceTerm.Id, newTermGroup.TermSets[1].Terms[0].Id);
+            }
         }
 
     }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Utilities/TermGroupHelper.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Utilities/TermGroupHelper.cs
@@ -177,14 +177,17 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
                                         modelTerm.Id = returnTuple.Item1;
                                         parser = returnTuple.Item2;
                                     }
+                                    reusedTerms.AddRange(returnTuple.Item3);
                                 }
                                 else
                                 {
+                                    // todo: add handling for reused term?
                                     modelTerm.Id = term.Id;
                                 }
                             }
                             else
                             {
+                                // todo: add handling for reused term?
                                 modelTerm.Id = term.Id;
                             }
 
@@ -201,6 +204,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
                                 modelTerm.Id = returnTuple.Item1;
                                 parser = returnTuple.Item2;
                             }
+                            reusedTerms.AddRange(returnTuple.Item3);
                         }
                     }
                     else
@@ -211,6 +215,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
                             modelTerm.Id = returnTuple.Item1;
                             parser = returnTuple.Item2;
                         }
+                        reusedTerms.AddRange(returnTuple.Item3);
                     }
                 }
 
@@ -273,7 +278,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
                     Parent = parent,
                     TermStore = termStore
                 });
-                return Tuple.Create(Guid.Empty, parser, reusedTerms); ;
+                return Tuple.Create(modelTerm.Id, parser, reusedTerms); ;
             }
 
             // Create new term


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #2176 

#### What's in this Pull Request?

Fixed test. Reused term sets should provision correctly (how did this ever work??). I hope this also covers cases where term sets are already existing or the structure is more complex.