### PR TITLE
Content type update children

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/FieldAndContentTypeExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/FieldAndContentTypeExtensions.cs
@@ -968,60 +968,64 @@ namespace Microsoft.SharePoint.Client
             return true;
         }
 
-        /// <summary>
-        /// Associates field to content type
-        /// </summary>
-        /// <param name="contentType">Content Type to add the field to</param>
-        /// <param name="fieldId">String representation of the id of the field (=Guid)</param>
-        /// <param name="required">True if the field is required</param>
-        /// <param name="hidden">True if the field is hidden</param>
-        public static void AddFieldById(this ContentType contentType, string fieldId, bool required = false, bool hidden = false)
+		/// <summary>
+		/// Associates field to content type
+		/// </summary>
+		/// <param name="contentType">Content Type to add the field to</param>
+		/// <param name="fieldId">String representation of the id of the field (=Guid)</param>
+		/// <param name="required">True if the field is required</param>
+		/// <param name="hidden">True if the field is hidden</param>
+		/// <param name="updateChildren">True to update content types that inherit from the content type; otherwise, false.</param>
+		public static void AddFieldById(this ContentType contentType, string fieldId, bool required = false, bool hidden = false, bool updateChildren = true)
         {
-            AddFieldById(contentType, Guid.Parse(fieldId), required, hidden);
+            AddFieldById(contentType, Guid.Parse(fieldId), required, hidden, updateChildren);
         }
 
-        /// <summary>
-        /// Associates field to content type
-        /// </summary>
-        /// <param name="contentType">Content Type to add the field to</param>
-        /// <param name="fieldId">The Id of the field</param>
-        /// <param name="required">True if the field is required</param>
-        /// <param name="hidden">True if the field is hidden</param>
-        public static void AddFieldById(this ContentType contentType, Guid fieldId, bool required = false, bool hidden = false)
+		/// <summary>
+		/// Associates field to content type
+		/// </summary>
+		/// <param name="contentType">Content Type to add the field to</param>
+		/// <param name="fieldId">The Id of the field</param>
+		/// <param name="required">True if the field is required</param>
+		/// <param name="hidden">True if the field is hidden</param>
+		/// <param name="updateChildren">True to update content types that inherit from the content type; otherwise, false.</param>
+		public static void AddFieldById(this ContentType contentType, Guid fieldId, bool required = false, bool hidden = false, bool updateChildren = true)
         {
             var ctx = contentType.Context as ClientContext;
             var field = ctx.Web.Fields.GetById(fieldId);
             ctx.Load(field);
             ctx.ExecuteQueryRetry();
-            AddFieldToContentType(ctx.Web, contentType, field, required, hidden);
+            AddFieldToContentType(ctx.Web, contentType, field, required, hidden, updateChildren);
         }
 
-        /// <summary>
-        /// Associates field to content type
-        /// </summary>
-        /// <param name="contentType">Content Type to add the field to</param>
-        /// <param name="fieldName">The title or internal name of the field</param>
-        /// <param name="required">True if the field is required</param>
-        /// <param name="hidden">True if the field is hidden</param>
-        public static void AddFieldByName(this ContentType contentType, string fieldName, bool required = false, bool hidden = false)
+		/// <summary>
+		/// Associates field to content type
+		/// </summary>
+		/// <param name="contentType">Content Type to add the field to</param>
+		/// <param name="fieldName">The title or internal name of the field</param>
+		/// <param name="required">True if the field is required</param>
+		/// <param name="hidden">True if the field is hidden</param>
+		/// <param name="updateChildren">True to update content types that inherit from the content type; otherwise, false.</param>
+		public static void AddFieldByName(this ContentType contentType, string fieldName, bool required = false, bool hidden = false, bool updateChildren = true)
         {
             var ctx = contentType.Context as ClientContext;
             var field = ctx.Web.Fields.GetByInternalNameOrTitle(fieldName);
             ctx.Load(field);
             ctx.ExecuteQueryRetry();
 
-            AddFieldToContentType(ctx.Web, contentType, field, required, hidden);
+            AddFieldToContentType(ctx.Web, contentType, field, required, hidden, updateChildren);
         }
 
