### PR TITLE
Update to avoid 'object reference not found' error - for 'TagName"

### DIFF
--- a/Core/OfficeDevPnP.Core/Pages/ClientSideText.cs
+++ b/Core/OfficeDevPnP.Core/Pages/ClientSideText.cs
@@ -189,7 +189,7 @@ namespace OfficeDevPnP.Core.Pages
 
             // By default simple plain text is wrapped in a Paragraph, need to drop it to avoid getting multiple paragraphs on page edits.
             // Only drop the paragraph tag when there's only one Paragraph element underneath the DIV tag
-            if ((div.FirstChild != null && (div.FirstChild as IElement).TagName.Equals("P", StringComparison.InvariantCultureIgnoreCase)) &&
+            if ((div.FirstChild as IElement != null && (div.FirstChild as IElement).TagName.Equals("P", StringComparison.InvariantCultureIgnoreCase)) &&
                 (div.ChildElementCount == 1))
             {
                 this.Text = (div.FirstChild as IElement).InnerHtml;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |  yes
| New feature?    | no
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?
Have been seeing problems with the PnP PowerShell - when getting an object reference error.

This can be seen here.
https://github.com/SharePoint/PnP-PowerShell/issues/1947

The key problem was the inner content of a page - would 'sometimes' have an element - but was getting a NULL exception on "TagName".

Included "as IElement" before comparing to NULL - is the resolution.


