### PR TITLE
Fix : Ensuring principal Id for role definition

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
@@ -582,6 +582,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 }
             }
 
+            principal?.EnsureProperty(p => p.Id);
+
             return principal;
         }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no 
| New sample?      | no
| Related issues?  | fixes #2205, https://github.com/SharePoint/PnP-PowerShell/issues/2057

#### What's in this Pull Request?

This PR fixes the above mentioned issues which were caused due to a regression in the previous version 3.7. We are simply ensuring that the principal Id is initialised for role definitions 