-        /// <summary>
-        /// Associates field to content type
-        /// </summary>
-        /// <param name="web">Site to be processed - can be root web or sub site</param>
-        /// <param name="contentTypeID">String representation of the id of the content type to add the field to</param>
-        /// <param name="fieldId">String representation of the field ID (=guid)</param>
-        /// <param name="required">True if the field is required</param>
-        /// <param name="hidden">True if the field is hidden</param>
-        public static void AddFieldToContentTypeById(this Web web, string contentTypeID, string fieldId, bool required = false, bool hidden = false)
+		/// <summary>
+		/// Associates field to content type
+		/// </summary>
+		/// <param name="web">Site to be processed - can be root web or sub site</param>
+		/// <param name="contentTypeID">String representation of the id of the content type to add the field to</param>
+		/// <param name="fieldId">String representation of the field ID (=guid)</param>
+		/// <param name="required">True if the field is required</param>
+		/// <param name="hidden">True if the field is hidden</param>
+		/// <param name="updateChildren">True to update content types that inherit from the content type; otherwise, false.</param>
+		public static void AddFieldToContentTypeById(this Web web, string contentTypeID, string fieldId, bool required = false, bool hidden = false, bool updateChildren = true)
         {
             // Get content type
             var ct = web.GetContentTypeById(contentTypeID);
@@ -1033,18 +1037,19 @@ namespace Microsoft.SharePoint.Client
             var fld = web.Fields.GetById(new Guid(fieldId));
 
             // Add field association to content type
-            AddFieldToContentType(web, ct, fld, required, hidden);
+            AddFieldToContentType(web, ct, fld, required, hidden, updateChildren);
         }
 
-        /// <summary>
-        /// Associates field to content type
-        /// </summary>
-        /// <param name="web">Site to be processed - can be root web or sub site</param>
-        /// <param name="contentTypeName">Name of the content type</param>
-        /// <param name="fieldID">Guid representation of the field ID</param>
-        /// <param name="required">True if the field is required</param>
-        /// <param name="hidden">True if the field is hidden</param>
-        public static void AddFieldToContentTypeByName(this Web web, string contentTypeName, Guid fieldID, bool required = false, bool hidden = false)
+		/// <summary>
+		/// Associates field to content type
+		/// </summary>
+		/// <param name="web">Site to be processed - can be root web or sub site</param>
+		/// <param name="contentTypeName">Name of the content type</param>
+		/// <param name="fieldID">Guid representation of the field ID</param>
+		/// <param name="required">True if the field is required</param>
+		/// <param name="hidden">True if the field is hidden</param>
+		/// <param name="updateChildren">True to update content types that inherit from the content type; otherwise, false.</param>
+		public static void AddFieldToContentTypeByName(this Web web, string contentTypeName, Guid fieldID, bool required = false, bool hidden = false, bool updateChildren = true)
         {
             // Get content type
             var ct = web.GetContentTypeByName(contentTypeName);
@@ -1056,18 +1061,19 @@ namespace Microsoft.SharePoint.Client
             var fld = web.Fields.GetById(fieldID);
 
             // Add field association to content type
-            AddFieldToContentType(web, ct, fld, required, hidden);
+            AddFieldToContentType(web, ct, fld, required, hidden, updateChildren);
         }
 
-        /// <summary>
-        /// Associates field to content type
-        /// </summary>
-        /// <param name="web">Site to be processed - can be root web or sub site</param>
-        /// <param name="contentType">Content type to associate field to</param>
-        /// <param name="field">Field to associate to the content type</param>
-        /// <param name="required">Optionally make this a required field</param>
-        /// <param name="hidden">Optionally make this a hidden field</param>
-        public static void AddFieldToContentType(this Web web, ContentType contentType, Field field, bool required = false, bool hidden = false)
+		/// <summary>
+		/// Associates field to content type
+		/// </summary>
+		/// <param name="web">Site to be processed - can be root web or sub site</param>
+		/// <param name="contentType">Content type to associate field to</param>
+		/// <param name="field">Field to associate to the content type</param>
+		/// <param name="required">Optionally make this a required field</param>
+		/// <param name="hidden">Optionally make this a hidden field</param>
+		/// <param name="updateChildren">True to update content types that inherit from the content type; otherwise, false.</param>
+		public static void AddFieldToContentType(this Web web, ContentType contentType, Field field, bool required = false, bool hidden = false, bool updateChildren = true)
         {
             //// Forcibly include Ids of FieldLinks
             //web.Context.Load(contentType, c => c.FieldLinks.Include(fl => fl.Id, fl => fl.Required, fl => fl.Hidden));
@@ -1090,7 +1096,7 @@ namespace Microsoft.SharePoint.Client
                 var fldInfo = new FieldLinkCreationInformation();
                 fldInfo.Field = field;
                 contentType.FieldLinks.Add(fldInfo);
-                contentType.Update(true);
+                contentType.Update(updateChildren);
                 web.Context.ExecuteQueryRetry();
 
                 flink = contentType.FieldLinks.GetById(field.Id);

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/FieldRef.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/FieldRef.cs
@@ -48,10 +48,10 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model
         /// </summary>
         public bool Remove { get; set; }
 
-        /// <summary>
-        /// Declares whether the current field reference has to be udpated on inherited content types
-        /// </summary>
-        public bool UpdateChildren { get; set; }
+		/// <summary>
+		/// Declares whether the current field reference has to be udpated on inherited content types
+		/// </summary>
+		public bool UpdateChildren { get; set; } = true;
 
         #endregion
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
@@ -216,10 +216,15 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 isDirty = true;
             }
 #endif
