### PR TITLE
Fix fileUniqueId parsing in ReplaceFileUniqueToken when point to Folder

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectNavigation.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectNavigation.cs
@@ -282,7 +282,25 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         }
                         catch (Exception ex)
                         {
+                            //Test if fileuniqueid belongs to a folder
+                            try
+                            {
+                                web.EnsureProperties(w => w.ServerRelativeUrl);
+                                string folderUrl = $"{web.ServerRelativeUrl}/{ match.Groups["fileurl"].Value}";
+                                var spFolder = web.GetFolderByServerRelativeUrl(folderUrl);
+                                web.Context.Load(spFolder, f => f.UniqueId);
+                                web.Context.ExecuteQuery();
+                                string folderId = spFolder.UniqueId.ToString();
+                                if (match.Groups["tokenname"].Value.Equals("fileuniqueidencoded", StringComparison.InvariantCultureIgnoreCase))
+                                {
+                                    folderId = folderId.Replace("-", "%2D");
+                                }
+                                UrlValue = Regex.Replace(UrlValue, $"{{{match.Groups["tokenname"].Value}:{match.Groups["fileurl"].Value}}}", folderId, RegexOptions.IgnoreCase);
+                            }
+                            catch (Exception ex1)
+                            {
 
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no
| Related issues?  | fixes #2283

#### What's in this Pull Request?
When ReplaceFileUniqueToken can not resolve the Token {fileuniqueid:xxx} to a File it will try if it can resolve it to a Folder. In that way we can use the fileuniqueid token also for OneNote as the root is a Folder.