### PR TITLE
Skip ExecuteQuery for new ListItem until all attachments are added

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Utilities/ListItemUtilities.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Utilities/ListItemUtilities.cs
@@ -261,7 +261,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
             UpdateOverwriteVersion
         }
 
-        public static void UpdateListItem(ListItem item, TokenParser parser, IDictionary<string, string> valuesToSet, ListItemUpdateType updateType)
+        public static void UpdateListItem(ListItem item, TokenParser parser, IDictionary<string, string> valuesToSet, ListItemUpdateType updateType, bool SkipExecuteQuery=false)
         {
             var itemValues = new List<FieldUpdateValue>();
 
@@ -521,7 +521,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Utilities
 #else
             item.Update();
 #endif
-            context.ExecuteQueryRetry();
+            if(!SkipExecuteQuery)
+                context.ExecuteQueryRetry();
         }
 
         [Obsolete("Use UpdateListItem(ListItem item, TokenParser parser, IDictionary<string, string> valuesToSet, ListItemUpdateType updateType) instead")]


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |  yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
@erwinvanhunen  Fix to Add Attachments to new List Items. Minimal invasive fix to Commit cd457e1 to avoid ExecuteQuery for new ListItem until all Attachments have been added as otherwise the Error "Item does not exist. It may have been deleted by another user." will happen. 