### PR TITLE
Support for default header image for client side page based on visual layout

### DIFF
--- a/Core/OfficeDevPnP.Core/Pages/ClientSidePage.cs
+++ b/Core/OfficeDevPnP.Core/Pages/ClientSidePage.cs
@@ -948,7 +948,8 @@ namespace OfficeDevPnP.Core.Pages
                     }
 
                     // Validate the found preview image url
-                    if (!string.IsNullOrEmpty(previewImageServerRelativeUrl))
+                    if (!string.IsNullOrEmpty(previewImageServerRelativeUrl) &&
+                        !previewImageServerRelativeUrl.StartsWith("/_LAYOUTS", StringComparison.OrdinalIgnoreCase))
                     {
                         try
                         {

--- a/Core/OfficeDevPnP.Core/Pages/ClientSidePageHeader.cs
+++ b/Core/OfficeDevPnP.Core/Pages/ClientSidePageHeader.cs
@@ -466,17 +466,19 @@ namespace OfficeDevPnP.Core.Pages
         {
             try
             {
-                this.clientContext.Site.EnsureProperties(p => p.Id);
-                this.clientContext.Web.EnsureProperties(p => p.Id);
+                this.siteId = this.clientContext.Site.EnsureProperty(p => p.Id);
+                this.webId = this.clientContext.Web.EnsureProperty(p => p.Id);
 
-                var pageHeaderImage = this.clientContext.Web.GetFileByServerRelativePath(ResourcePath.FromDecodedUrl(ImageServerRelativeUrl));
-                this.clientContext.Load(pageHeaderImage, p => p.UniqueId, p => p.ListId);
-                this.clientContext.ExecuteQueryRetry();
+                if (!ImageServerRelativeUrl.StartsWith("/_LAYOUTS", StringComparison.OrdinalIgnoreCase))
+                {
+                    var pageHeaderImage = this.clientContext.Web.GetFileByServerRelativePath(ResourcePath.FromDecodedUrl(ImageServerRelativeUrl));
+                    this.clientContext.Load(pageHeaderImage, p => p.UniqueId, p => p.ListId);
+                    this.clientContext.ExecuteQueryRetry();
 
-                this.siteId = this.clientContext.Site.Id;
-                this.webId = this.clientContext.Web.Id;
-                this.listId = pageHeaderImage.ListId;
-                this.uniqueId = pageHeaderImage.UniqueId;
+                    this.listId = pageHeaderImage.ListId;
+                    this.uniqueId = pageHeaderImage.UniqueId;
+                }
+
                 this.headerImageResolved = true;
             }
             catch (ServerException ex)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no - yes?
| New feature?    | no - yes?
| New sample?      | no
| Related issues?  | N/A

#### What's in this Pull Request?

When creating a Client Side Page based on the Visual Layout template, the header image will reference "/_LAYOUTS/IMAGES/VISUALTEMPLATETITLEIMAGE.JPG".

When applying an exported template, this will result in an "Server relative urls must start with SPWeb.ServerRelativeUrl" exception within OfficeDevPnP.Core.Pages.ClientSidePageHeader.ResolvePageHeaderImage.

This PR allows references to the _layouts folder.
