### PR TITLE
Team template property overwrite

### DIFF
--- a/Core/OfficeDevPnP.Core/CoreResources.Designer.cs
+++ b/Core/OfficeDevPnP.Core/CoreResources.Designer.cs
@@ -2021,7 +2021,7 @@ namespace OfficeDevPnP.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Provisioning a team based on a team template failed. {0}.
+        ///   Looks up a localized string similar to Provisioning a team based on a team template failed. Ensure that the JSON template markup is valid and contains all the required properties. {0}.
         /// </summary>
         internal static string Provisioning_ObjectHandlers_Teams_TeamTemplate_ProvisioningError {
             get {

--- a/Core/OfficeDevPnP.Core/CoreResources.resx
+++ b/Core/OfficeDevPnP.Core/CoreResources.resx
@@ -1130,7 +1130,7 @@
     <value>The {0} image set as page header lives in a different web and will not be set.</value>
   </data>
   <data name="Provisioning_ObjectHandlers_Teams_TeamTemplate_ProvisioningError" xml:space="preserve">
-    <value>Provisioning a team based on a team template failed. {0}</value>
+    <value>Provisioning a team based on a team template failed. Ensure that the JSON template markup is valid and contains all the required properties. {0}</value>
   </data>
   <data name="Provisioning_ObjectHandlers_Teams_TeamTemplate_FetchingError" xml:space="preserve">
     <value>Failed to get team information after provisioning.</value>

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTeams.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTeams.cs
@@ -81,7 +81,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             HttpResponseHeaders responseHeaders;
             try
             {
-                var content = parser.ParseString(teamTemplate.JsonTemplate);
+                var content = OverwriteJsonTemplateProperties(parser, teamTemplate);
                 responseHeaders = HttpHelper.MakePostRequestForHeaders("https://graph.microsoft.com/beta/teams", content, "application/json", accessToken);
             }
             catch (Exception ex)
@@ -102,6 +102,19 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             }
 
             return null;
+        }
+
+        private static string OverwriteJsonTemplateProperties(TokenParser parser, TeamTemplate teamTemplate)
+        {
+            var jsonTemplate = parser.ParseString(teamTemplate.JsonTemplate);
+            var team = JToken.Parse(jsonTemplate);
+
+            if (teamTemplate.DisplayName != null) team["displayName"] = teamTemplate.DisplayName;
+            if (teamTemplate.Description != null) team["description"] = teamTemplate.Description;
+            if (teamTemplate.Classification != null) team["classification"] = teamTemplate.Classification;
+            if (teamTemplate.Visibility != null) team["visibility"] = teamTemplate.Visibility.ToString();
+
+            return team.ToString();
         }
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no

#### What's in this Pull Request?

- Added a method for overwriting certain properties in the team template (JSON) if they've been separately specified in the xml markup.

- Made an error message more descriptive in case team provisioning fails.