### PR TITLE
Fix CPU Load and Performance for ExtractClientSidePage

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Utilities/ClientSidePageContentsHelper.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Utilities/ClientSidePageContentsHelper.cs
@@ -397,7 +397,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
         {
             // grab all the guids in the already tokenized json and check try to get them as a file
             string guidPattern = "\"[a-fA-F0-9]{8}-([a-fA-F0-9]{4}-){3}[a-fA-F0-9]{12}\"";
-            Regex regexClientIds = new Regex(guidPattern);
+            Regex regexClientIds = new Regex(guidPattern, RegexOptions.Compiled);
             if (regexClientIds.IsMatch(jsonControlData))
             {
                 foreach (Match guidMatch in regexClientIds.Matches(jsonControlData))
@@ -411,7 +411,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
             }
             // grab potentially encoded guids in the already tokenized json and check try to get them as a file
             guidPattern = "=[a-fA-F0-9]{8}(?:%2D|-)([a-fA-F0-9]{4}(?:%2D|-)){3}[a-fA-F0-9]{12}";
-            regexClientIds = new Regex(guidPattern);
+            regexClientIds = new Regex(guidPattern, RegexOptions.Compiled);
             if (regexClientIds.IsMatch(jsonControlData))
             {
                 foreach (Match guidMatch in regexClientIds.Matches(jsonControlData))
@@ -483,7 +483,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
         {
             // match urls to SiteAssets library
             string siteAssetUrlsPattern = @".*""(.*?/SiteAssets/SitePages/.+?)"".*";
-            Regex regexSiteAssetUrls = new Regex(siteAssetUrlsPattern);
+            Regex regexSiteAssetUrls = new Regex(siteAssetUrlsPattern,RegexOptions.Compiled);
             if (regexSiteAssetUrls.IsMatch(untokenizedJsonControlData))
             {
                 foreach (Match siteAssetUrlMatch in regexSiteAssetUrls.Matches(untokenizedJsonControlData))

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Utilities/ClientSidePageContentsHelper.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Utilities/ClientSidePageContentsHelper.cs
@@ -95,6 +95,12 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
                         }
                     }
 
+                    string guidPattern = "\"[a-fA-F0-9]{8}-([a-fA-F0-9]{4}-){3}[a-fA-F0-9]{12}\"";
+                    Regex regexGuidPattern = new Regex(guidPattern, RegexOptions.Compiled);
+
+                    string siteAssetUrlsPattern = @".*""(.*?/SiteAssets/SitePages/.+?)"".*";
+                    Regex regexSiteAssetUrls = new Regex(siteAssetUrlsPattern, RegexOptions.Compiled);
+
                     // Add the sections
                     foreach (var section in pageToExtract.Sections)
                     {
@@ -288,8 +294,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
                                         Dictionary<string, string> exportedFiles = new Dictionary<string, string>();
                                         Dictionary<string, string> exportedPages = new Dictionary<string, string>();
 
-                                        CollectSiteAssetImageFiles(web, untokenizedJsonControlData, fileGuids);
-                                        CollectImageFilesFromGenericGuids(controlInstance.JsonControlData, fileGuids);
+                                        CollectSiteAssetImageFiles(regexSiteAssetUrls,web, untokenizedJsonControlData, fileGuids);
+                                        CollectImageFilesFromGenericGuids(regexGuidPattern,controlInstance.JsonControlData, fileGuids);
 
                                         // Iterate over the found guids to see if they're exportable files
                                         foreach (var uniqueId in fileGuids)
@@ -393,11 +399,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
         }
 
         #region Helper methods
-        private static void CollectImageFilesFromGenericGuids(string jsonControlData, List<Guid> fileGuids)
+        private static void CollectImageFilesFromGenericGuids(Regex regexClientIds, string jsonControlData, List<Guid> fileGuids)
         {
             // grab all the guids in the already tokenized json and check try to get them as a file
-            string guidPattern = "\"[a-fA-F0-9]{8}-([a-fA-F0-9]{4}-){3}[a-fA-F0-9]{12}\"";
-            Regex regexClientIds = new Regex(guidPattern, RegexOptions.Compiled);
+            //string guidPattern = "\"[a-fA-F0-9]{8}-([a-fA-F0-9]{4}-){3}[a-fA-F0-9]{12}\"";
+            //Regex regexClientIds = new Regex(guidPattern, RegexOptions.Compiled);
             if (regexClientIds.IsMatch(jsonControlData))
             {
                 foreach (Match guidMatch in regexClientIds.Matches(jsonControlData))
@@ -479,11 +485,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
             return new Tuple<bool, string>(false, fileName);
         }
 
-        private static void CollectSiteAssetImageFiles(Web web, string untokenizedJsonControlData, List<Guid> fileGuids)
+        private static void CollectSiteAssetImageFiles(Regex regexSiteAssetUrls, Web web, string untokenizedJsonControlData, List<Guid> fileGuids)
         {
-            // match urls to SiteAssets library
-            string siteAssetUrlsPattern = @".*""(.*?/SiteAssets/SitePages/.+?)"".*";
-            Regex regexSiteAssetUrls = new Regex(siteAssetUrlsPattern,RegexOptions.Compiled);
+            //// match urls to SiteAssets library
+            //string siteAssetUrlsPattern = @".*""(.*?/SiteAssets/SitePages/.+?)"".*";
+            //Regex regexSiteAssetUrls = new Regex(siteAssetUrlsPattern,RegexOptions.Compiled);
             if (regexSiteAssetUrls.IsMatch(untokenizedJsonControlData))
             {
                 foreach (Match siteAssetUrlMatch in regexSiteAssetUrls.Matches(untokenizedJsonControlData))

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Utilities/ClientSidePageContentsHelper.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Utilities/ClientSidePageContentsHelper.cs
@@ -98,6 +98,9 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
                     string guidPattern = "\"[a-fA-F0-9]{8}-([a-fA-F0-9]{4}-){3}[a-fA-F0-9]{12}\"";
                     Regex regexGuidPattern = new Regex(guidPattern, RegexOptions.Compiled);
 
+                    string guidPatternEncoded = "=[a-fA-F0-9]{8}(?:%2D|-)([a-fA-F0-9]{4}(?:%2D|-)){3}[a-fA-F0-9]{12}";
+                    Regex regexGuidPatternEncoded = new Regex(guidPatternEncoded, RegexOptions.Compiled);
+
                     string siteAssetUrlsPattern = @".*""(.*?/SiteAssets/SitePages/.+?)"".*";
                     Regex regexSiteAssetUrls = new Regex(siteAssetUrlsPattern, RegexOptions.Compiled);
 
@@ -295,7 +298,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
                                         Dictionary<string, string> exportedPages = new Dictionary<string, string>();
 
                                         CollectSiteAssetImageFiles(regexSiteAssetUrls,web, untokenizedJsonControlData, fileGuids);
-                                        CollectImageFilesFromGenericGuids(regexGuidPattern,controlInstance.JsonControlData, fileGuids);
+                                        CollectImageFilesFromGenericGuids(regexGuidPattern, regexGuidPatternEncoded,controlInstance.JsonControlData, fileGuids);
 
                                         // Iterate over the found guids to see if they're exportable files
                                         foreach (var uniqueId in fileGuids)
@@ -399,14 +402,14 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
         }
 
         #region Helper methods
-        private static void CollectImageFilesFromGenericGuids(Regex regexClientIds, string jsonControlData, List<Guid> fileGuids)
+        private static void CollectImageFilesFromGenericGuids(Regex regexGuidPattern, Regex regexGuidPatternEncoded, string jsonControlData, List<Guid> fileGuids)
         {
             // grab all the guids in the already tokenized json and check try to get them as a file
             //string guidPattern = "\"[a-fA-F0-9]{8}-([a-fA-F0-9]{4}-){3}[a-fA-F0-9]{12}\"";
             //Regex regexClientIds = new Regex(guidPattern, RegexOptions.Compiled);
-            if (regexClientIds.IsMatch(jsonControlData))
+            if (regexGuidPattern.IsMatch(jsonControlData))
             {
-                foreach (Match guidMatch in regexClientIds.Matches(jsonControlData))
+                foreach (Match guidMatch in regexGuidPattern.Matches(jsonControlData))
                 {
                     Guid uniqueId;
                     if (Guid.TryParse(guidMatch.Value.Trim("\"".ToCharArray()), out uniqueId))
@@ -415,12 +418,12 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
                     }
                 }
             }
-            // grab potentially encoded guids in the already tokenized json and check try to get them as a file
-            guidPattern = "=[a-fA-F0-9]{8}(?:%2D|-)([a-fA-F0-9]{4}(?:%2D|-)){3}[a-fA-F0-9]{12}";
-            regexClientIds = new Regex(guidPattern, RegexOptions.Compiled);
-            if (regexClientIds.IsMatch(jsonControlData))
+            //// grab potentially encoded guids in the already tokenized json and check try to get them as a file
+            //guidPattern = "=[a-fA-F0-9]{8}(?:%2D|-)([a-fA-F0-9]{4}(?:%2D|-)){3}[a-fA-F0-9]{12}";
+            //regexClientIds = new Regex(guidPattern, RegexOptions.Compiled);
+            if (regexGuidPatternEncoded.IsMatch(jsonControlData))
             {
-                foreach (Match guidMatch in regexClientIds.Matches(jsonControlData))
+                foreach (Match guidMatch in regexGuidPatternEncoded.Matches(jsonControlData))
                 {
                     Guid uniqueId;
                     if (Guid.TryParse(guidMatch.Value.TrimStart("=".ToCharArray()), out uniqueId))


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |  yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
@jansenbe Initialize RegEx for CollectImageFilesFromGenericGuids and CollectSiteAssetImageFiles outside the foreach loop and make them compiled does speed-up time spend in ObjectClientSidePageContents Extract (on my test site from 26min down to 11min).
