### PR TITLE
Allow all properties on messages

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTeams.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTeams.cs
@@ -813,7 +813,9 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         private static string CreateTeamChannelMessage(PnPMonitoredScope scope, TokenParser parser, TeamChannelMessage message, string teamId, string channelId, string accessToken)
         {
             var messageString = parser.ParseString(message.Message);
-            var messageJson = JToken.Parse($"{{ \"body\": {{ \"content\": \"{messageString}\" }} }}");
+            var messageJson = messageString.Contains("\"body\":")
+                ? JToken.Parse(messageString)
+                : JToken.Parse($"{{ \"body\": {{ \"content\": \"{messageString}\" }} }}");
 
             var messageId = GraphHelper.CreateOrUpdateGraphObject(scope,
                 HttpMethodVerb.POST,


### PR DESCRIPTION
described in Graph Api documentation

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no
| Related issues?  | fixes #2392 

#### What's in this Pull Request?

In method CreateTeamChannelMessage, checking if there is a body property in the message string when parsing string to a Json object.
If there is a body property then use it as Json object and all the properties in Graph Api documentation will be supported.