### PR TITLE
Fixed NullReferenceException caused by missing cookie

### DIFF
--- a/Core/OfficeDevPnP.Core/Utilities/RESTUtilities.cs
+++ b/Core/OfficeDevPnP.Core/Utilities/RESTUtilities.cs
@@ -27,7 +27,11 @@ namespace OfficeDevPnP.Core.Utilities
             }
             else if (context.Credentials == null)
             {
-                var cookieString = CookieReader.GetCookie(context.Web.Url).Replace("; ", ",").Replace(";", ",");
+                var cookieString = CookieReader.GetCookie(context.Web.Url)?.Replace("; ", ",")?.Replace(";", ",");
+                if(cookieString == null)
+                {
+                    return;
+                }
                 var authCookiesContainer = new System.Net.CookieContainer();
                 // Get FedAuth and rtFa cookies issued by ADFS when accessing claims aware applications.
                 // - or get the EdgeAccessCookie issued by the Web Application Proxy (WAP) when accessing non-claims aware applications (Kerberos).


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |  yes
| New feature?    | no
| New sample?      | no
| Related issues?  | -

#### What's in this Pull Request?

This PR fixes an issue that occured when `Credentials` were not set and the cookie was also empty (this is the case, when the `CurrentCredentials` flag is set in the `Connect-PnPOnline` PowerShell CmdLet).
If the `cookieString` is null, it does not make sense to continue executing the method as all subsequent commands expect the `cookieString` to contain a value.