### PR TITLE
Feature: Extract DefaultDocument for DocumentSet ContentType

### DIFF
--- a/Core/OfficeDevPnP.Core/CoreResources.Designer.cs
+++ b/Core/OfficeDevPnP.Core/CoreResources.Designer.cs
@@ -19,7 +19,7 @@ namespace OfficeDevPnP.Core {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class CoreResources {
@@ -1269,6 +1269,33 @@ namespace OfficeDevPnP.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to add &apos;{1}&apos; as DocumentTemplate to ContentType &apos;{0}&apos;.
+        /// </summary>
+        internal static string Provisioning_ObjectHandlers_ContentTypes_ErrorDocumentTemplate {
+            get {
+                return ResourceManager.GetString("Provisioning_ObjectHandlers_ContentTypes_ErrorDocumentTemplate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to extract DefaultDocument &apos;{0}&apos; from DocumentSet.
+        /// </summary>
+        internal static string Provisioning_ObjectHandlers_ContentTypes_ErrorExtractDocumentSetTemplate {
+            get {
+                return ResourceManager.GetString("Provisioning_ObjectHandlers_ContentTypes_ErrorExtractDocumentSetTemplate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to extract DocumentTemplate &apos;{1}&apos; from ContentType &apos;{0}&apos;.
+        /// </summary>
+        internal static string Provisioning_ObjectHandlers_ContentTypes_ErrorSaveDocumentTemplateToConnector {
+            get {
+                return ResourceManager.GetString("Provisioning_ObjectHandlers_ContentTypes_ErrorSaveDocumentTemplateToConnector", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Field {0} exists in content type.
         /// </summary>
         internal static string Provisioning_ObjectHandlers_ContentTypes_Field__0__exists_in_content_type {
@@ -1311,6 +1338,15 @@ namespace OfficeDevPnP.Core {
         internal static string Provisioning_ObjectHandlers_ContentTypes_SkipDocumentSetDefaultDocuments {
             get {
                 return ResourceManager.GetString("Provisioning_ObjectHandlers_ContentTypes_SkipDocumentSetDefaultDocuments", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Skipping adding DocumentTemplate to ContentType &apos;{0}&apos; because we can&apos;t upload them on &apos;noscript&apos; sites..
+        /// </summary>
+        internal static string Provisioning_ObjectHandlers_ContentTypes_SkipDocumentTemplate {
+            get {
+                return ResourceManager.GetString("Provisioning_ObjectHandlers_ContentTypes_SkipDocumentTemplate", resourceCulture);
             }
         }
         

--- a/Core/OfficeDevPnP.Core/CoreResources.resx
+++ b/Core/OfficeDevPnP.Core/CoreResources.resx
@@ -1225,4 +1225,16 @@
   <data name="Provisioning_ObjectHandlers_ListInstancesDataRows_Creating_listitem_notsupported_0" xml:space="preserve">
     <value>Creating list items in document libraries is not supported. Please remove DataRow elements for library '{0}'.</value>
   </data>
+  <data name="Provisioning_ObjectHandlers_ContentTypes_ErrorDocumentTemplate" xml:space="preserve">
+    <value>Failed to add '{1}' as DocumentTemplate to ContentType '{0}'</value>
+  </data>
+  <data name="Provisioning_ObjectHandlers_ContentTypes_ErrorExtractDocumentSetTemplate" xml:space="preserve">
+    <value>Failed to extract DefaultDocument '{0}' from DocumentSet</value>
+  </data>
+  <data name="Provisioning_ObjectHandlers_ContentTypes_ErrorSaveDocumentTemplateToConnector" xml:space="preserve">
+    <value>Failed to extract DocumentTemplate '{1}' from ContentType '{0}'</value>
+  </data>
+  <data name="Provisioning_ObjectHandlers_ContentTypes_SkipDocumentTemplate" xml:space="preserve">
+    <value>Skipping adding DocumentTemplate to ContentType '{0}' because we can't upload them on 'noscript' sites.</value>
+  </data>
 </root>

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
@@ -407,9 +407,46 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             if (templateContentType.DocumentSetTemplate == null)
             {
                 // Only apply a document template when the contenttype is not a document set
-                if (!string.IsNullOrEmpty(parser.ParseString(templateContentType.DocumentTemplate)))
+                //Skipping updates of DocumentTemplate as we can't upload files to /_cts/ContentTypeName/FileName to noscript sites
+                if (!isNoScriptSite)
+                {
+                    // Only apply a document template when the contenttype is not a document set
+                    if (!string.IsNullOrEmpty(parser.ParseString(templateContentType.DocumentTemplate)))
+                    {
+                        string documentTemplate = parser.ParseString(templateContentType.DocumentTemplate);
+                        web.EnsureProperties(w => w.ServerRelativeUrl, w => w.Url);
+                        try
+                        {
+                            using (var fsstream = template.Connector.GetFileStream($"_cts/{name}/{documentTemplate}"))
+                            {
+                                Microsoft.SharePoint.Client.Folder ctFolder = web.GetFolderByServerRelativeUrl($"{web.ServerRelativeUrl}/_cts/{name}");
+                                web.Context.Load(ctFolder, fl => fl.Files.Include(f => f.Name, f => f.ServerRelativeUrl));
+                                web.Context.ExecuteQuery();
+
+                                FileCreationInformation newFile = new FileCreationInformation();
+                                newFile.ContentStream = fsstream;
+                                newFile.Url = $"{web.ServerRelativeUrl}/_cts/{name}/{documentTemplate}";
+
+                                Microsoft.SharePoint.Client.File uploadedFile = ctFolder.Files.Add(newFile);
+                                web.Context.Load(uploadedFile);
+                                web.Context.ExecuteQuery();
+                            }
+                            createdCT.DocumentTemplate = documentTemplate;
+                        }
+                        catch (Exception ex)
+                        {
+                            scope.LogError(ex, CoreResources.Provisioning_ObjectHandlers_ContentTypes_ErrorDocumentTemplate, name, documentTemplate);
+                        }
+                    }
+                }
+                else
                 {
                     createdCT.DocumentTemplate = parser.ParseString(templateContentType.DocumentTemplate);
+                    if (!string.IsNullOrEmpty(parser.ParseString(templateContentType.DocumentTemplate)))
+                    {
+                        // log message
+                        scope.LogWarning(CoreResources.Provisioning_ObjectHandlers_ContentTypes_SkipDocumentTemplate, name);
+                    }
                 }
             }
 
@@ -582,6 +619,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             {
                 WriteMessage("We discovered content types in this subweb. While technically possible, we recommend moving these content types to the root site collection. Consider excluding them from this template.", ProvisioningMessageType.Warning);
             }
+            web.EnsureProperties(w => w.Url, w => w.ServerRelativeUrl);//neded for DocumentTemplate extraction
+
             List<ContentType> ctsToReturn = new List<ContentType>();
             var currentCtIndex = 0;
             foreach (var ct in cts)
@@ -606,6 +645,34 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         if (!ct.DocumentTemplate.StartsWith("_cts/"))
                         {
                             ctDocumentTemplate = ct.DocumentTemplate;
+                        }
+                        //extract DocumentTemplate if it points to ContentType Ressource Folder
+                        if (creationInfo.ExtractConfiguration.PersistAssetFiles && !string.IsNullOrWhiteSpace(ct.DocumentTemplateUrl) && ct.DocumentTemplateUrl.Contains("_cts/"))
+                        {
+                            try
+                            {
+                                var spFile = web.GetFileByServerRelativeUrl(ct.DocumentTemplateUrl);
+                                spFile.EnsureProperties(f => f.Level, f => f.ServerRelativeUrl, f => f.Name);
+
+                                // If we got here it's a file, let's grab the file's path and name
+                                var baseUri = new Uri(web.Url);
+                                var fullUri = new Uri(baseUri, spFile.ServerRelativeUrl);
+                                var folderPath = System.Web.HttpUtility.UrlDecode(fullUri.Segments.Take(fullUri.Segments.Count() - 1).ToArray().Aggregate((i, x) => i + x).TrimEnd('/'));
+                                var fileName = System.Web.HttpUtility.UrlDecode(fullUri.Segments[fullUri.Segments.Count() - 1]);
+
+                                var templateFolderPath = folderPath.Substring(web.ServerRelativeUrl.Length).TrimStart("/".ToCharArray());
+
+                                web.Context.Load(spFile);
+                                web.Context.ExecuteQueryRetry();
+                                var spFileStream = spFile.OpenBinaryStream();
+                                web.Context.ExecuteQueryRetry();
+
+                                template.Connector.SaveFileStream(spFile.Name, templateFolderPath, spFileStream.Value);
+                            }
+                            catch (Exception ex)
+                            {
+                                scope.LogError(ex, CoreResources.Provisioning_ObjectHandlers_ContentTypes_ErrorSaveDocumentTemplateToConnector, ct.Name, ct.DocumentTemplateUrl);
+                            }
                         }
                     }
 
@@ -687,13 +754,44 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                              {
                                  ContentTypeId = defaultDocument.ContentTypeId.StringValue,
                                  Name = defaultDocument.Name,
-                                 FileSourcePath = String.Empty, // TODO: How can we extract the proper file?!
+                                 FileSourcePath = creationInfo.ExtractConfiguration.PersistAssetFiles ? $"_cts/{ct.Name}/{defaultDocument.DocumentPath.DecodedUrl}" : string.Empty,
                              }).ToList(),
                             (from sharedField in documentSetTemplate.SharedFields.AsEnumerable()
                              select sharedField.Id).ToList(),
                             (from welcomePageField in documentSetTemplate.WelcomePageFields.AsEnumerable()
                              select welcomePageField.Id).ToList()
                         );
+
+                        //extract the DefaultDocument files
+                        foreach (var defaultDoc in newCT.DocumentSetTemplate.DefaultDocuments.Where(dd => !string.IsNullOrWhiteSpace(dd.FileSourcePath)))
+                        {
+                            try
+                            {
+                                string serverRelativeUrl = $"{web.ServerRelativeUrl}/{defaultDoc.FileSourcePath}";
+                                var spFile = web.GetFileByServerRelativeUrl(serverRelativeUrl);
+
+                                spFile.EnsureProperties(f => f.Level, f => f.ServerRelativeUrl, f => f.Name);
+
+                                // If we got here it's a file, let's grab the file's path and name
+                                var baseUri = new Uri(web.Url);
+                                var fullUri = new Uri(baseUri, spFile.ServerRelativeUrl);
+                                var folderPath = System.Web.HttpUtility.UrlDecode(fullUri.Segments.Take(fullUri.Segments.Count() - 1).ToArray().Aggregate((i, x) => i + x).TrimEnd('/'));
+                                var fileName = System.Web.HttpUtility.UrlDecode(fullUri.Segments[fullUri.Segments.Count() - 1]);
+
+                                var templateFolderPath = folderPath.Substring(web.ServerRelativeUrl.Length).TrimStart("/".ToCharArray());
+
+                                web.Context.Load(spFile);
+                                web.Context.ExecuteQueryRetry();
+                                var spFileStream = spFile.OpenBinaryStream();
+                                web.Context.ExecuteQueryRetry();
+
+                                template.Connector.SaveFileStream(spFile.Name, templateFolderPath, spFileStream.Value);
+                            }
+                            catch (Exception ex)
+                            {
+                                scope.LogError(ex, CoreResources.Provisioning_ObjectHandlers_ContentTypes_ErrorExtractDocumentSetTemplate, defaultDoc.FileSourcePath);
+                            }
+                        }
                     }
 
                     ctsToReturn.Add(newCT);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    |  yes
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
The DefaultDocument of a DocumentSet will be extracted - for Example: 
 <pnp:DefaultDocuments>
              <pnp:DefaultDocument Name="DocSetTestDok.docx" ContentTypeID="0x0101007B3995784C2BF642B3B4D7F4DE37C96E" FileSourcePath="_cts/MyDocSetTest/DocSetTestDok.docx" />
            </pnp:DefaultDocuments>
