### PR TITLE
Bugfix/datarowprovisioning

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
@@ -1,11 +1,10 @@
-﻿using Microsoft.SharePoint.Client;
+﻿using System;
+using System.Linq;
+using Microsoft.SharePoint.Client;
 using OfficeDevPnP.Core.Diagnostics;
 using OfficeDevPnP.Core.Framework.Provisioning.Model;
 using OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Extensions;
 using OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 {
@@ -116,13 +115,19 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                                 if (processItem)
                                 {
+                                    ListItemUtilities.ListItemUpdateType updateMode;
                                     if (listitem == null)
                                     {
                                         var listitemCI = new ListItemCreationInformation();
                                         listitem = list.AddItem(listitemCI);
+                                        updateMode = ListItemUtilities.ListItemUpdateType.Update;
+                                    }
+                                    else
+                                    {
+                                        updateMode = ListItemUtilities.ListItemUpdateType.UpdateOverwriteVersion;
                                     }
 
-                                    ListItemUtilities.UpdateListItem(listitem, parser, dataRow.Values, ListItemUtilities.ListItemUpdateType.UpdateOverwriteVersion);
+                                    ListItemUtilities.UpdateListItem(listitem, parser, dataRow.Values, updateMode);
 
                                     if (dataRow.Security != null && (dataRow.Security.ClearSubscopes || dataRow.Security.CopyRoleAssignments || dataRow.Security.RoleAssignments.Count > 0))
                                     {
@@ -136,7 +141,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                     && applyingInformation.IgnoreDuplicateDataRowErrors)
                                 {
                                     scope.LogWarning(CoreResources.Provisioning_ObjectHandlers_ListInstancesDataRows_Creating_listitem_duplicate);
-                                    continue;
                                 }
                             }
                             catch (Exception ex)
@@ -156,8 +160,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
         public override ProvisioningTemplate ExtractObjects(Web web, ProvisioningTemplate template, ProvisioningTemplateCreationInformation creationInfo)
         {
-            //using (var scope = new PnPMonitoredScope(this.Name))
-            //{ }
             return template;
         }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  |

#### What's in this Pull Request?

This PR fixes an issue with **ObjectListInstanceDataRows** when deploying data rows with security information.

Previously **ObjectListInstanceDataRows** used the update mode **UpdateOverwriteVersion** regardless of the item state (new or existing). **UpdateOverwriteVersion** on a new item causes the server to return a **ListItem** instance with an ID of **-1**. Any subsequent (security) action (for example **BreakRoleInheritance** called by **SetSecurity**) on an item in this state will cause a **ServerException** with an inner exception of the type **InvalidOperationException**. Switching to the update mode **Update** for new items will prevent this from happening.