### PR TITLE
Allow -1 to be used for taxonomy fields in pnp:FieldDefault

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
@@ -407,7 +407,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             }
         }
 
-        private static string GetTaxonomyFieldValidatedValue(TaxonomyField field, string defaultValue)
+        public static string GetTaxonomyFieldValidatedValue(TaxonomyField field, string defaultValue)
         {
             string res = null;
             object parsedValue = null;

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -337,7 +337,22 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 {
                     var fieldDefaultValue = parser.ParseString(fieldDefault.Value);
                     var field = listInfo.SiteList.Fields.GetByInternalNameOrTitle(fieldDefault.Key);
+
+                    // If there has been a default value specified, request the type of field so we know if we have to deal with the default value in a special way according to the field type. If no default has been specified, we can simply set the default to NULL, regardless of the field type.
+                    if (!string.IsNullOrEmpty(fieldDefaultValue))
+                    {
+                        // A default value has been provided, request the field type so we know if we have to apply special handling for the type of field
+                        web.Context.Load(field, f => f.TypeAsString);
+                        web.Context.ExecuteQueryRetry();
+
+                        // In the case of a Taxonomy field, ensure that the default value which is in the format <ID>;#<NAME>|<TERMGUID> has its ID match with the actual ID in the TaxonomyHiddenList of the target site if the ID has been set to -1.
+                        if (field.TypeAsString == "TaxonomyFieldType" || field.TypeAsString == "TaxonomyFieldTypeMulti")
+                        {
+                            fieldDefaultValue = ObjectField.GetTaxonomyFieldValidatedValue(web.Context.CastTo<TaxonomyField>(field), fieldDefaultValue);
+                        }
+                    }
                     field.DefaultValue = fieldDefaultValue;
+
                     field.Update();
                     web.Context.ExecuteQueryRetry();
                 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| New sample?      | no
| Related issues?  | N/A

#### What's in this Pull Request?

When providing a FieldDefaults under a ListInstance for a taxonomy field and setting the ID to -1, this code change will make sure to update the -1 to the actual ID as it exists in the hidden TaxonomyHiddenList list or if it doesn't exist in there yet, create a new entry for it and update the -1 to the ID of this new entry.

To test this, create a PnP Provisioning Template by i.e. exporting an existing site. Inside a `<pnp:ListInstance> ... </pnp:ListInstance>` element, add:

`		  <pnp:FieldDefaults>
            <pnp:FieldDefault FieldName="TaxSiteField">-1;#Value 3|3d30ef63-d5a4-42fa-909c-5cd578223132</pnp:FieldDefault>
          </pnp:FieldDefaults>`

Update TaxSiteField with the internal name of an actual taxonomy field in your list and replace the Value 3 and GUID behind the pipe symbol with an actual value in the taxonomy term you have the taxonomy field linked to. Now Apply-PnPProvisiningTemplate the template. Once done, request the field default value using i.e.

`get-pnplist -Identity ListName | get-pnpfield | select title,defaultvalue`

Replace ListName with the list you referred to with your ListInstance in the PnP Provisioning Template above. Instead of showing "-1;#Value 3|3d30ef63-d5a4-42fa-909c-5cd578223132" as the defaultvalue it should now show the actual ID of the taxonomy item in the TaxonomyHiddenList, i.e. 2;#Value 3|3d30ef63-d5a4-42fa-909c-5cd578223132. Before this PR, it would not take the -1 as a special case and just leave it as a -1. Inside a SiteField the Field Default node would already have the -1 treated as a special case, i.e.:

`<Default>-1;#Value 2|7aa6591c-8530-4f13-9552-6013bf0eeff2</Default>`

Would work, but again the <pnp:FieldDefault> didn't work this way. With this PR they now both work and can handle -1 just as well as absolute values (1, 2, 3, etc).