-            
+			if (isDirty)
+			{
+				// Default to false as there is no reason to update children on CT property changes.
+				existingContentType.Update(false);
+				web.Context.ExecuteQueryRetry();
+			}
 
-            // Set flag to reorder fields CT fields are not equal to template fields
-            var existingFieldNames = existingContentType.FieldLinks.AsEnumerable().Select(fld => fld.Name).ToArray();
+			// Set flag to reorder fields CT fields are not equal to template fields
+			var existingFieldNames = existingContentType.FieldLinks.AsEnumerable().Select(fld => fld.Name).ToArray();
             var ctFieldNames = templateContentType.FieldRefs.Select(fld => parser.ParseString(fld.Name)).ToArray();
             reOrderFields = ctFieldNames.Length > 0 && !existingFieldNames.SequenceEqual(ctFieldNames);
 
@@ -240,15 +245,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
 				return true;
 			}
-			scope.LogDebug("Update child Content Types: {0}", UpdateChildren());
-
-			if (isDirty)
-			{
-				// Update for changes to content type properties.
-				existingContentType.Update(UpdateChildren());
-				web.Context.ExecuteQueryRetry();
-			}
-
+			
 			if (fieldsNotPresentInTarget.Any())
             {
                 // Set flag to reorder fields when new fields are added.
@@ -330,7 +327,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
             if (isDirty)
             {
-                existingContentType.Update(UpdateChildren());
+				scope.LogDebug("Update child Content Types: {0}", UpdateChildren());
+				existingContentType.Update(UpdateChildren());
                 web.Context.ExecuteQueryRetry();
             }
         }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
@@ -124,6 +124,9 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             var isDirty = false;
             var reOrderFields = false;
 
+			bool updateChildren = !templateContentType.FieldRefs.All(f => f.UpdateChildren == false);
+			scope.LogInfo("Update child Content Types: {0}", updateChildren);
+
             if (existingContentType.Hidden != templateContentType.Hidden)
             {
                 scope.LogPropertyUpdate("Hidden");
@@ -217,7 +220,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 #endif
             if (isDirty)
             {
-                existingContentType.Update(true);
+                existingContentType.Update(updateChildren);
                 web.Context.ExecuteQueryRetry();
             }
 
@@ -262,7 +265,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     }
 
                     scope.LogDebug(CoreResources.Provisioning_ObjectHandlers_ContentTypes_Adding_field__0__to_content_type, fieldId);
-                    web.AddFieldToContentType(existingContentType, field, fieldRef.Required, fieldRef.Hidden);
+                    web.AddFieldToContentType(existingContentType, field, fieldRef.Required, fieldRef.Hidden, fieldRef.UpdateChildren);
                 }
             }
 
@@ -314,7 +317,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
             if (isDirty)
             {
-                existingContentType.Update(true);
+                existingContentType.Update(updateChildren);
                 web.Context.ExecuteQueryRetry();
             }
         }
@@ -364,7 +367,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 }
                 // Add it to the target content type
                 // Notice that this code will fail if the field does not exist
-                web.AddFieldToContentType(createdCT, field, fieldRef.Required, fieldRef.Hidden);
+                web.AddFieldToContentType(createdCT, field, fieldRef.Required, fieldRef.Hidden, fieldRef.UpdateChildren);
             }
 
             // Add new CTs


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #2251 #2049

#### What's in this Pull Request?

UpdateChildren was added to FieldRefs in Content Types.  According to [this](https://github.com/SharePoint/PnP-Sites-Core/pull/2049#issuecomment-494748756) comment the original PR wasn't merged.

This includes the changes in the original PR, plus an additional `AddFieldById` overload.

This also wasn't the whole story as any other changes to the content type would mean `Update` is called, plus if FieldRefs are in a different order again `Update` is called with updateChildren true.
I've defaulted the first `Update`, which is CT properties only to `false`
I've added a slightly questionable workaround where I check that is there are changes to the FieldRefs it will only update children if one has `UpdateChildren` set to true

However...this still isn't 100%, as `UpdateChildren` isn't required in the XML, the default value on the `FieldRef` property is false, but the default value of `UpdateChildren` in the engine wants to be true.
I did try setting it to be true by default, but that didn't work.
`public bool UpdateChildren { get; set; } = true;`

Ideally, `UpdateChildren` should be a property at the Content Type level rather than the field ref I think or both the CT and the FieldRef (but I can't think of a scenario where I'd only want certain fields to be pushed down, plus with the re-order causing and update, if pushed and the fields weren't present in the child, I'd expect and error).  So perhaps at the CT level is best and if you only want certain fields pushed, you can have two CT elements in your template doing different things.

At least for now at least we have a working solution, with a caveat!  To force and update of child content types you must set at least one field ref's `UpdateChildren` property to `true`