### PR TITLE
Fix tokenization for calculated field formula where one field is present multiple times in the formula

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
@@ -272,11 +272,9 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                 if (formulastring != null)
                 {
-                    var fieldRefs = schemaElement.Descendants("FieldRef");
-                    foreach (var fieldRef in fieldRefs)
+                    var fieldInternalNames = schemaElement.Descendants("FieldRef").Select(fr => fr.Attribute("Name").Value).Distinct();
+                    foreach (var fieldInternalName in fieldInternalNames)
                     {
-                        var fieldInternalName = fieldRef.Attribute("Name").Value;
-
                         formulastring = formulastring.Replace($"{fieldInternalName}", $"[{{fieldtitle:{fieldInternalName}}}]");
                     }
                     var fieldRefParent = schemaElement.Descendants("FieldRefs");


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | no

#### What's in this Pull Request?

Tokenization of a Calculated field is incorrect when the formula contains the same field more than once e.g.
_=IF(Probability=\"Low\",1,IF(Probability=\"Medium\",2,3))_

The tokenization result for this will be:
_=IF(**[{fieldtitle:[{fieldtitle:Probability}]}]**=\"Low\",1,IF(**[{fieldtitle:[{fieldtitle:Probability}]}]**=\"Medium\",2,3))_

Each time a field is referenced in the formula, a corresponding FieldRef element is present in the schema xml for the calculated field. The result of this is that on the second iteration, the token for the field will get tokenized and create a token inside another token.

This PR ensures that we only process unique FieldRefs which will give the correct tokenization result:
_=IF(**[{fieldtitle:Probability}]**=\"Low\",1,IF(**[{fieldtitle:Probability}]**=\"Medium\",2,3))_