### PR TITLE
Fix for Tenant Hierarchy settings when template doesnt use them.

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectHierarchyTenant.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectHierarchyTenant.cs
@@ -57,7 +57,18 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
         public override bool WillProvision(Tenant tenant, ProvisioningHierarchy hierarchy, string sequenceId, ProvisioningTemplateApplyingInformation applyingInformation)
         {
-            return hierarchy.Tenant != null;
+            if (!_willProvision.HasValue && hierarchy.Tenant != null)
+            {
+                _willProvision = ((hierarchy.Tenant.AppCatalog.Packages != null && hierarchy.Tenant.AppCatalog.Packages.Count > 0 ) ||
+                                hierarchy.Tenant.ContentDeliveryNetwork != null ||
+                                (hierarchy.Tenant.SiteDesigns != null && hierarchy.Tenant.SiteDesigns.Count > 0) ||
+                                (hierarchy.Tenant.SiteScripts != null && hierarchy.Tenant.SiteScripts.Count > 0) ||
+                                (hierarchy.Tenant.StorageEntities != null && hierarchy.Tenant.StorageEntities.Count > 0) ||
+                                (hierarchy.Tenant.WebApiPermissions != null && hierarchy.Tenant.WebApiPermissions.Count > 0) ||
+                                (hierarchy.Tenant.Themes != null && hierarchy.Tenant.Themes.Count > 0)
+                                );
+            }
+            return (_willProvision.Value);
         }
     }
 }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectHierarchyTenant.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectHierarchyTenant.cs
@@ -59,7 +59,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         {
             if (!_willProvision.HasValue && hierarchy.Tenant != null)
             {
-                _willProvision = ((hierarchy.Tenant.AppCatalog.Packages != null && hierarchy.Tenant.AppCatalog.Packages.Count > 0 ) ||
+                _willProvision = ((hierarchy.Tenant.AppCatalog?.Packages != null && hierarchy.Tenant.AppCatalog?.Packages.Count > 0 ) ||
                                 hierarchy.Tenant.ContentDeliveryNetwork != null ||
                                 (hierarchy.Tenant.SiteDesigns != null && hierarchy.Tenant.SiteDesigns.Count > 0) ||
                                 (hierarchy.Tenant.SiteScripts != null && hierarchy.Tenant.SiteScripts.Count > 0) ||


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| New sample?      | no
| Related issues?  | NA

#### What's in this Pull Request?

This PR adds additional check to the WillProvision method so that tenant settings are only applied if they are specified in the template.

Take the case of the below template:

```xml
<pnp:Provisioning xmlns:pnp="http://schemas.dev.office.com/PnP/2018/07/ProvisioningSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dev.office.com/PnP/2018/07/ProvisioningSchema https://raw.githubusercontent.com/OfficeDev/PnP-Provisioning-Schema/master/OfficeDevPnP.ProvisioningSchema/ProvisioningSchema-2018-07.xsd">
  <pnp:Preferences Author="Gautam" Version="1.0" />
  <pnp:Sequence ID="Test">
    <pnp:SiteCollections>
      <pnp:SiteCollection xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                          xsi:type="pnp:TeamSite"
                          Title="Team site collection"
                          DisplayName="Team site collection"
                          Description=""
                          Alias="sitecollection"
                          IsPublic="false"
                          IsHubSite="false">
        <pnp:Sites>
          <pnp:Site xsi:type="pnp:TeamSubSiteNoGroup"
                    Title="Team sub-site"
                    Description=""
                    Url="subsite"
                    QuickLaunchEnabled="true"
                    UseSamePermissionsAsParentSite="false"
                    TimeZoneId="73"
                    Language="3081">
          </pnp:Site>
        </pnp:Sites>
      </pnp:SiteCollection>
    </pnp:SiteCollections>
  </pnp:Sequence>
</pnp:Provisioning>
```

In the above template, we have not specified any tenant settings, even then the handler is executed. This PR fixes that issue.