### PR TITLE
SiteToTemplate - fix WebHook AddRange null exception

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/SiteToTemplateConversion.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/SiteToTemplateConversion.cs
@@ -457,15 +457,14 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 var webhooks = new List<ProvisioningWebhookBase>();
 
                 // Merge the webhooks at template level with those at global level
-                webhooks.AddRange(
-                    template.ProvisioningTemplateWebhooks != null && template.ProvisioningTemplateWebhooks.Any() ?
-                    template.ProvisioningTemplateWebhooks : null
-                    );
-                webhooks.AddRange(
-                    template.ParentHierarchy?.ProvisioningWebhooks != null && template.ParentHierarchy.ProvisioningWebhooks.Any() ?
-                    template.ParentHierarchy?.ProvisioningWebhooks : null
-                    );
-
+                if (template.ProvisioningTemplateWebhooks != null && template.ProvisioningTemplateWebhooks.Any())
+                {
+                    webhooks.AddRange(template.ProvisioningTemplateWebhooks);
+                }
+                if (template.ParentHierarchy?.ProvisioningWebhooks != null && template.ParentHierarchy.ProvisioningWebhooks.Any())
+                {
+                    webhooks.AddRange(template.ParentHierarchy.ProvisioningWebhooks);
+                }
                 // If there is any webhook
                 if (webhooks.Count > 0)
                 {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |  yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
@PaoloPia  CallWebHooks fails when WebHooks in template are empty since it passes null to AddRange. Fixed by having if-statement outside AddRange