### PR TITLE
Feature: S2S user delegation in Hightrust app scenario

### DIFF
--- a/Core/OfficeDevPnP.Core/AuthenticationManager.cs
+++ b/Core/OfficeDevPnP.Core/AuthenticationManager.cs
@@ -613,7 +613,7 @@ namespace OfficeDevPnP.Core
             // Configure the handler to generate the Bearer Access Token on each request and add it to the request
             clientContext.ExecutingWebRequest += (sender, args) =>
             {
-                var accessToken = TokenHelper.GetS2SAccessTokenWithUserName(siteUri, loginName);
+                var accessToken = TokenHelper.GetS2SAccessTokenWithWindowsUserName(siteUri, loginName);
                 args.WebRequestExecutor.RequestHeaders["Authorization"] = "Bearer " + accessToken;
             };
 

--- a/Core/OfficeDevPnP.Core/AuthenticationManager.cs
+++ b/Core/OfficeDevPnP.Core/AuthenticationManager.cs
@@ -529,7 +529,11 @@ namespace OfficeDevPnP.Core
         /// <param name="certificatePath">Full path to the private key certificate (.pfx) used to authenticate</param>
         /// <param name="certificatePassword">Password used for the private key certificate (.pfx)</param>
         /// <param name="certificateIssuerId">The IssuerID under which the CER counterpart of the PFX has been registered in SharePoint as a Trusted Security Token issuer</param>
