### PR TITLE
Fix TermGroup retrieval

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTermGroups.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTermGroups.cs
@@ -593,7 +593,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 }
                 termsToReturn.Add(modelTerm);
 
-                if (!string.IsNullOrEmpty(customSortOrder))
+                if (!string.IsNullOrEmpty(customSortOrder) && !customSortOrder.Equals("False", StringComparison.OrdinalIgnoreCase))
                 {
                     var sortOrder = customSortOrder.Split(new[] { ':' }).ToList();
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |  yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #2396 

#### What's in this Pull Request?
Check if the value in CustomSortOrder is "False", if so, don't try to apply the custom sort order.
This fixes pnp provisioning template retrieval for termgroups.