### PR TITLE
Disable compiler warning 0618 for obsolete provisioning schema const…

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/ProvisioningSchema-2015-12.extensions.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/ProvisioningSchema-2015-12.extensions.cs
@@ -43,7 +43,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml.V201512
             schemaSet.XmlResolver = new XmlUrlResolver();
             schemaSet.Add(webPartSchema);
 
-            return (new XmlQualifiedName("WikiPageWebPart", XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2015_12));
+            return (new XmlQualifiedName("WikiPageWebPart",
+#pragma warning disable 0618
+                XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2015_12
+#pragma warning restore 0618
+                ));
         }
 
         XmlSchema IXmlSerializable.GetSchema()
@@ -53,7 +57,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml.V201512
 
         void IXmlSerializable.ReadXml(XmlReader reader)
         {
-            XNamespace ns = XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2015_12;
+            XNamespace ns =
+#pragma warning disable 0618
+                XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2015_12
+#pragma warning restore 0618
+                ;
 
             XElement webPartXml = (XElement)XElement.ReadFrom(reader);
             this.Title = webPartXml.Attribute("Title").Value;
@@ -69,7 +77,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml.V201512
             writer.WriteAttributeString("Title", this.Title);
             writer.WriteAttributeString("Row", this.Row.ToString());
             writer.WriteAttributeString("Column", this.Column.ToString());
-            writer.WriteStartElement(XMLConstants.PROVISIONING_SCHEMA_PREFIX, "Contents", XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2015_12);
+            writer.WriteStartElement(XMLConstants.PROVISIONING_SCHEMA_PREFIX, "Contents",
+#pragma warning disable 0618
+                XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2015_12
+#pragma warning restore 0618
+                );
 
             using (XmlReader xr = new XmlNodeReader(this.Contents))
             {
@@ -104,7 +116,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml.V201512
             schemaSet.XmlResolver = new XmlUrlResolver();
             schemaSet.Add(baseFieldValueSchema);
 
-            return (new XmlQualifiedName("BaseFieldValue", XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2015_12));
+            return (new XmlQualifiedName("BaseFieldValue",
+#pragma warning disable 0618
+                XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2015_12
+#pragma warning restore 0618
+                ));
         }
 
         XmlSchema IXmlSerializable.GetSchema()
@@ -114,7 +130,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml.V201512
 
         void IXmlSerializable.ReadXml(XmlReader reader)
         {
-            XNamespace ns = XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2015_12;
+            XNamespace ns =
+#pragma warning disable 0618
+                XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2015_12
+#pragma warning restore 0618
+                ;
 
             XElement baseFieldValueXml = (XElement)XElement.ReadFrom(reader);
             this.FieldName = baseFieldValueXml.Attribute("FieldName").Value;
@@ -177,7 +197,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml.V201512
             schemaSet.XmlResolver = new XmlUrlResolver();
             schemaSet.Add(webPartSchema);
 
-            return (new XmlQualifiedName("WebPartPageWebPart", XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2015_12));
+            return (new XmlQualifiedName("WebPartPageWebPart",
+#pragma warning disable 0618
+                XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2015_12
+#pragma warning restore 0618
+                ));
         }
 
         XmlSchema IXmlSerializable.GetSchema()
@@ -187,7 +211,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml.V201512
 
         void IXmlSerializable.ReadXml(XmlReader reader)
         {
-            XNamespace ns = XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2015_12;
+            XNamespace ns =
+#pragma warning disable 0618
+                XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2015_12
+#pragma warning restore 0618
+                ;
 
             XElement webPartXml = (XElement)XElement.ReadFrom(reader);
             this.Title = webPartXml.Attribute("Title").Value;
@@ -203,7 +231,12 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml.V201512
             writer.WriteAttributeString("Title", this.Title);
             writer.WriteAttributeString("Zone", this.Zone);
             writer.WriteAttributeString("Order", this.Order.ToString());
-            writer.WriteStartElement(XMLConstants.PROVISIONING_SCHEMA_PREFIX, "Contents", XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2015_12);
+            writer.WriteStartElement(XMLConstants.PROVISIONING_SCHEMA_PREFIX, 
+                "Contents",
+#pragma warning disable 0618
+                XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2015_12
+#pragma warning restore 0618
+                );
 
             using (XmlReader xr = new XmlNodeReader(this.Contents))
             {

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/ProvisioningSchema-2016-05.extensions.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/ProvisioningSchema-2016-05.extensions.cs
@@ -57,7 +57,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml.V201605
             schemaSet.XmlResolver = new XmlUrlResolver();
             schemaSet.Add(webPartSchema);
 
-            return (new XmlQualifiedName("WikiPageWebPart", XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2016_05));
+            return (new XmlQualifiedName("WikiPageWebPart",
+#pragma warning disable 0618
+                XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2016_05
+#pragma warning restore 0618
+                ));
         }
 
         XmlSchema IXmlSerializable.GetSchema()
@@ -67,7 +71,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml.V201605
 
         void IXmlSerializable.ReadXml(XmlReader reader)
         {
-            XNamespace ns = XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2016_05;
+            XNamespace ns =
+#pragma warning disable 0618
+                XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2016_05
+#pragma warning restore 0618
+                ;
 
             XElement webPartXml = (XElement)XElement.ReadFrom(reader);
             this.Title = webPartXml.Attribute("Title").Value;
@@ -83,7 +91,12 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml.V201605
             writer.WriteAttributeString("Title", this.Title);
             writer.WriteAttributeString("Row", this.Row.ToString());
             writer.WriteAttributeString("Column", this.Column.ToString());
-            writer.WriteStartElement(XMLConstants.PROVISIONING_SCHEMA_PREFIX, "Contents", XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2016_05);
+            writer.WriteStartElement(XMLConstants.PROVISIONING_SCHEMA_PREFIX, 
+                "Contents",
+#pragma warning disable 0618
+                XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2016_05
+#pragma warning restore 0618
+                );
 
             using (XmlReader xr = new XmlNodeReader(this.Contents))
             {
@@ -118,7 +131,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml.V201605
             schemaSet.XmlResolver = new XmlUrlResolver();
             schemaSet.Add(baseFieldValueSchema);
 
-            return (new XmlQualifiedName("BaseFieldValue", XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2016_05));
+            return (new XmlQualifiedName("BaseFieldValue",
+#pragma warning disable 0618
+                XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2016_05
+#pragma warning restore 0618
+                ));
         }
 
         XmlSchema IXmlSerializable.GetSchema()
@@ -128,7 +145,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml.V201605
 
         void IXmlSerializable.ReadXml(XmlReader reader)
         {
-            XNamespace ns = XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2016_05;
+            XNamespace ns =
+#pragma warning disable 0618
+                XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2016_05
+#pragma warning restore 0618
+                ;
 
             XElement baseFieldValueXml = (XElement)XElement.ReadFrom(reader);
             this.FieldName = baseFieldValueXml.Attribute("FieldName").Value;
@@ -191,7 +212,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml.V201605
             schemaSet.XmlResolver = new XmlUrlResolver();
             schemaSet.Add(webPartSchema);
 
-            return (new XmlQualifiedName("WebPartPageWebPart", XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2016_05));
+            return (new XmlQualifiedName("WebPartPageWebPart",
+#pragma warning disable 0618
+                XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2016_05
+#pragma warning restore 0618
+                ));
         }
 
         XmlSchema IXmlSerializable.GetSchema()
@@ -201,7 +226,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml.V201605
 
         void IXmlSerializable.ReadXml(XmlReader reader)
         {
-            XNamespace ns = XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2016_05;
+            XNamespace ns =
+#pragma warning disable 0618                
+                XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2016_05
+#pragma warning restore 0618
+                ;
 
             XElement webPartXml = (XElement)XElement.ReadFrom(reader);
             this.Title = webPartXml.Attribute("Title").Value;
@@ -217,7 +246,12 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml.V201605
             writer.WriteAttributeString("Title", this.Title);
             writer.WriteAttributeString("Zone", this.Zone);
             writer.WriteAttributeString("Order", this.Order.ToString());
-            writer.WriteStartElement(XMLConstants.PROVISIONING_SCHEMA_PREFIX, "Contents", XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2016_05);
+            writer.WriteStartElement(XMLConstants.PROVISIONING_SCHEMA_PREFIX, 
+                "Contents",
+#pragma warning disable 0618
+                XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2016_05
+#pragma warning restore 0618
+                );
 
             using (XmlReader xr = new XmlNodeReader(this.Contents))
             {

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/XMLPnPSchemaV201512Formatter.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/XMLPnPSchemaV201512Formatter.cs
@@ -27,7 +27,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
 
         string IXMLSchemaFormatter.NamespaceUri
         {
-            get { return (XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2015_12); }
+            get { return (
+#pragma warning disable 0618
+                    XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2015_12
+#pragma warning restore 0618
+                    ); }
         }
 
         string IXMLSchemaFormatter.NamespacePrefix
@@ -52,7 +56,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
 
             // Prepare the XML Schema Set
             XmlSchemaSet schemas = new XmlSchemaSet();
-            schemas.Add(XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2015_12,
+            schemas.Add(
+#pragma warning disable 0618
+                XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2015_12
+#pragma warning restore 0618
+                ,
                 new XmlTextReader(stream));
 
             Boolean result = true;
@@ -1086,7 +1094,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
 
             sourceStream.Position = 0;
             XDocument xml = XDocument.Load(sourceStream);
-            XNamespace pnp = XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2015_12;
+            XNamespace pnp =
+#pragma warning disable 0618
+                XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2015_12
+#pragma warning disable 0618
+                ;
 
             // Prepare a variable to hold the single source formatted template
             V201512.ProvisioningTemplate source = null;

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/XMLPnPSchemaV201605Formatter.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/XMLPnPSchemaV201605Formatter.cs
@@ -27,8 +27,12 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
 
         string IXMLSchemaFormatter.NamespaceUri
         {
-            get { return (XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2016_05); }
-        }
+            get { return (
+#pragma warning disable 0618
+                    XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2016_05
+#pragma warning restore 0618
+                    ); }
+            }
 
         string IXMLSchemaFormatter.NamespacePrefix
         {
@@ -52,7 +56,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
 
             // Prepare the XML Schema Set
             XmlSchemaSet schemas = new XmlSchemaSet();
-            schemas.Add(XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2016_05,
+            schemas.Add(
+#pragma warning disable 0618
+                XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2016_05
+#pragma warning restore 0618
+                ,
                 new XmlTextReader(stream));
 
             Boolean result = true;
@@ -1195,7 +1203,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
 
             sourceStream.Position = 0;
             XDocument xml = XDocument.Load(sourceStream);
-            XNamespace pnp = XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2016_05;
+            XNamespace pnp =
+#pragma warning disable 0618
+                XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2016_05
+#pragma warning restore 0618
+                ;
 
             // Prepare a variable to hold the single source formatted template
             V201605.ProvisioningTemplate source = null;

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/XMLPnPSchemaV201605Serializer.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/XMLPnPSchemaV201605Serializer.cs
@@ -33,7 +33,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
 
         public override string NamespaceUri
         {
-            get { return (XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2016_05); }
+            get { return (
+#pragma warning disable 0618
+                    XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2016_05
+#pragma warning restore 0618
+                    ); }
         }
 
         public override string NamespacePrefix

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/XMLPnPSchemaV201705Serializer.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/XMLPnPSchemaV201705Serializer.cs
@@ -33,7 +33,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
 
         public override string NamespaceUri
         {
-            get { return (XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2017_05); }
+            get { return (
+#pragma warning disable 0618
+                    XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2017_05
+#pragma warning restore 0618
+                    ); }
         }
 
         public override string NamespacePrefix


### PR DESCRIPTION
…ants to reduce compiler warnings.

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| New sample?      | no
| Related issues?  | compiler warnings

#### What's in this Pull Request?
Disables compiler warning 0618 for obsolete provisioning schema constants to reduce compiler warnings.