### PR TITLE
Feature: added support for additional teamify methods

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/ClientContextExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/ClientContextExtensions.cs
@@ -817,6 +817,30 @@ namespace Microsoft.SharePoint.Client
 
             return await SiteCollection.TeamifySiteAsync(clientContext);
         }
+
+        /// <summary>
+        /// Checks whether the teamify prompt is hidden in O365 Group connected sites
+        /// </summary>
+        /// <param name="clientContext">ClientContext of the site to operate against</param>
+        /// <returns></returns>
+        public static async Task<bool> IsTeamifyPromptHidden(this ClientContext clientContext)
+        {
+            await new SynchronizationContextRemover();
+
+            return await SiteCollection.IsTeamifyPromptHidden(clientContext);
+        }
+
+        /// <summary>
+        /// Hide the teamify prompt displayed in O365 group connected sites
+        /// </summary>
+        /// <param name="clientContext">ClientContext of the site to operate against</param>
+        /// <returns></returns>
+        public static async Task<bool> HideTeamifyPrompt(this ClientContext clientContext)
+        {
+            await new SynchronizationContextRemover();
+
+            return await SiteCollection.HideTeamifyPrompt(clientContext);
+        }
 #endif
     }
 }

--- a/Core/OfficeDevPnP.Core/Sites/SiteCollection.cs
+++ b/Core/OfficeDevPnP.Core/Sites/SiteCollection.cs
@@ -773,7 +773,7 @@ namespace OfficeDevPnP.Core.Sites
             }
             else
             {
-                var result = await context.Web.ExecutePost($"/_api/groupsitemanager/IsTeamifyPromptHidden?siteUrl='{context.Site.Url}'", string.Empty);
+                var result = await context.Web.ExecuteGet($"/_api/groupsitemanager/IsTeamifyPromptHidden?siteUrl='{context.Site.Url}'");
 
                 var teamifyPromptHidden = JObject.Parse(result);
 

--- a/Core/OfficeDevPnP.Core/Sites/SiteCollection.cs
+++ b/Core/OfficeDevPnP.Core/Sites/SiteCollection.cs
@@ -755,6 +755,60 @@ namespace OfficeDevPnP.Core.Sites
                 return await Task.Run(() => responseString);
             }
         }
+
+        /// <summary>
+        /// Checks if the Teamify prompt/banner is displayed in the O365 group connected sites.        
+        /// </summary>
+        /// <param name="context">ClientContext of the site to operate against</param>
+        /// <returns></returns>
+        public static async Task<bool> IsTeamifyPromptHidden(ClientContext context)
+        {
+            bool responseString = false;
+
+            context.Site.EnsureProperties(s => s.GroupId, s => s.Url);
+
+            if (context.Site.GroupId == Guid.Empty)
+            {
+                throw new Exception("Teamify prompts are only displayed in O365 group connected sites.");
+            }
+            else
+            {
+                var result = await context.Web.ExecutePost($"/_api/groupsitemanager/IsTeamifyPromptHidden?siteUrl='{context.Site.Url}'", string.Empty);
+
+                var teamifyPromptHidden = JObject.Parse(result);
+
+                responseString = Convert.ToBoolean(teamifyPromptHidden["value"]);
+
+                return await Task.Run(() => responseString);
+            }
+        }
+
+        /// <summary>
+        /// Hide the teamify prompt/banner displayed in O365 group connected sites
+        /// </summary>
+        /// <param name="context">ClientContext of the site to operate against</param>
+        /// <returns></returns>
+        public static async Task<bool> HideTeamifyPrompt(ClientContext context)
+        {
+            bool responseString = false;
+
+            context.Site.EnsureProperties(s => s.GroupId, s => s.Url);
+
+            if (context.Site.GroupId == Guid.Empty)
+            {
+                throw new Exception("Teamify prompts can only be hidden in O365 group connected sites.");
+            }
+            else
+            {
+                var result = await context.Web.ExecutePost("/_api/groupsitemanager/HideTeamifyPrompt", $@" {{ ""siteUrl"": ""{context.Site.Url}"" }}");
+
+                var teamifyPromptHidden = JObject.Parse(result);
+
+                responseString = Convert.ToBoolean(teamifyPromptHidden["odata.null"]);
+
+                return await Task.Run(() => responseString);
+            }
+        }
     }
 }
 #endif


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no
| Related issues?  | NA

#### What's in this Pull Request?

This PR adds additional methods related to teamify-ing O365 group sites.

1) Adds method of check if the teamify prompt is visible or not in the bottom left corner of the site.
2) Adds method to hide the teamify prompt from the bottom left corner of the site.