### PR TITLE
Fix: Additional null checks and content rating fix while creating team

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/Teams/TeamFunSettings.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/Teams/TeamFunSettings.cs
@@ -21,7 +21,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model.Teams
         /// <summary>
         /// Defines the Content Rating for Giphys
         /// </summary>
-        public TeamGiphyContentRating GiphyContentRating { get; set; }
+        public string GiphyContentRating { get; set; }
 
         /// <summary>
         /// Defines whether Stickers and Memes are consented or not
@@ -90,15 +90,15 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model.Teams
         /// <summary>
         /// Defines the Content Rating for Giphys
         /// </summary>
-        public enum TeamGiphyContentRating
+        public static class TeamGiphyContentRating
     {
         /// <summary>
         /// Moderate Content Rating
         /// </summary>
-        Moderate,
+        public const string Moderate = "moderate";
         /// <summary>
         /// Strict Content Rating
         /// </summary>
-        Strict,
+        public const string Strict = "strict";
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |  yes
| New feature?    | yes
| New sample?      | no
| Related issues?  | fixes NA

#### What's in this Pull Request?

1) This PR adds additional null check while provisioning teams with additional settings like FunSettings, GuestSettings etc. 

2) Additionally, it removes compiler directives which are not needed as we already handle it "above".

3) If the Giphy content rating is set to Strict, that value is not respected, so fixed that issue with static class.

4) Added support for users with special characters in email address.

This PR fixes null issue when you try to provision a team from PnP template which is as below:

```
<pnp:Teams>    
    <pnp:Team DisplayName="Sample Team 01" Description="This is just a sample Team 01" Visibility="Public" Specialization="None">
      <pnp:Security>
        <pnp:Owners ClearExistingItems="true">
          <pnp:User UserPrincipalName="admin@tenant.onmicrosoft.com" />
          <pnp:User UserPrincipalName="meganb@tenant.onmicrosoft.com" />
        </pnp:Owners>
        <pnp:Members ClearExistingItems="true">
          <pnp:User UserPrincipalName="admin@tenant.onmicrosoft.com" />
          <pnp:User UserPrincipalName="meganb@tenant.onmicrosoft.com" />
        </pnp:Members>
      </pnp:Security>
    </pnp:Team>
</pnp:Teams>	
```

When i try to provision a Team using above template, the Team is not getting created, error is not thrown either but debugging the code, it gives a null reference error. This PR fixes it.

@PaoloPia - sorry, had to create a new PR as the previous https://github.com/SharePoint/PnP-Sites-Core/pull/2241 had some issue due to merge issue. Have included the review comments and fixed them.