### PR TITLE
Fix for null reference exception in WebAPIHelper.GetClientContext

### DIFF
--- a/Core/OfficeDevPnP.Core/CoreResources.Designer.cs
+++ b/Core/OfficeDevPnP.Core/CoreResources.Designer.cs
@@ -2382,6 +2382,15 @@ namespace OfficeDevPnP.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The WebAPI context cache item was not found...nothing can be retrieved from cache, so no clientcontext can be created..
+        /// </summary>
+        internal static string Services_CacheItemNotFound {
+            get {
+                return ResourceManager.GetString("Services_CacheItemNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The cookie with the cachekey was not found...nothing can be retrieved from cache, so no clientcontext can be created..
         /// </summary>
         internal static string Services_CookieWithCachKeyNotFound {
@@ -2497,7 +2506,7 @@ namespace OfficeDevPnP.Core {
         /// * @see {@link http://usejsdoc.org/|JSDoc}
         /// */
         ///
-        /// /*
+        ////*
         /// * PnPResponsiveApp
         /// * @namespace
         /// */
@@ -2507,11 +2516,11 @@ namespace OfficeDevPnP.Core {
         ///    window.PnPResponsiveApp = window.PnPResponsiveApp || {};
         ///}
         ///
-        /// /**
+        ////**
         /// * PnP Responsive
         /// * @class
         /// */
-        /// PnPResponsiveApp.Main = (function ()  [rest of string was truncated]&quot;;.
+        ///PnPResponsiveApp.Main = (function ()  [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string SP_Responsive_UI {
             get {
@@ -2536,7 +2545,7 @@ namespace OfficeDevPnP.Core {
         ///    min-width: auto;
         ///}
         ///
-        /// /* Make sure dialog windows don&apos;t break */
+        ////* Make sure dialog windows don&apos;t break */
         ///.ms-dialog #contentRow {
         ///    margin-left: 0;
         ///}

--- a/Core/OfficeDevPnP.Core/CoreResources.resx
+++ b/Core/OfficeDevPnP.Core/CoreResources.resx
@@ -285,6 +285,9 @@
   <data name="Services_CookieWithCachKeyNotFound" xml:space="preserve">
     <value>The cookie with the cachekey was not found...nothing can be retrieved from cache, so no clientcontext can be created.</value>
   </data>
+  <data name="Services_CacheItemNotFound" xml:space="preserve">
+    <value>The WebAPI context cache item was not found...nothing can be retrieved from cache, so no clientcontext can be created.</value>
+  </data>
   <data name="Services_Registered" xml:space="preserve">
     <value>Service {0} has been registered for endpoint {1} using cachekey {2}.</value>
   </data>

--- a/Core/OfficeDevPnP.Core/WebAPI/WebAPIHelper.cs
+++ b/Core/OfficeDevPnP.Core/WebAPI/WebAPIHelper.cs
@@ -85,6 +85,12 @@ namespace OfficeDevPnP.Core.WebAPI
             {
                 WebAPIContexCacheItem cacheItem = WebAPIContextCache.Instance.Get(cacheKey);
 
+                if (cacheItem == null)
+                {
+                    Log.Warning(Constants.LOGGING_SOURCE, CoreResources.Services_CacheItemNotFound);
+                    throw new Exception("A WebAPI context cache item was not found. Make sure to use RegisterWebAPIService to populate the cache before calling this method.");
+                }
+
                 //request a new access token from ACS whenever our current access token will expire in less than 1 hour
                 if (cacheItem.AccessToken.ExpiresOn.ToUniversalTime() < (DateTime.UtcNow.AddHours(1)))
                 {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | N/A

#### What's in this Pull Request?
Log and cast a clearer exception instead of an unhandled null reference exception in WebAPIHelper.GetClientContext when the cache item has not been registered using RegisterWebAPIService.
