### PR TITLE
Fix tokenization issue with views in root site collection

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectHandlerBase.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectHandlerBase.cs
@@ -214,8 +214,14 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 xml = masterPageRegex.Replace(xml, subsite ? "{sitecollection}/_catalogs/masterpage" : "{masterpagecatalog}");
 
                 // Site
-                var siteRegex = new Regex(web.ServerRelativeUrl.Replace("/", @"\/"));
-                xml = siteRegex.Replace(xml, "{site}");
+                var siteRegexReplacement = "{site}";
+                // If we are in the root site collection with just / as ServerRelativeUrl then we cannot replace all / with {site}, otherwise the urls will look like "{site}_layouts/15/images"
+                if (web.ServerRelativeUrl == "/")
+                    siteRegexReplacement += "/";
+
+                xml = Regex.Replace(xml, "(\"" + web.ServerRelativeUrl + ")(?!&)", "\"" + siteRegexReplacement, RegexOptions.IgnoreCase);
+                xml = Regex.Replace(xml, "'" + web.ServerRelativeUrl, "'" + siteRegexReplacement, RegexOptions.IgnoreCase);
+                xml = Regex.Replace(xml, ">" + web.ServerRelativeUrl, ">" + siteRegexReplacement, RegexOptions.IgnoreCase);
 
                 return xml;
             }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #2247

#### What's in this Pull Request?

Fix Views tokenizer not working correctly in the root site collection with a ServerRelativeUrl of value "/" .

This is the output xml before this PR:
```xml
<View Name="{4CDD7F9D-7A64-4CA7-9C73-5F0FC848E92B}" DefaultView="TRUE" MobileView="TRUE" MobileDefaultView="TRUE" Type="HTML" DisplayName="All Documents" Url="{site}Shared Documents{site}Forms{site}AllItems.aspx"  Level="1" BaseViewID="1" ContentTypeID="0x" ImageUrl="{site}_layouts{site}15{site}images{site}dlicon.png?rev=47">
  <Query>
	<OrderBy>
	  <FieldRef Name="FileLeafRef" {site}>
	<{site}OrderBy>
  <{site}Query>
  <ViewFields>
	<FieldRef Name="DocIcon" {site}>
	<FieldRef Name="LinkFilename" {site}>
	<FieldRef Name="Modified" {site}>
	<FieldRef Name="Editor" {site}>
  <{site}ViewFields>
  <RowLimit Paged="TRUE">30<{site}RowLimit>
  <JSLink>clienttemplates.js<{site}JSLink>
<{site}View>
```

This is the output xml after applying this PR
```xml
<View Name="{4CDD7F9D-7A64-4CA7-9C73-5F0FC848E92B}" DefaultView="TRUE" MobileView="TRUE" MobileDefaultView="TRUE" Type="HTML" DisplayName="All Documents" Url="{site}/Shared Documents/Forms/AllItems.aspx" Level="1" BaseViewID="1" ContentTypeID="0x" ImageUrl="{site}/_layouts/15/images/dlicon.png?rev=47">
  <Query>
	<OrderBy>
	  <FieldRef Name="FileLeafRef" />
	</OrderBy>
  </Query>
  <ViewFields>
	<FieldRef Name="DocIcon" />
	<FieldRef Name="LinkFilename" />
	<FieldRef Name="Modified" />
	<FieldRef Name="Editor" />
  </ViewFields>
  <RowLimit Paged="TRUE">30</RowLimit>
  <JSLink>clienttemplates.js</JSLink>
</View>
```

The Regex replacement are the same as https://github.com/SharePoint/PnP-Sites-Core/blob/dev/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPageContents.cs#L291 so that no XML tags are affected.
In addition in case of the root site collection another check ensures that "{site}" token is followed by /, otherwise paths would look like "{site}_layouts/15/images" not working when applying the template.

If we want to add any additional validation, we could call XElement.Parse(xml) at the beginning and at the end of TokenizeXml(). That would throw a System.Xml.XmlException that would be easy to debug (instead of many function calls later)