-        /// <param name="loginName">Name of the user (login name) on whose behalf to create the access token</param>
+        /// <param name="loginName">
+        /// Name of the user (login name) on whose behalf to create the access token.
+        /// Supported input formats are SID and User Principal Name (UPN).
+        /// If the parameter is left empty (including null) an App Only Context will be created.
+        /// </param>
         /// <returns>Authenticated SharePoint ClientContext</returns>
         public ClientContext GetHighTrustCertificateAppAuthenticatedContext(string siteUrl, string clientId, string certificatePath, string certificatePassword, string certificateIssuerId, string loginName)
         {
@@ -545,7 +549,11 @@ namespace OfficeDevPnP.Core
         /// <param name="certificatePath">Full path to the private key certificate (.pfx) used to authenticate</param>
         /// <param name="certificatePassword">Password used for the private key certificate (.pfx)</param>
         /// <param name="certificateIssuerId">The IssuerID under which the CER counterpart of the PFX has been registered in SharePoint as a Trusted Security Token issuer</param>
-        /// <param name="loginName">Name of the user (login name) on whose behalf to create the access token</param>
+        /// <param name="loginName">
+        /// Name of the user (login name) on whose behalf to create the access token.
+        /// Supported input formats are SID and User Principal Name (UPN).
+        /// If the parameter is left empty (including null) an App Only Context will be created.
+        /// </param>
         /// <returns>Authenticated SharePoint ClientContext</returns>
         public ClientContext GetHighTrustCertificateAppAuthenticatedContext(string siteUrl, string clientId, string certificatePath, SecureString certificatePassword, string certificateIssuerId, string loginName)
         {
@@ -562,7 +570,11 @@ namespace OfficeDevPnP.Core
         /// <param name="storeLocation">The location of the store for the certificate</param>
         /// <param name="thumbPrint">The thumbprint of the certificate to locate in the store</param>
         /// <param name="certificateIssuerId">The IssuerID under which the CER counterpart of the PFX has been registered in SharePoint as a Trusted Security Token issuer</param>
-        /// <param name="loginName">Name of the user (login name) on whose behalf to create the access token</param>
+        /// <param name="loginName">
+        /// Name of the user (login name) on whose behalf to create the access token.
+        /// Supported input formats are SID and User Principal Name (UPN).
+        /// If the parameter is left empty (including null) an App Only Context will be created.
+        /// </param>
         /// <returns>Authenticated SharePoint ClientContext</returns>
         public ClientContext GetHighTrustCertificateAppAuthenticatedContext(string siteUrl, string clientId, StoreName storeName, StoreLocation storeLocation, string thumbPrint, string certificateIssuerId, string loginName)
         {
@@ -578,7 +590,11 @@ namespace OfficeDevPnP.Core
         /// <param name="clientId">The SharePoint Client ID</param>
         /// <param name="certificate">Private key certificate (.pfx) used to authenticate</param>
         /// <param name="certificateIssuerId">The IssuerID under which the CER counterpart of the PFX has been registered in SharePoint as a Trusted Security Token issuer</param>
-        /// <param name="loginName">Name of the user (login name) on whose behalf to create the access token</param>
+        /// <param name="loginName">
+        /// Name of the user (login name) on whose behalf to create the access token.
+        /// Supported input formats are SID and User Principal Name (UPN).
+        /// If the parameter is left empty (including null) an App Only Context will be created.
+        /// </param>
         /// <returns>Authenticated SharePoint ClientContext</returns>
         public ClientContext GetHighTrustCertificateAppAuthenticatedContext(string siteUrl, string clientId, X509Certificate2 certificate, string certificateIssuerId, string loginName)
         {

--- a/Core/OfficeDevPnP.Core/AuthenticationManager.cs
+++ b/Core/OfficeDevPnP.Core/AuthenticationManager.cs
@@ -520,6 +520,89 @@ namespace OfficeDevPnP.Core
 
             return clientContext;
         }
+
+        /// <summary>
+        /// Returns a SharePoint ClientContext using High Trust Certificate App Only Authentication
+        /// </summary>
+        /// <param name="siteUrl">Site for which the ClientContext object will be instantiated</param>
+        /// <param name="clientId">The SharePoint Client ID</param>
+        /// <param name="certificatePath">Full path to the private key certificate (.pfx) used to authenticate</param>
+        /// <param name="certificatePassword">Password used for the private key certificate (.pfx)</param>
+        /// <param name="certificateIssuerId">The IssuerID under which the CER counterpart of the PFX has been registered in SharePoint as a Trusted Security Token issuer</param>
+        /// <param name="loginName">Name of the user (login name) on whose behalf to create the access token</param>
+        /// <returns>Authenticated SharePoint ClientContext</returns>
+        public ClientContext GetHighTrustCertificateAppAuthenticatedContext(string siteUrl, string clientId, string certificatePath, string certificatePassword, string certificateIssuerId, string loginName)
+        {
+            var certPassword = Utilities.EncryptionUtility.ToSecureString(certificatePassword);
+            return GetHighTrustCertificateAppAuthenticatedContext(siteUrl, clientId, certificatePath, certPassword, certificateIssuerId, loginName);
+        }
+
+        /// <summary>
+        /// Returns a SharePoint ClientContext using High Trust Certificate App Only Authentication
+        /// </summary>
+        /// <param name="siteUrl">Site for which the ClientContext object will be instantiated</param>
+        /// <param name="clientId">The SharePoint Client ID</param>
+        /// <param name="certificatePath">Full path to the private key certificate (.pfx) used to authenticate</param>
+        /// <param name="certificatePassword">Password used for the private key certificate (.pfx)</param>
+        /// <param name="certificateIssuerId">The IssuerID under which the CER counterpart of the PFX has been registered in SharePoint as a Trusted Security Token issuer</param>
+        /// <param name="loginName">Name of the user (login name) on whose behalf to create the access token</param>
+        /// <returns>Authenticated SharePoint ClientContext</returns>
+        public ClientContext GetHighTrustCertificateAppAuthenticatedContext(string siteUrl, string clientId, string certificatePath, SecureString certificatePassword, string certificateIssuerId, string loginName)
+        {
+            var certificate = new X509Certificate2(certificatePath, certificatePassword);
+            return GetHighTrustCertificateAppAuthenticatedContext(siteUrl, clientId, certificate, certificateIssuerId, loginName);
+        }
+
+        /// <summary>
+        /// Returns a SharePoint ClientContext using High Trust Certificate App Only Authentication
+        /// </summary>
+        /// <param name="siteUrl">Site for which the ClientContext object will be instantiated</param>
+        /// <param name="clientId">The SharePoint Client ID</param>
+        /// <param name="storeName">The name of the store for the certificate</param>
+        /// <param name="storeLocation">The location of the store for the certificate</param>
+        /// <param name="thumbPrint">The thumbprint of the certificate to locate in the store</param>
+        /// <param name="certificateIssuerId">The IssuerID under which the CER counterpart of the PFX has been registered in SharePoint as a Trusted Security Token issuer</param>
+        /// <param name="loginName">Name of the user (login name) on whose behalf to create the access token</param>
+        /// <returns>Authenticated SharePoint ClientContext</returns>
+        public ClientContext GetHighTrustCertificateAppAuthenticatedContext(string siteUrl, string clientId, StoreName storeName, StoreLocation storeLocation, string thumbPrint, string certificateIssuerId, string loginName)
+        {
+            // Retrieve the certificate from the Windows Certificate Store
+            var cert = Utilities.X509CertificateUtility.LoadCertificate(storeName, storeLocation, thumbPrint);
+            return GetHighTrustCertificateAppAuthenticatedContext(siteUrl, clientId, cert, certificateIssuerId, loginName);
+        }
+
+        /// <summary>
+        /// Returns a SharePoint ClientContext using High Trust Certificate App Only Authentication
+        /// </summary>
+        /// <param name="siteUrl">Site for which the ClientContext object will be instantiated</param>
+        /// <param name="clientId">The SharePoint Client ID</param>
+        /// <param name="certificate">Private key certificate (.pfx) used to authenticate</param>
+        /// <param name="certificateIssuerId">The IssuerID under which the CER counterpart of the PFX has been registered in SharePoint as a Trusted Security Token issuer</param>
+        /// <param name="loginName">Name of the user (login name) on whose behalf to create the access token</param>
+        /// <returns>Authenticated SharePoint ClientContext</returns>
+        public ClientContext GetHighTrustCertificateAppAuthenticatedContext(string siteUrl, string clientId, X509Certificate2 certificate, string certificateIssuerId, string loginName)
+        {
+            var siteUri = new Uri(siteUrl);
+            var clientContext = new ClientContext(siteUri);
+#if !ONPREMISES || SP2016 || SP2019
+            clientContext.DisableReturnValueCache = true;
+#endif
+
+            // Feed the TokenHelper the SharePoint information so it doesn't try to fetch it from the config file
+            TokenHelper.Realm = TokenHelper.GetRealmFromTargetUrl(siteUri);
+            TokenHelper.ClientId = clientId;
+            TokenHelper.ClientCertificate = certificate;
+            TokenHelper.IssuerId = certificateIssuerId;
+
+            // Configure the handler to generate the Bearer Access Token on each request and add it to the request
+            clientContext.ExecutingWebRequest += (sender, args) =>
+            {
+                var accessToken = TokenHelper.GetS2SAccessTokenWithUserName(siteUri, loginName);
+                args.WebRequestExecutor.RequestHeaders["Authorization"] = "Bearer " + accessToken;
+            };
+
+            return clientContext;
+        }
 #endif
 
         #endregion
@@ -1155,7 +1238,7 @@ namespace OfficeDevPnP.Core
                 throw new Exception("Endpoint does not use ADFS for authentication.", ex);
             }
         }
-		
+
         #endregion
 #endif
     }

