### PR TITLE
Feature: added support for page header images which reside outside current site collection

### DIFF
--- a/Core/OfficeDevPnP.Core/CoreResources.resx
+++ b/Core/OfficeDevPnP.Core/CoreResources.resx
@@ -1127,7 +1127,7 @@
     <value>Provisioning of the navigation node failed : {0}</value>
   </data>
   <data name="ClientSidePageHeader_ImageInDifferentWeb" xml:space="preserve">
-    <value>The {0} image set as page header lives in a different web and will not be set.</value>
+    <value>The {0} image set as page header lives outside the current site collection and might not be set. Once provisioning is complete, please check if the header image path is correct or you have adequate permissions to view the image.</value>
   </data>
   <data name="Provisioning_ObjectHandlers_Teams_TeamTemplate_ProvisioningError" xml:space="preserve">
     <value>Provisioning a team based on a team template failed. Ensure that the JSON template markup is valid and contains all the required properties. {0}</value>

--- a/Core/OfficeDevPnP.Core/Pages/ClientSidePageHeader.cs
+++ b/Core/OfficeDevPnP.Core/Pages/ClientSidePageHeader.cs
@@ -490,12 +490,16 @@ namespace OfficeDevPnP.Core.Pages
                 }
                 else if (ex.Message.Contains("SPWeb.ServerRelativeUrl"))
                 {
-                    // image has to live in the web for which we've set up the client context...if not skip and log a warning
+                    // image resides in a different site collection context, we will simply allow it to be referred in the page header section.                    
                     Log.Warning(Constants.LOGGING_SOURCE, CoreResources.ClientSidePageHeader_ImageInDifferentWeb, imageServerRelativeUrl);
+                    this.headerImageResolved = true;
                 }
                 else
                 {
-                    throw;
+                    // the image can also refer to a path outside SharePoint, that is also allowed, so we will mark it as resolved and move ahead.
+                    Log.Warning(Constants.LOGGING_SOURCE, CoreResources.ClientSidePageHeader_ImageInDifferentWeb, imageServerRelativeUrl);
+                    this.headerImageResolved = true;
+                    //throw;
                 }
             }
         }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| New sample?      | no
| Related issues?  | fixes #2355 

#### What's in this Pull Request?

This PR adds support for modern page header images which reside outside the current site collection. The image can be in a different site collection or any other CDN path.

Have modified the error message accordingly so that the end user is aware of the implication of setting the image path outside of the current site collection scope.

This PR was added since it was already possible to do this via UI, only when using the provisioning engine did we face this issue. I tested this with images in different site collection as well as hosted outside SharePoint on CDNs as well as wordpress blogs and it works fine in both the cases.