### PR TITLE
CAML improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,6 @@ FakesAssemblies/
 
 # Visual Studio 2015 cache/options directory
 .vs/
+
+# VS Code Settings
+.vscode/

--- a/Core/OfficeDevPnP.Core/Utilities/Caml.cs
+++ b/Core/OfficeDevPnP.Core/Utilities/Caml.cs
@@ -31,6 +31,8 @@ namespace OfficeDevPnP.Core.Utilities {
         const string VIEW_FIELDS_CLAUSE = "<ViewFields>{0}</ViewFields>";
         const string FIELD_REF_CLAUSE = "<FieldRef Name='{0}'/>";
 
+        const string VALUE_FOR_IN_CLAUSE = "<Value Type='{0}'>{1}</Value>";
+
         public static readonly string Me = "<UserId />";
         public static readonly string Month = "<Month />";
         public static readonly string Now = "<Now />";
@@ -69,6 +71,16 @@ namespace OfficeDevPnP.Core.Utilities {
         public static string ViewQuery(ViewScope scope, string whereClause = "", string orderByClause = "", string viewFields = "", int rowLimit = 100) {
             string viewScopeStr = scope == ViewScope.DefaultValue ? string.Empty : scope.ToString();
             return string.Format(VIEW_XML_WRAPPER, viewScopeStr, whereClause, orderByClause, viewFields, rowLimit);
+        }
+
+        /// <summary>
+        /// Creates a &lt;Value&gt; node for In comparison clauses.
+        /// </summary>
+        /// <param name="value">Value of the field</param>
+        /// <param name="fieldValueType">Value type of the field</param>
+        /// <returns>Value string to be used for In comparisions in CAML queries</returns>
+        public static string Value(string value, string fieldValueType) {
+            return string.Format(VALUE_FOR_IN_CLAUSE, fieldValueType, value);
         }
 
         /// <summary>
@@ -223,13 +235,13 @@ namespace OfficeDevPnP.Core.Utilities {
         /// Creates &lt;In&gt; node for Comparison
         /// </summary>
         /// <param name="fieldRef">Field Reference</param>
-        /// <param name="values">Values to be included inside the &lt;In&gt;-clause</param>
+        /// <param name="values">Value strings to be included inside the &lt;In&gt;-clause</param>
         /// <returns>Returns Comparison string to be used in CAML queries</returns>
         public static string In(string fieldRef, params string[] values) {
             var fieldValue = fieldRef;
             fieldValue += "<Values>";
             foreach(var value in values) {
-                fieldValue = string.Format("<Value>{0}</Value>", value);
+                fieldValue += value;
             }
             fieldValue += "</Values>";
             return In(fieldValue);

--- a/Core/OfficeDevPnP.Core/Utilities/Caml.cs
+++ b/Core/OfficeDevPnP.Core/Utilities/Caml.cs
@@ -25,7 +25,6 @@ namespace OfficeDevPnP.Core.Utilities {
         const string VIEW_XML_WRAPPER = "<View Scope=\"{0}\"><Query>{1}{2}</Query>{3}<RowLimit>{4}</RowLimit></View>";
         const string FIELD_VALUE = "<FieldRef Name='{0}' {1}/><Value Type='{2}'>{3}</Value>";
         const string FIELD_VALUE_ID = "<FieldRef ID='{0}' {1} /><Value Type='{2}'>{3}</Value>";
-        const string WHERE_CLAUSE = "<Where>{0}</Where>";
         const string GENERIC_CLAUSE = "<{0}>{1}</{0}>";
         const string CONDITION_CLAUSE = "<{0}>{1}{2}</{0}>";
 

--- a/Core/OfficeDevPnP.Core/Utilities/Caml.cs
+++ b/Core/OfficeDevPnP.Core/Utilities/Caml.cs
@@ -220,6 +220,21 @@ namespace OfficeDevPnP.Core.Utilities {
             return Comparison(CamlComparisions.In, fieldValue);
         }
         /// <summary>
+        /// Creates &lt;In&gt; node for Comparison
+        /// </summary>
+        /// <param name="fieldRef">Field Reference</param>
+        /// <param name="values">Values to be included inside the &lt;In&gt;-clause</param>
+        /// <returns>Returns Comparison string to be used in CAML queries</returns>
+        public static string In(string fieldRef, params string[] values) {
+            var fieldValue = fieldRef;
+            fieldValue += "<Values>";
+            foreach(var value in values) {
+                fieldValue = string.Format("<Value>{0}</Value>", value);
+            }
+            fieldValue += "</Values>";
+            return In(fieldValue);
+        }
+        /// <summary>
         /// Creates &lt;Includes&gt; node for Comparison
         /// </summary>
         /// <param name="fieldValue">Value of the field</param>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no
| Related issues?  | -

#### What's in this Pull Request?

This PR contains a little improvement for the CAML class. When doing a CAML query that contains a In-comparision, one would need to forge most of the query by himself with the current class:
```csharp
var fieldRef = CAML.FieldRef("ID")+"<Values><Value Type="Number">1</Value><Value Type="Number">2</Value></Values>";
var caml = CAML.In(fieldRef);
```
There is no method for creating a Value node without a FieldRef node. Furthermore the Values node also needs to be created manually.

I've added an overload for the In method, accepting a FieldRef string and an array for Value strings. In Addition, I've added a method "Value" to generate the string for a Value node.

Usage:
```csharp
var fieldRef = CAML.FieldRef("ID");
var values = new string[] { CAML.Value("1", "Integer"), CAML.Value("2", "Integer") };
var caml = CAML.In(fieldRef, values);
```