--- a/Core/OfficeDevPnP.Core/Utilities/TokenHelper.cs
+++ b/Core/OfficeDevPnP.Core/Utilities/TokenHelper.cs
@@ -46,7 +46,7 @@ namespace OfficeDevPnP.Core.Utilities
 #region public methods
 
         /// <summary>
-        /// Retrieves the context token string from the specified request by looking for well-known parameter names in the 
+        /// Retrieves the context token string from the specified request by looking for well-known parameter names in the
         /// POSTed form parameters and the querystring. Returns null if no context token is found.
         /// </summary>
         /// <param name="request">HttpRequest in which to look for a context token</param>
@@ -57,7 +57,7 @@ namespace OfficeDevPnP.Core.Utilities
         }
 
         /// <summary>
-        /// Retrieves the context token string from the specified request by looking for well-known parameter names in the 
+        /// Retrieves the context token string from the specified request by looking for well-known parameter names in the
         /// POSTed form parameters and the querystring. Returns null if no context token is found.
         /// </summary>
         /// <param name="request">HttpRequest in which to look for a context token</param>
@@ -80,17 +80,17 @@ namespace OfficeDevPnP.Core.Utilities
         }
 
         /// <summary>
-        /// Validate that a specified context token string is intended for this application based on the parameters 
-        /// specified in web.config. Parameters used from web.config used for validation include ClientId, 
+        /// Validate that a specified context token string is intended for this application based on the parameters
+        /// specified in web.config. Parameters used from web.config used for validation include ClientId,
         /// HostedAppHostNameOverride, HostedAppHostName, ClientSecret, and Realm (if it is specified). If HostedAppHostNameOverride is present,
