### PR TITLE
Fix list view localization (when destination single Language and PnP-Template Multilanguage)

### DIFF
--- a/Core/OfficeDevPnP.Core/CoreResources.Designer.cs
+++ b/Core/OfficeDevPnP.Core/CoreResources.Designer.cs
@@ -1020,6 +1020,24 @@ namespace OfficeDevPnP.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Translation for default language of site is missing.
+        /// </summary>
+        internal static string Provisioning_Extensions_ViewLocalization_DefaultLngMissing_Skip {
+            get {
+                return ResourceManager.GetString("Provisioning_Extensions_ViewLocalization_DefaultLngMissing_Skip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No Viewtranslation needed since web is single language.
+        /// </summary>
+        internal static string Provisioning_Extensions_ViewLocalization_NoMUI_Skip {
+            get {
+                return ResourceManager.GetString("Provisioning_Extensions_ViewLocalization_NoMUI_Skip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Skipping view localization because we&apos;re running under a user context who has a preferred language set in it&apos;s profile. This setup will not allow to add the needed localized string versions..
         /// </summary>
         internal static string Provisioning_Extensions_ViewLocalization_Skip {
@@ -2497,7 +2515,7 @@ namespace OfficeDevPnP.Core {
         /// * @see {@link http://usejsdoc.org/|JSDoc}
         /// */
         ///
-        /// /*
+        ////*
         /// * PnPResponsiveApp
         /// * @namespace
         /// */
@@ -2507,11 +2525,11 @@ namespace OfficeDevPnP.Core {
         ///    window.PnPResponsiveApp = window.PnPResponsiveApp || {};
         ///}
         ///
-        /// /**
+        ////**
         /// * PnP Responsive
         /// * @class
         /// */
-        /// PnPResponsiveApp.Main = (function ()  [rest of string was truncated]&quot;;.
+        ///PnPResponsiveApp.Main = (function ()  [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string SP_Responsive_UI {
             get {
@@ -2536,7 +2554,7 @@ namespace OfficeDevPnP.Core {
         ///    min-width: auto;
         ///}
         ///
-        /// /* Make sure dialog windows don&apos;t break */
+        ////* Make sure dialog windows don&apos;t break */
         ///.ms-dialog #contentRow {
         ///    margin-left: 0;
         ///}

--- a/Core/OfficeDevPnP.Core/CoreResources.resx
+++ b/Core/OfficeDevPnP.Core/CoreResources.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -1203,5 +1203,11 @@
   </data>
   <data name="Provisioning_ObjectHandlers_AAD_User_ProvisioningError" xml:space="preserve">
     <value>Provisioning a user failed.</value>
+  </data>
+  <data name="Provisioning_Extensions_ViewLocalization_NoMUI_Skip" xml:space="preserve">
+    <value>No Viewtranslation needed since web is single language</value>
+  </data>
+  <data name="Provisioning_Extensions_ViewLocalization_DefaultLngMissing_Skip" xml:space="preserve">
+    <value>Translation for default language of site is missing</value>
   </data>
 </root>

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Extensions/LocalizationExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Extensions/LocalizationExtensions.cs
@@ -93,33 +93,46 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Extensions
             {
                 var context = web.Context;
                 //preserve Default Language to set last since otherwise Entries in QuickLaunch can show wrong language
-                web.EnsureProperties(w => w.Language);
-                var culture = new CultureInfo((int)web.Language);
-
-                var resourceValues = parser.GetResourceTokenResourceValues(token);
-
-                var defaultLanguageResource = resourceValues.FirstOrDefault(r => !r.Item1.Equals(culture.Name, StringComparison.InvariantCultureIgnoreCase));
-                if (defaultLanguageResource != null)
+                web.EnsureProperties(w => w.Language, w => w.IsMultilingual, w => w.SupportedUILanguageIds);
+                if (web.IsMultilingual)
                 {
-                    foreach (var resourceValue in resourceValues.Where(r => !r.Item1.Equals(culture.Name, StringComparison.InvariantCultureIgnoreCase)))
+                    //just update if web is multilingual 
+                    var culture = new CultureInfo((int)web.Language);
+
+                    var resourceValues = parser.GetResourceTokenResourceValues(token);
+
+                    var defaultLanguageResource = resourceValues.FirstOrDefault(r => r.Item1.Equals(culture.Name, StringComparison.InvariantCultureIgnoreCase));
+                    if (defaultLanguageResource != null)
                     {
-                        // Save property with correct locale on the request to make it stick
-                        // http://sadomovalex.blogspot.no/2015/09/localize-web-part-titles-via-client.html
-                        context.PendingRequest.RequestExecutor.WebRequest.Headers["Accept-Language"] = resourceValue.Item1;
-                        view.Title = resourceValue.Item2;
+                        foreach (var resourceValue in resourceValues.Where(r => !r.Item1.Equals(culture.Name, StringComparison.InvariantCultureIgnoreCase)))
+                        {
+                            var translationculture = new CultureInfo(resourceValue.Item1);
+                            if (web.SupportedUILanguageIds.Contains(translationculture.LCID))
+                            {
+                                // Save property with correct locale on the request to make it stick
+                                // http://sadomovalex.blogspot.no/2015/09/localize-web-part-titles-via-client.html
+                                context.PendingRequest.RequestExecutor.WebRequest.Headers["Accept-Language"] = resourceValue.Item1;
+                                view.Title = resourceValue.Item2;
+                                view.Update();
+                                context.ExecuteQueryRetry();
+                            }
+                        }
+                        //Set for default Language of Web
+                        context.PendingRequest.RequestExecutor.WebRequest.Headers["Accept-Language"] = defaultLanguageResource.Item1;
+                        view.Title = defaultLanguageResource.Item2;
                         view.Update();
                         context.ExecuteQueryRetry();
                     }
-                    //Set for default Language of Web
-                    context.PendingRequest.RequestExecutor.WebRequest.Headers["Accept-Language"] = defaultLanguageResource.Item1;
-                    view.Title = defaultLanguageResource.Item2;
-                    view.Update();
-                    context.ExecuteQueryRetry();
+                    else
+                    {
+                        //skip since default language of web is not contained in resource file
+                        scope.LogWarning(CoreResources.Provisioning_Extensions_ViewLocalization_DefaultLngMissing_Skip);
+                    }
                 }
                 else
                 {
-                    //skip since default language of web is not contained in resource file
-                    scope.LogWarning(CoreResources.Provisioning_Extensions_ViewLocalization_Skip);
+                    //skip since web is not multilingual
+                    scope.LogWarning(CoreResources.Provisioning_Extensions_ViewLocalization_NoMUI_Skip);
                 }
             }
             else


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |   yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #2365 

#### What's in this Pull Request?
The fix checks if destination site IsMultilingual and skips localization if not. 
If the Site IsMultilingual=true, it checks if the language from ressourcefile is in SupportedUILanguageIds of the web and applys only if they exist.