### PR TITLE
Allow ZoneEmphasis in ClientSidePage to be undefined

### DIFF
--- a/Core/OfficeDevPnP.Core/Pages/ClientSidePage.cs
+++ b/Core/OfficeDevPnP.Core/Pages/ClientSidePage.cs
@@ -1581,7 +1581,7 @@ namespace OfficeDevPnP.Core.Pages
                         {
                             if (sectionData.Position != null)
                             {
-                                this.AddSection(new CanvasSection(this) { ZoneEmphasis = sectionData.Emphasis != null ? sectionData.Emphasis.ZoneEmphasis : 0 }, sectionData.Position.ZoneIndex);
+                                this.AddSection(new CanvasSection(this) { ZoneEmphasis = sectionData.Emphasis != null ? sectionData.Emphasis.ZoneEmphasis.GetValueOrDefault(0) : 0 }, sectionData.Position.ZoneIndex);
                                 currentSection = this.sections.Where(p => p.Order == sectionData.Position.ZoneIndex).First();
                             }
                         }
@@ -1668,7 +1668,7 @@ namespace OfficeDevPnP.Core.Pages
             var currentSection = this.sections.Where(p => p.Order == position.ZoneIndex).FirstOrDefault();
             if (currentSection == null)
             {
-                this.AddSection(new CanvasSection(this) { ZoneEmphasis = emphasis != null ? emphasis.ZoneEmphasis : 0 }, position.ZoneIndex);
+                this.AddSection(new CanvasSection(this) { ZoneEmphasis = emphasis != null ? emphasis.ZoneEmphasis.GetValueOrDefault(0) : 0 }, position.ZoneIndex);
                 currentSection = this.sections.Where(p => p.Order == position.ZoneIndex).First();
             }
 

--- a/Core/OfficeDevPnP.Core/Pages/ClientSideSectionEmphasis.cs
+++ b/Core/OfficeDevPnP.Core/Pages/ClientSideSectionEmphasis.cs
@@ -1,15 +1,24 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace OfficeDevPnP.Core.Pages
 {
     public class ClientSideSectionEmphasis
     {
-        [JsonProperty(PropertyName = "zoneEmphasis")]
-        public int ZoneEmphasis { get; set; }
+        [JsonIgnore]
+        public int? ZoneEmphasis
+        {
+            get
+            {
+                if (!string.IsNullOrWhiteSpace(ZoneEmphasisString) && int.TryParse(ZoneEmphasisString, out int result))
+                {
+                    return result;
+                }
+                return null;
+            }
+            set { ZoneEmphasisString = value.ToString(); }
+        }
+
+        [JsonProperty(PropertyName = "zoneEmphasis", NullValueHandling = NullValueHandling.Ignore)]
+        public string ZoneEmphasisString { get; set; }
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes https://github.com/SharePoint/PnP-PowerShell/issues/2141

#### What's in this Pull Request?
ZoneEmphasis in some cases returns undefined when requesting a ClientSidePage. This code change will ensure the PnP Core library can deal with this whereas now it would crash. I ran into this issue while fixing issue https://github.com/SharePoint/PnP-PowerShell/issues/2141 where requesting a clientside page on a subsite would return the client page but with the zoneemphasis information set to "undefined" which caused the code to crash trying to JSONConvert that into an int.