### PR TITLE
Fix : Compile issues for OnPrem in the new handlers

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteFooterSettings.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteFooterSettings.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !ONPREMISES
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -27,7 +28,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
         public override ProvisioningTemplate ExtractObjects(Web web, ProvisioningTemplate template, ProvisioningTemplateCreationInformation creationInfo)
         {
-#if !ONPREMISES
             using (var scope = new PnPMonitoredScope(this.Name))
             {
                 web.EnsureProperties(w => w.FooterEnabled, w => w.ServerRelativeUrl);
@@ -58,10 +58,10 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         }
                     }
                     // find the logo node
-                    if(string.IsNullOrEmpty(footer.Logo))
+                    if (string.IsNullOrEmpty(footer.Logo))
                     {
                         var logoNode = menuState.Nodes.FirstOrDefault(n => n.Title == Constants.SITEFOOTER_LOGONODEKEY);
-                        if(logoNode != null)
+                        if (logoNode != null)
                         {
                             footer.Logo = Tokenize(logoNode.SimpleUrl, web.ServerRelativeUrl);
                         }
@@ -78,7 +78,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 }
                 template.Footer = footer;
             }
-#endif
             return template;
         }
 
@@ -101,7 +100,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
         public override TokenParser ProvisionObjects(Web web, ProvisioningTemplate template, TokenParser parser, ProvisioningTemplateApplyingInformation applyingInformation)
         {
-#if !ONPREMISES
             using (var scope = new PnPMonitoredScope(this.Name))
             {
                 if (template.Footer != null)
@@ -211,16 +209,12 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     }
                 }
             }
-#endif
             return parser;
         }
 
         public override bool WillExtract(Web web, ProvisioningTemplate template, ProvisioningTemplateCreationInformation creationInfo)
         {
-#if !ONPREMISES
-            web.EnsureProperties(w => w.Configuration, w => w.WebTemplate);
-            var webTemplate = $"{web.WebTemplate}#{web.Configuration}";
-            if (webTemplate.Equals("SITEPAGEPUBLISHING#0", StringComparison.InvariantCultureIgnoreCase))
+            if ((web.Context as ClientContext).Site.IsCommunicationSite())
             {
                 return true;
             }
@@ -228,17 +222,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             {
                 return false;
             }
-#else
-            return false;
-#endif
         }
 
         public override bool WillProvision(Web web, ProvisioningTemplate template, ProvisioningTemplateApplyingInformation applyingInformation)
         {
-#if !ONPREMISES
-            web.EnsureProperties(w => w.Configuration, w => w.WebTemplate);
-            var webTemplate = $"{web.WebTemplate}#{web.Configuration}";
-            if (webTemplate.Equals("SITEPAGEPUBLISHING#0", StringComparison.InvariantCultureIgnoreCase))
+            if ((web.Context as ClientContext).Site.IsCommunicationSite())
             {
                 return template.Footer != null;
             }
@@ -246,9 +234,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             {
                 return false;
             }
-#else
-            return false;
-#endif
         }
 
         private class MenuState
@@ -293,3 +278,4 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         }
     }
 }
