### PR TITLE
Provisioing: Make sure we ExecuteQuery for newItem when no Attachments exist

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
@@ -173,9 +173,9 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                                 AddAttachment(template, listitem, attachment, IsNewItem);
                                             }
                                         }
-                                        if (IsNewItem)
-                                            listitem.Context.ExecuteQueryRetry();
                                     }
+                                    if (IsNewItem)
+                                        listitem.Context.ExecuteQueryRetry();
                                 }
                             }
                             catch (ServerException ex)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
Move the check if ExecuteQuery is needed outside the Block for Update the Attachments in order to have it executed even when no Attachments exist.