-        /// it will be used for validation. Otherwise, if the <paramref name="appHostName"/> is not 
-        /// null, it is used for validation instead of the web.config's HostedAppHostName. If the token is invalid, an 
+        /// it will be used for validation. Otherwise, if the <paramref name="appHostName"/> is not
+        /// null, it is used for validation instead of the web.config's HostedAppHostName. If the token is invalid, an
         /// exception is thrown. If the token is valid, TokenHelper's static STS metadata URL is updated based on the token contents
         /// and a JsonWebSecurityToken based on the context token is returned.
         /// </summary>
         /// <param name="contextTokenString">The context token to validate</param>
         /// <param name="appHostName">The URL authority, consisting of  Domain Name System (DNS) host name or IP address and the port number, to use for token audience validation.
-        /// If null, HostedAppHostName web.config setting is used instead. HostedAppHostNameOverride web.config setting, if present, will be used 
+        /// If null, HostedAppHostName web.config setting is used instead. HostedAppHostNameOverride web.config setting, if present, will be used
         /// for validation instead of <paramref name="appHostName"/> .</param>
         /// <returns>A JsonWebSecurityToken based on the context token.</returns>
         public static SharePointContextToken ReadAndValidateContextToken(string contextTokenString, string appHostName = null)
@@ -145,7 +145,7 @@ namespace OfficeDevPnP.Core.Utilities
         }
 
         /// <summary>
-        /// Retrieves an access token from ACS to call the source of the specified context token at the specified 
+        /// Retrieves an access token from ACS to call the source of the specified context token at the specified
         /// targetHost. The targetHost must be registered for the principal that sent the context token.
         /// </summary>
         /// <param name="contextToken">Context token issued by the intended access token audience</param>
@@ -172,8 +172,8 @@ namespace OfficeDevPnP.Core.Utilities
         }
 
         /// <summary>
-        /// Uses the specified authorization code to retrieve an access token from ACS to call the specified principal 
-        /// at the specified targetHost. The targetHost must be registered for target principal.  If specified realm is 
+        /// Uses the specified authorization code to retrieve an access token from ACS to call the specified principal
+        /// at the specified targetHost. The targetHost must be registered for target principal.  If specified realm is
         /// null, the "Realm" setting in web.config will be used instead.
         /// </summary>
         /// <param name="authorizationCode">Authorization code to exchange for access token</param>
@@ -227,8 +227,8 @@ namespace OfficeDevPnP.Core.Utilities
         }
 
         /// <summary>
-        /// Uses the specified refresh token to retrieve an access token from ACS to call the specified principal 
-        /// at the specified targetHost. The targetHost must be registered for target principal.  If specified realm is 
+        /// Uses the specified refresh token to retrieve an access token from ACS to call the specified principal
+        /// at the specified targetHost. The targetHost must be registered for target principal.  If specified realm is
         /// null, the "Realm" setting in web.config will be used instead.
         /// </summary>
         /// <param name="refreshToken">Refresh token to exchange for access token</param>
@@ -273,8 +273,8 @@ namespace OfficeDevPnP.Core.Utilities
         }
 
         /// <summary>
-        /// Retrieves an app-only access token from ACS to call the specified principal 
-        /// at the specified targetHost. The targetHost must be registered for target principal.  If specified realm is 
+        /// Retrieves an app-only access token from ACS to call the specified principal
+        /// at the specified targetHost. The targetHost must be registered for target principal.  If specified realm is
         /// null, the "Realm" setting in web.config will be used instead.
         /// </summary>
         /// <param name="targetPrincipalName">Name of the target principal to retrieve an access token for</param>