+#endif

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteHeaderSettings.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteHeaderSettings.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !ONPREMISES
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -20,13 +21,12 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
         public override ProvisioningTemplate ExtractObjects(Web web, ProvisioningTemplate template, ProvisioningTemplateCreationInformation creationInfo)
         {
-#if !ONPREMISES
             using (var scope = new PnPMonitoredScope(this.Name))
             {
                 web.EnsureProperties(w => w.HeaderEmphasis, w => w.HeaderLayout, w => w.MegaMenuEnabled);
                 var header = new SiteHeader();
                 header.MenuStyle = web.MegaMenuEnabled ? SiteHeaderMenuStyle.MegaMenu : SiteHeaderMenuStyle.Cascading;
-                switch(web.HeaderLayout)
+                switch (web.HeaderLayout)
                 {
                     case HeaderLayoutType.Compact:
                         {
@@ -40,25 +40,24 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                             break;
                         }
                 }
-                
-                if(Enum.TryParse<SiteHeaderBackgroundEmphasis>(web.HeaderEmphasis.ToString(),out SiteHeaderBackgroundEmphasis backgroundEmphasis))
+
+                if (Enum.TryParse<SiteHeaderBackgroundEmphasis>(web.HeaderEmphasis.ToString(), out SiteHeaderBackgroundEmphasis backgroundEmphasis))
                 {
                     header.BackgroundEmphasis = backgroundEmphasis;
                 }
+
                 template.Header = header;
             }
-#endif
             return template;
         }
 
         public override TokenParser ProvisionObjects(Web web, ProvisioningTemplate template, TokenParser parser, ProvisioningTemplateApplyingInformation applyingInformation)
         {
-#if !ONPREMISES
             using (var scope = new PnPMonitoredScope(this.Name))
             {
                 if (template.Header != null)
                 {
-                    switch(template.Header.Layout)
+                    switch (template.Header.Layout)
                     {
                         case SiteHeaderLayout.Compact:
                             {
@@ -74,45 +73,21 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     web.HeaderEmphasis = (SPVariantThemeType)Enum.Parse(typeof(SPVariantThemeType), template.Header.BackgroundEmphasis.ToString());
                     web.MegaMenuEnabled = template.Header.MenuStyle == SiteHeaderMenuStyle.MegaMenu;
                     web.Update();
+                    web.Context.ExecuteQueryRetry();
                 }
             }
-#endif
             return parser;
         }
 
         public override bool WillExtract(Web web, ProvisioningTemplate template, ProvisioningTemplateCreationInformation creationInfo)
         {
-#if !ONPREMISES
-            web.EnsureProperties(w => w.Configuration, w => w.WebTemplate);
-            var webTemplate = $"{web.WebTemplate}#{web.Configuration}";
-            if (webTemplate.Equals("GROUP#0", StringComparison.InvariantCultureIgnoreCase) || webTemplate.Equals("SITEPAGEPUBLISHING#0", StringComparison.InvariantCultureIgnoreCase))
-            {
-                return true;
-            } else
-            {
-                return false;
-            }
-#else
-            return false;
-#endif
+            return true;
         }
 
         public override bool WillProvision(Web web, ProvisioningTemplate template, ProvisioningTemplateApplyingInformation applyingInformation)
         {
-#if !ONPREMISES
-            web.EnsureProperties(w => w.Configuration, w => w.WebTemplate);
-            var webTemplate = $"{web.WebTemplate}#{web.Configuration}";
-            if (webTemplate.Equals("GROUP#0", StringComparison.InvariantCultureIgnoreCase) || webTemplate.Equals("SITEPAGEPUBLISHING#0", StringComparison.InvariantCultureIgnoreCase))
-            {
-                return template.Header != null;
-            }
-            else
-            {
-                return false;
-            }
-#else
-            return false;
-#endif
+            return template.Header != null;
         }
     }
 }
+#endif

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTeams.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTeams.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.SharePoint.Client;
+﻿#if !ONPREMISES
+using Microsoft.SharePoint.Client;
 using OfficeDevPnP.Core.Diagnostics;
 using OfficeDevPnP.Core.Framework.Provisioning.Model;
 using System;
@@ -748,7 +749,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             }
         }
 
-        #region PnP Provisioning Engine infrastructural code
+#region PnP Provisioning Engine infrastructural code
 
         public override bool WillProvision(Tenant tenant, ProvisioningHierarchy hierarchy, string sequenceId, ProvisioningTemplateApplyingInformation applyingInformation)
         {
@@ -763,7 +764,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             {
                 _willProvision = false;
             }
-#endif            
+#endif
             return _willProvision.Value;
         }
 
@@ -829,7 +830,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             return hierarchy;
         }
 
-        #endregion
+#endregion
     }
 
     enum HttpMethodVerb
@@ -841,3 +842,4 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         POST_WITH_RESPONSE_HEADERS
     }
 }
+#endif

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/SiteToTemplateConversion.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/SiteToTemplateConversion.cs
@@ -90,13 +90,14 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 if (creationInfo.HandlersToProcess.HasFlag(Handlers.PageContents)) objectHandlers.Add(new ObjectPageContents());
 #if !ONPREMISES
                 if (creationInfo.HandlersToProcess.HasFlag(Handlers.PageContents)) objectHandlers.Add(new ObjectClientSidePageContents());
+                if (creationInfo.HandlersToProcess.HasFlag(Handlers.SiteHeader)) objectHandlers.Add(new ObjectSiteHeaderSettings());
+                if (creationInfo.HandlersToProcess.HasFlag(Handlers.SiteFooter)) objectHandlers.Add(new ObjectSiteFooterSettings());
 #endif
                 if (creationInfo.HandlersToProcess.HasFlag(Handlers.PropertyBagEntries)) objectHandlers.Add(new ObjectPropertyBagEntry());
                 if (creationInfo.HandlersToProcess.HasFlag(Handlers.Publishing)) objectHandlers.Add(new ObjectPublishing());
                 if (creationInfo.HandlersToProcess.HasFlag(Handlers.Workflows)) objectHandlers.Add(new ObjectWorkflows());
                 if (creationInfo.HandlersToProcess.HasFlag(Handlers.WebSettings)) objectHandlers.Add(new ObjectWebSettings());
