### PR TITLE
Update SiteLockState enum

### DIFF
--- a/Core/OfficeDevPnP.Core/Enums/TenantEnums.cs
+++ b/Core/OfficeDevPnP.Core/Enums/TenantEnums.cs
@@ -1,7 +1,8 @@
 ﻿namespace OfficeDevPnP.Core {
     public enum SiteLockState {
         Unlock,
-        NoAccess
+        NoAccess,
+        ReadOnly
     }
 
     public enum TenantOperationMessage


### PR DESCRIPTION
Add ReadOnly option for SiteLockState enum as it is supported for SPO now.
Described at (-LockState):
https://docs.microsoft.com/en-us/powershell/module/sharepoint-online/set-sposite?view=sharepoint-ps 

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no
