### PR TITLE
Feature: Made owner mandatory for communication site in app-only context

### DIFF
--- a/Core/OfficeDevPnP.Core/Sites/SiteCollection.cs
+++ b/Core/OfficeDevPnP.Core/Sites/SiteCollection.cs
@@ -58,6 +58,11 @@ namespace OfficeDevPnP.Core.Sites
 
             var accessToken = clientContext.GetAccessToken();
 
+            if (clientContext.IsAppOnly() && string.IsNullOrEmpty(siteCollectionCreationInformation.Owner))
+            {
+                throw new Exception("You need to set the owner in App-only context");
+            }
+
             using (var handler = new HttpClientHandler())
             {
                 clientContext.Web.EnsureProperty(w => w.Url);
@@ -294,12 +299,13 @@ namespace OfficeDevPnP.Core.Sites
 
             ClientContext responseContext = null;
 
-            var accessToken = clientContext.GetAccessToken();
-
             if (clientContext.IsAppOnly())
             {
                 throw new Exception("App-Only is currently not supported.");
             }
+
+            var accessToken = clientContext.GetAccessToken();
+
             using (var handler = new HttpClientHandler())
             {
                 clientContext.Web.EnsureProperty(w => w.Url);
@@ -638,7 +644,7 @@ namespace OfficeDevPnP.Core.Sites
             if (context.Web.IsSubSite())
             {
                 throw new Exception("You cannot Teamify a subsite");
-            }            
+            }
             else if (context.Site.GroupId == Guid.Empty)
             {
                 throw new Exception($"You cannot associate Teams on this site collection. It is only supported for O365 Group connected sites.");

--- a/Core/OfficeDevPnP.Core/Sites/SiteCollection.cs
+++ b/Core/OfficeDevPnP.Core/Sites/SiteCollection.cs
@@ -56,12 +56,12 @@ namespace OfficeDevPnP.Core.Sites
 
             ClientContext responseContext = null;
 
-            var accessToken = clientContext.GetAccessToken();
-
             if (clientContext.IsAppOnly() && string.IsNullOrEmpty(siteCollectionCreationInformation.Owner))
             {
                 throw new Exception("You need to set the owner in App-only context");
             }
+
+            var accessToken = clientContext.GetAccessToken();
 
             using (var handler = new HttpClientHandler())
             {
@@ -178,12 +178,13 @@ namespace OfficeDevPnP.Core.Sites
 
             ClientContext responseContext = null;
 
-            var accessToken = clientContext.GetAccessToken();
-
             if (clientContext.IsAppOnly())
             {
                 throw new Exception("App-Only is currently not supported.");
             }
+
+            var accessToken = clientContext.GetAccessToken();
+
             using (var handler = new HttpClientHandler())
             {
                 clientContext.Web.EnsureProperty(w => w.Url);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no
| Related issues?  | fixes NA

#### What's in this Pull Request?

As per the updated article for communication sites,  [create modern SharePoint sites](https://docs.microsoft.com/en-us/sharepoint/dev/apis/site-creation-rest), owner property is mandatory in App-only context. This PR adds support for it as per updated guidance.