-                if (creationInfo.HandlersToProcess.HasFlag(Handlers.SiteHeader)) objectHandlers.Add(new ObjectSiteHeaderSettings());
-                if (creationInfo.HandlersToProcess.HasFlag(Handlers.SiteFooter)) objectHandlers.Add(new ObjectSiteFooterSettings());
+
                 if (creationInfo.HandlersToProcess.HasFlag(Handlers.Navigation)) objectHandlers.Add(new ObjectNavigation());
                 if (creationInfo.HandlersToProcess.HasFlag(Handlers.ImageRenditions)) objectHandlers.Add(new ObjectImageRenditions());
                 objectHandlers.Add(new ObjectLocalization()); // Always add this one, check is done in the handler
@@ -320,6 +321,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 if (!calledFromHierarchy && provisioningInfo.HandlersToProcess.HasFlag(Handlers.Tenant)) objectHandlers.Add(new ObjectTenant());
                 if (provisioningInfo.HandlersToProcess.HasFlag(Handlers.ApplicationLifecycleManagement)) objectHandlers.Add(new ObjectApplicationLifecycleManagement());
                 if (provisioningInfo.HandlersToProcess.HasFlag(Handlers.Pages)) objectHandlers.Add(new ObjectClientSidePages());
+                if (provisioningInfo.HandlersToProcess.HasFlag(Handlers.SiteHeader)) objectHandlers.Add(new ObjectSiteHeaderSettings());
+                if (provisioningInfo.HandlersToProcess.HasFlag(Handlers.SiteFooter)) objectHandlers.Add(new ObjectSiteFooterSettings());
 #endif
                 if (provisioningInfo.HandlersToProcess.HasFlag(Handlers.CustomActions)) objectHandlers.Add(new ObjectCustomActions());
                 if (provisioningInfo.HandlersToProcess.HasFlag(Handlers.Publishing)) objectHandlers.Add(new ObjectPublishing());
@@ -327,8 +330,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 if (provisioningInfo.HandlersToProcess.HasFlag(Handlers.SearchSettings)) objectHandlers.Add(new ObjectSearchSettings());
                 if (provisioningInfo.HandlersToProcess.HasFlag(Handlers.PropertyBagEntries)) objectHandlers.Add(new ObjectPropertyBagEntry());
                 if (provisioningInfo.HandlersToProcess.HasFlag(Handlers.WebSettings)) objectHandlers.Add(new ObjectWebSettings());
-                if (provisioningInfo.HandlersToProcess.HasFlag(Handlers.SiteHeader)) objectHandlers.Add(new ObjectSiteHeaderSettings());
-                if (provisioningInfo.HandlersToProcess.HasFlag(Handlers.SiteFooter)) objectHandlers.Add(new ObjectSiteFooterSettings());
                 if (provisioningInfo.HandlersToProcess.HasFlag(Handlers.Navigation)) objectHandlers.Add(new ObjectNavigation());
                 if (provisioningInfo.HandlersToProcess.HasFlag(Handlers.ImageRenditions)) objectHandlers.Add(new ObjectImageRenditions());
                 objectHandlers.Add(new ObjectLocalization()); // Always add this one, check is done in the handler
@@ -399,9 +400,9 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         private void CallWebHooks(ProvisioningTemplate template, TokenParser parser, ProvisioningTemplateWebhookKind kind, ObjectHandlerBase objectHandler = null)
         {
             using (var scope = new PnPMonitoredScope("ProvisioningTemplate WebHook Call"))
-            { 
-                if (template.ProvisioningTemplateWebhooks != null && template.ProvisioningTemplateWebhooks.Any())
             {
+                if (template.ProvisioningTemplateWebhooks != null && template.ProvisioningTemplateWebhooks.Any())
+                {
                     foreach (var webhook in template.ProvisioningTemplateWebhooks.Where(w => w.Kind == kind))
                     {
                         SimpleTokenParser internalParser = new SimpleTokenParser();
@@ -437,7 +438,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                     }
                                     catch (HttpRequestException ex)
                                     {
-                                        scope.LogError(ex,"Error calling provisioning template webhook");
+                                        scope.LogError(ex, "Error calling provisioning template webhook");
                                     }
                                     break;
                                 }
@@ -484,7 +485,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                                 }
                                             }
                                         }
-                                    } catch (HttpRequestException ex)
+                                    }
+                                    catch (HttpRequestException ex)
                                     {
                                         scope.LogError(ex, "Error calling provisioning template webhook");
                                     }


### PR DESCRIPTION

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| New sample?      | no
| Related issues?  | fixes NA

#### What's in this Pull Request?

1) This PR fixes compile issues in the new Site Header, Footer and Teams handlers.

2) Used `(web.Context as ClientContext).Site.IsCommunicationSite()` extension method to check communication site in the Footer handler.

3) Added missing `web.Context.ExecuteQueryRetry();` in the Site Header handler.

4) Removed extra checks for header provisioning since modern pages on classic sites can have these capabilities.  

This is an extension of the [PR 2164](https://github.com/SharePoint/PnP-Sites-Core/pull/2164) which i had to close as i made boo-boo :( 