@@ -375,7 +375,7 @@ namespace OfficeDevPnP.Core.Utilities
         }
 
         /// <summary>
-        /// Retrieves an access token from ACS using the specified authorization code, and uses that access token to 
+        /// Retrieves an access token from ACS using the specified authorization code, and uses that access token to
         /// create a client context
         /// </summary>
         /// <param name="targetUrl">Url of the target SharePoint site</param>
@@ -391,7 +391,7 @@ namespace OfficeDevPnP.Core.Utilities
         }
 
         /// <summary>
-        /// Retrieves an access token from ACS using the specified authorization code, and uses that access token to 
+        /// Retrieves an access token from ACS using the specified authorization code, and uses that access token to
         /// create a client context
         /// </summary>
         /// <param name="targetUrl">Url of the target SharePoint site</param>
@@ -465,7 +465,7 @@ namespace OfficeDevPnP.Core.Utilities
         /// an authorization code.
         /// </summary>
         /// <param name="contextUrl">Absolute Url of the SharePoint site</param>
-        /// <param name="scope">Space-delimited permissions to request from the SharePoint site in "shorthand" format 
+        /// <param name="scope">Space-delimited permissions to request from the SharePoint site in "shorthand" format
         /// (e.g. "Web.Read Site.Write")</param>
         /// <returns>Url of the SharePoint site's OAuth authorization page</returns>
         public static string GetAuthorizationUrl(string contextUrl, string scope)
@@ -485,7 +485,7 @@ namespace OfficeDevPnP.Core.Utilities
         /// <param name="contextUrl">Absolute Url of the SharePoint site</param>
         /// <param name="scope">Space-delimited permissions to request from the SharePoint site in "shorthand" format
         /// (e.g. "Web.Read Site.Write")</param>
-        /// <param name="redirectUri">Uri to which SharePoint should redirect the browser to after consent is 
+        /// <param name="redirectUri">Uri to which SharePoint should redirect the browser to after consent is
         /// granted</param>
         /// <returns>Url of the SharePoint site's OAuth authorization page</returns>
         public static string GetAuthorizationUrl(string contextUrl, string scope, string redirectUri)
@@ -516,8 +516,8 @@ namespace OfficeDevPnP.Core.Utilities
         }
 
         /// <summary>
-        /// Retrieves an S2S access token signed by the application's private certificate on behalf of the specified 
-        /// WindowsIdentity and intended for the SharePoint at the targetApplicationUri. If no Realm is specified in 
+        /// Retrieves an S2S access token signed by the application's private certificate on behalf of the specified
+        /// WindowsIdentity and intended for the SharePoint at the targetApplicationUri. If no Realm is specified in
         /// web.config, an auth challenge will be issued to the targetApplicationUri to discover it.
         /// </summary>
         /// <param name="targetApplicationUri">Url of the target SharePoint site</param>
@@ -535,9 +535,28 @@ namespace OfficeDevPnP.Core.Utilities
         }
 
         /// <summary>
-        /// Retrieves an S2S client context with an access token signed by the application's private certificate on 
-        /// behalf of the specified WindowsIdentity and intended for application at the targetApplicationUri using the 
-        /// targetRealm. If no Realm is specified in web.config, an auth challenge will be issued to the 
+        /// Retrieves an S2S access token signed by the application's private certificate on behalf of the specified
+        /// user name and intended for the SharePoint at the targetApplicationUri. If no Realm is specified in
+        /// web.config, an auth challenge will be issued to the targetApplicationUri to discover it.
+        /// </summary>
+        /// <param name="targetApplicationUri">Url of the target SharePoint site</param>
+        /// <param name="identity">Name of the user (login name) on whose behalf to create the access token</param>
+        /// <returns>An access token with an audience of the target principal</returns>
+        public static string GetS2SAccessTokenWithUserName(
+            Uri targetApplicationUri,
+            string identity)
+        {
+            string realm = string.IsNullOrEmpty(Realm) ? GetRealmFromTargetUrl(targetApplicationUri) : Realm;
+
+            JsonWebTokenClaim[] claims = identity != null ? GetClaimsWithUserName(identity) : null;
+
+            return GetS2SAccessTokenWithClaims(targetApplicationUri.Authority, realm, claims);
+        }
+
+        /// <summary>
+        /// Retrieves an S2S client context with an access token signed by the application's private certificate on
+        /// behalf of the specified WindowsIdentity and intended for application at the targetApplicationUri using the
+        /// targetRealm. If no Realm is specified in web.config, an auth challenge will be issued to the
         /// targetApplicationUri to discover it.
         /// </summary>
         /// <param name="targetApplicationUri">Url of the target SharePoint site</param>
