### PR TITLE
Fix for "The 'Equals' member cannot be used in the expression" in GetPrincipalUniqueRoleAssignments

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/SecurityExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/SecurityExtensions.cs
@@ -1509,10 +1509,26 @@ namespace Microsoft.SharePoint.Client
                 {
                     return;
                 }
-                var roleAssignments = web.Context.LoadQuery(obj.RoleAssignments.Where(i => i.Member.LoginName.Equals(principal.LoginName, StringComparison.OrdinalIgnoreCase)));
-                web.Context.ExecuteQueryRetry();
 
-                var assignment = roleAssignments.FirstOrDefault();
+                RoleAssignment assignment;
+                try
+                {
+                    assignment = obj.RoleAssignments.GetByPrincipal(principal);
+                    web.Context.ExecuteQueryRetry();
+                }
+                catch (ServerException ex)
+                {
+                    if (ex.HResult == -2146233088)
+                    {
+                        // Can not find the principal so suppress the exception
+                        assignment = null;
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
+
                 if (assignment != null)
                 {
                     var bindings = web.Context.LoadQuery(assignment.RoleDefinitionBindings.Where(b => b.Name != "Limited Access"));


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | N/A

#### What's in this Pull Request?
This PR fixes an exception "The 'Equals' member cannot be used in the expression" thrown in GetPrincipalUniqueRoleAssignments.
