### PR TITLE
Fix set Item Security on new ListItems

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
@@ -133,11 +133,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                                     ListItemUtilities.UpdateListItem(listitem, parser, dataRow.Values, ListItemUtilities.ListItemUpdateType.UpdateOverwriteVersion, IsNewItem);
 
-                                    if (dataRow.Security != null && (dataRow.Security.ClearSubscopes || dataRow.Security.CopyRoleAssignments || dataRow.Security.RoleAssignments.Count > 0))
-                                    {
-                                        listitem.SetSecurity(parser, dataRow.Security);
-                                    }
-
                                     if (dataRow.Attachments != null && dataRow.Attachments.Count > 0)
                                     {
                                         foreach (var attachment in dataRow.Attachments)
@@ -175,7 +170,14 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                         }
                                     }
                                     if (IsNewItem)
+                                    {
+                                        listitem.Context.Load(listitem, i => i.Id);
                                         listitem.Context.ExecuteQueryRetry();
+                                    }
+                                    if (dataRow.Security != null && (dataRow.Security.ClearSubscopes || dataRow.Security.CopyRoleAssignments || dataRow.Security.RoleAssignments.Count > 0))
+                                    {
+                                        listitem.SetSecurity(parser, dataRow.Security);
+                                    }
                                 }
                             }
                             catch (ServerException ex)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
@erwinvanhunen New List Item will have security not set since listitem.SetSecurity does want to read item security but item is not comited to sp at that time. The Block is now moved to the end of the function.