@@ -557,16 +576,16 @@ namespace OfficeDevPnP.Core.Utilities
 		}
 
 		/// <summary>
-		/// Retrieves an S2S client context with an access token signed by the application's private certificate on 
-		/// behalf of the specified ClaimsIdentity and intended for application at the targetApplicationUri using the 
-		/// targetRealm. If no Realm is specified in web.config, an auth challenge will be issued to the 
-		/// targetApplicationUri to discover it. Identity claim type and identity provider name (as registered in SharePoint) 
+		/// Retrieves an S2S client context with an access token signed by the application's private certificate on
+		/// behalf of the specified ClaimsIdentity and intended for application at the targetApplicationUri using the
+		/// targetRealm. If no Realm is specified in web.config, an auth challenge will be issued to the
+		/// targetApplicationUri to discover it. Identity claim type and identity provider name (as registered in SharePoint)
 		/// should be specified in configuration file e.g.:
 		///   <appSettings>
 		///	    <add key = "IdentityClaimType" value="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress" />
 		///	    <add key = "TrustedIdentityTokenIssuerName" value="sso" />
 		///	  </appSettings>
-		///	 To discover trusted identity token issuer name use following cmdlet: 
+		///	 To discover trusted identity token issuer name use following cmdlet:
 		///	 Get-SPTrustedIdentityTokenIssuer | select name
 		/// </summary>
 		/// <param name="targetApplicationUri">Url of the target SharePoint site</param>
@@ -666,7 +685,7 @@ namespace OfficeDevPnP.Core.Utilities
 
         //
         // Configuration Constants
-        //        
+        //
 
         private const string AuthorizationPage = "_layouts/15/OAuthAuthorize.aspx";
         private const string RedirectPage = "_layouts/15/AppRedirect.aspx";
@@ -1045,15 +1064,32 @@ namespace OfficeDevPnP.Core.Utilities
 
         private static JsonWebTokenClaim[] GetClaimsWithWindowsIdentity(WindowsIdentity identity)
         {
+#if DEBUG
+            if (null == identity)
+            {
+                throw new ArgumentNullException("identity");
+            }
+#endif
+            return GetClaimsWithUserName(identity.User.Value);
+        }
+
+        private static JsonWebTokenClaim[] GetClaimsWithUserName(string identity)
+        {
+#if DEBUG
+            if (string.IsNullOrWhiteSpace(identity))
+            {
+                throw new ArgumentOutOfRangeException("identity");
+            }
+#endif
             JsonWebTokenClaim[] claims = new JsonWebTokenClaim[]
             {
-                new JsonWebTokenClaim(NameIdentifierClaimType, identity.User.Value.ToLower()),
+                new JsonWebTokenClaim(NameIdentifierClaimType, identity.ToLower()),
                 new JsonWebTokenClaim("nii", "urn:office:idp:activedirectory")
             };
             return claims;
         }
 
-		private static JsonWebTokenClaim[] GetClaimsWithClaimsIdentity(System.Security.Claims.ClaimsIdentity identity, string identityClaimType, string trustedProviderName)
+        private static JsonWebTokenClaim[] GetClaimsWithClaimsIdentity(System.Security.Claims.ClaimsIdentity identity, string identityClaimType, string trustedProviderName)
 		{
 			var identityClaim = identity.Claims.Where(c => string.Equals(c.Type, identityClaimType, StringComparison.InvariantCultureIgnoreCase)).First();
 			JsonWebTokenClaim[] claims = new JsonWebTokenClaim[]
@@ -1585,7 +1621,7 @@ namespace OfficeDevPnP.Core.Utilities
 
         //
         // Configuration Constants
-        //        
+        //
 
         private const string AuthorizationPage = "_layouts/15/OAuthAuthorize.aspx";
         private const string RedirectPage = "_layouts/15/AppRedirect.aspx";
@@ -1989,8 +2025,8 @@ namespace OfficeDevPnP.Core.Utilities
         }
 
         /// <summary>
