### PR TITLE
Feature: Adds capability to connect existing team site to MS Teams team

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/ClientContextExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/ClientContextExtensions.cs
@@ -310,7 +310,7 @@ namespace Microsoft.SharePoint.Client
                 if (contextSettings != null) // We do have more information about this client context, so let's use it to do a more intelligent clone
                 {
                     string newSiteUrl = siteUrl.ToString();
-                    
+
                     // A diffent host = different audience ==> new access token is needed
                     if (contextSettings.UsesDifferentAudience(newSiteUrl))
                     {
@@ -320,7 +320,7 @@ namespace Microsoft.SharePoint.Client
                         ClientContext newClientContext = null;
                         if (contextSettings.Type == ClientContextType.SharePointACSAppOnly)
                         {
-                            newClientContext = authManager.GetAppOnlyAuthenticatedContext(newSiteUrl, TokenHelper.GetRealmFromTargetUrl(new Uri(newSiteUrl)), contextSettings.ClientId, contextSettings.ClientSecret, contextSettings.AcsHostUrl, contextSettings.GlobalEndPointPrefix);                            
+                            newClientContext = authManager.GetAppOnlyAuthenticatedContext(newSiteUrl, TokenHelper.GetRealmFromTargetUrl(new Uri(newSiteUrl)), contextSettings.ClientId, contextSettings.ClientSecret, contextSettings.AcsHostUrl, contextSettings.GlobalEndPointPrefix);
                         }
 #if !ONPREMISES && !NETSTANDARD2_0
                         else if (contextSettings.Type == ClientContextType.AzureADCredentials)
@@ -363,7 +363,7 @@ namespace Microsoft.SharePoint.Client
                             methodInfo.Invoke(clientContext, parametersArray);
                         };
                     }
-                }                
+                }
                 else // Fallback the default cloning logic if there were not context settings available
                 {
                     //Take over the form digest handling setting
@@ -804,6 +804,18 @@ namespace Microsoft.SharePoint.Client
             await new SynchronizationContextRemover();
 
             return await SiteCollection.AliasExistsAsync(clientContext, alias);
+        }
+
+        /// <summary>
+        /// Enable MS Teams team on a group connected team site
+        /// </summary>
+        /// <param name="clientContext"></param>
+        /// <returns></returns>
+        public static async Task<string> TeamifyAsync(this ClientContext clientContext)
+        {
+            await new SynchronizationContextRemover();
+
+            return await SiteCollection.TeamifySiteAsync(clientContext);
         }
 #endif
     }

--- a/Core/OfficeDevPnP.Core/Sites/SiteCollection.cs
+++ b/Core/OfficeDevPnP.Core/Sites/SiteCollection.cs
@@ -622,6 +622,64 @@ namespace OfficeDevPnP.Core.Sites
                 return await Task.Run(() => responseString);
             }
         }
+
+        /// <summary>
+        /// Enable Microsoft Teams team in an O365 group connected team site
+        /// Will also enable it on a newly Groupified classic site
+        /// </summary>
+        /// <param name="context"></param>
+        /// <returns></returns>
+        public static async Task<string> TeamifySiteAsync(ClientContext context)
+        {
+            string responseString = null;
+
+            context.Site.EnsureProperties(s => s.RelatedGroupId);
+
+            var webTemplateId = context.Web.GetBaseTemplateId();
+
+            if (context.Web.IsSubSite())
+            {
+                throw new Exception("You cannot Teamify a subsite");
+            }
+            else if (context.IsAppOnly())
+            {
+                throw new Exception("App-Only is currently not supported.");
+            }
+            //check if the template is GROUP#0
+            //also check the Related Group Id property, if it is GUID.empty it means it doesnt have associated group otherwise it has been groupified
+            else if (webTemplateId != "GROUP#0")
+            {
+                if (context.Site.RelatedGroupId == Guid.Empty)
+                {
+                    throw new Exception($"You cannot associate Teams on this site collection having web TemplateId {webTemplateId}. It is only supported for O365 Group connected sites.");
+                }
+                else
+                {
+                    responseString = await TeamifySiteAsyncInternal(context);
+                }
+
+            }
+            //if it is a Group site, teamify it
+            else
+            {
+                responseString = await TeamifySiteAsyncInternal(context);
+            }
+
+            return responseString;
+        }
+
+        private static async Task<string> TeamifySiteAsyncInternal(ClientContext context)
+        {
+            string responseString = null;
+
+            var result = await context.Web.ExecutePost("/_api/groupsitemanager/EnsureTeamForGroup", string.Empty);
+
+            var teamId = JObject.Parse(result);
+
+            responseString = Convert.ToString(teamId["value"]);
+
+            return await Task.Run(() => responseString);
+        }
     }
 }
 #endif

--- a/Core/OfficeDevPnP.Core/Sites/SiteCollection.cs
+++ b/Core/OfficeDevPnP.Core/Sites/SiteCollection.cs
@@ -638,11 +638,7 @@ namespace OfficeDevPnP.Core.Sites
             if (context.Web.IsSubSite())
             {
                 throw new Exception("You cannot Teamify a subsite");
-            }
-            else if (context.IsAppOnly())
-            {
-                throw new Exception("App-Only is currently not supported.");
-            }
+            }            
             else if (context.Site.GroupId == Guid.Empty)
             {
                 throw new Exception($"You cannot associate Teams on this site collection. It is only supported for O365 Group connected sites.");


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no
| Related issues?  | NA

#### What's in this Pull Request?

This PR adds the capability to connect existing Modern team site to Microsoft team.
It will also work for classic sites which have been newly groupified because they have the RelatedGroupId property populated. 

Usage:

`var teamId = clientContext.TeamifyAsync().GetAwaiter().GetResult();`

or 

`var teamId = SiteCollection.TeamifySiteAsync(clientContext).GetAwaiter().GetResult();`