### PR TITLE
Fix for global navigation null reference exception when provisioning

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/Resolvers/NavigationFromModelToSchemaTypeResolver.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/Resolvers/NavigationFromModelToSchemaTypeResolver.cs
@@ -50,31 +50,34 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml.Resolvers
                     case "GlobalNavigation":
                         navigation = modelSource.GlobalNavigation;
 
-                        target = Activator.CreateInstance(globalNavigationType);
-                        target.SetPublicInstancePropertyValue("NavigationType", Enum.Parse(globalNavigationTypeType, modelSource.GlobalNavigation.NavigationType.ToString()));
-
-                        switch (modelSource.GlobalNavigation.NavigationType)
+                        if (navigation != null)
                         {
-                            case Model.GlobalNavigationType.Managed:
-                                var managedNavigation = Activator.CreateInstance(managedNavigationType);
+                            target = Activator.CreateInstance(globalNavigationType);
+                            target.SetPublicInstancePropertyValue("NavigationType", Enum.Parse(globalNavigationTypeType, modelSource.GlobalNavigation.NavigationType.ToString()));
 
-                                PnPObjectsMapper.MapProperties(modelSource.GlobalNavigation.ManagedNavigation, managedNavigation, resolvers, true);
-                                target.SetPublicInstancePropertyValue("ManagedNavigation", managedNavigation);
+                            switch (modelSource.GlobalNavigation.NavigationType)
+                            {
+                                case Model.GlobalNavigationType.Managed:
+                                    var managedNavigation = Activator.CreateInstance(managedNavigationType);
 
-                                break;
-                            case Model.GlobalNavigationType.Structural:
-                                var structuralNavigation = Activator.CreateInstance(structuralNavigationType);
+                                    PnPObjectsMapper.MapProperties(modelSource.GlobalNavigation.ManagedNavigation, managedNavigation, resolvers, true);
+                                    target.SetPublicInstancePropertyValue("ManagedNavigation", managedNavigation);
 
-                                if (!resolvers.ContainsKey($"{structuralNavigation.GetType().FullName}.NavigationNode"))
-                                {
-                                    resolvers.Add($"{structuralNavigation.GetType().FullName}.NavigationNode", new NavigationNodeFromModelToSchemaTypeResolver());
-                                }
-                                PnPObjectsMapper.MapProperties(modelSource.GlobalNavigation.StructuralNavigation, structuralNavigation, resolvers, true);
-                                target.SetPublicInstancePropertyValue("StructuralNavigation", structuralNavigation);
+                                    break;
+                                case Model.GlobalNavigationType.Structural:
+                                    var structuralNavigation = Activator.CreateInstance(structuralNavigationType);
 
-                                break;
-                            case Model.GlobalNavigationType.Inherit:
-                                break;
+                                    if (!resolvers.ContainsKey($"{structuralNavigation.GetType().FullName}.NavigationNode"))
+                                    {
+                                        resolvers.Add($"{structuralNavigation.GetType().FullName}.NavigationNode", new NavigationNodeFromModelToSchemaTypeResolver());
+                                    }
+                                    PnPObjectsMapper.MapProperties(modelSource.GlobalNavigation.StructuralNavigation, structuralNavigation, resolvers, true);
+                                    target.SetPublicInstancePropertyValue("StructuralNavigation", structuralNavigation);
+
+                                    break;
+                                case Model.GlobalNavigationType.Inherit:
+                                    break;
+                            } 
                         }
 
                         break;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | NA

#### What's in this Pull Request?

The provisioning schema specifies that GlobalNavigation is an optional element but if this element is not included in the provisioning template we get a null reference exception. This PR includes a fix for this.