-        /// Retrieves an app-only access token from ACS to call the specified principal 
-        /// at the specified targetHost. The targetHost must be registered for target principal.  If specified realm is 
+        /// Retrieves an app-only access token from ACS to call the specified principal
+        /// at the specified targetHost. The targetHost must be registered for target principal.  If specified realm is
         /// null, the "Realm" setting in web.config will be used instead.
         /// </summary>
         /// <param name="targetPrincipalName">Name of the target principal to retrieve an access token for</param>

--- a/Core/OfficeDevPnP.Core/Utilities/TokenHelper.cs
+++ b/Core/OfficeDevPnP.Core/Utilities/TokenHelper.cs
@@ -1081,9 +1081,14 @@ namespace OfficeDevPnP.Core.Utilities
                 throw new ArgumentOutOfRangeException("identity");
             }
 #endif
+            string claimType = NameIdentifierClaimType;
+            if (identity.Contains('@'))
+            {
+                claimType = "upn";
+            }
             JsonWebTokenClaim[] claims = new JsonWebTokenClaim[]
             {
-                new JsonWebTokenClaim(NameIdentifierClaimType, identity.ToLower()),
+                new JsonWebTokenClaim(claimType, identity.ToLower()),
                 new JsonWebTokenClaim("nii", "urn:office:idp:activedirectory")
             };
             return claims;

--- a/Core/OfficeDevPnP.Core/Utilities/TokenHelper.cs
+++ b/Core/OfficeDevPnP.Core/Utilities/TokenHelper.cs
@@ -548,7 +548,9 @@ namespace OfficeDevPnP.Core.Utilities
         {
             string realm = string.IsNullOrEmpty(Realm) ? GetRealmFromTargetUrl(targetApplicationUri) : Realm;
 
-            JsonWebTokenClaim[] claims = identity != null ? GetClaimsWithUserName(identity) : null;
+            JsonWebTokenClaim[] claims = string.IsNullOrWhiteSpace(identity)
+                ? GetClaimsWithUserName(identity)
+                : null;
 
             return GetS2SAccessTokenWithClaims(targetApplicationUri.Authority, realm, claims);
         }
@@ -568,7 +570,9 @@ namespace OfficeDevPnP.Core.Utilities
         {
             string realm = string.IsNullOrEmpty(Realm) ? GetRealmFromTargetUrl(targetApplicationUri) : Realm;
 
-            JsonWebTokenClaim[] claims = identity != null ? GetClaimsWithWindowsIdentity(identity) : null;
+            JsonWebTokenClaim[] claims = identity != null
+                ? GetClaimsWithWindowsIdentity(identity)
+                : null;
 
             string accessToken = GetS2SAccessTokenWithClaims(targetApplicationUri.Authority, realm, claims);
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    |  yes
| New sample?      | no
| Related issues?  |  n/a

#### What's in this Pull Request?

This PR contains an enhancement whith which it's possible to create an App Delegation token in an Hightrust configuration to act as specific user (behalf-of) within a SharePoint connection. Up to now this scenario was only possible with an `WindowsIdentity` object instance available, which is not the case if the addin is deployed in an environment which isn't connected to an Active Directory environment (e.g. Azue WebApp) and is employing other authentication themes like JWT Bearer or SAML tokens. 

This PR now provides new methods on `Core/OfficeDevPnP.Core/AuthenticationManager.cs` which allows to pass the SID or the UPN for an user for creating an impersonation (delegation) token. The SID is just as unavailable in the above scenario as the `WindowsIdentity` object instance but the UPN typically is, because the UPN is normally used in JWT or SAML token to identify an incoming user. 

With this extension it is possible to host a SharePoint Add in a "domain-less" environment, like as an Azure WebApp, utilize modern authentication methods and still perform impersonation on a SharePoint system in an Active Directory domain.