### PR TITLE
Site Settings option is gone

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/Handlers.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/Handlers.cs
@@ -130,12 +130,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model
         /// </summary>
         Theme = 268435456,
         /// <summary>
-        /// Value 536870912, represents SiteSettings
-        /// </summary>
-        SiteSettings = 536870912,
-        /// <summary>
         /// Takes all handlers
         /// </summary>
-        All = AuditSettings | ComposedLook | CustomActions | ExtensibilityProviders | Features | Fields | Files | Lists | Pages | Publishing | RegionalSettings | SearchSettings | SitePolicy | SupportedUILanguages | TermGroups | Workflows | SiteSecurity | ContentTypes | PropertyBagEntries | PageContents | WebSettings | Navigation | ImageRenditions | ApplicationLifecycleManagement | Tenant | WebApiPermissions | SiteHeader | SiteFooter | Theme | SiteSettings
+        All = AuditSettings | ComposedLook | CustomActions | ExtensibilityProviders | Features | Fields | Files | Lists | Pages | Publishing | RegionalSettings | SearchSettings | SitePolicy | SupportedUILanguages | TermGroups | Workflows | SiteSecurity | ContentTypes | PropertyBagEntries | PageContents | WebSettings | Navigation | ImageRenditions | ApplicationLifecycleManagement | Tenant | WebApiPermissions | SiteHeader | SiteFooter | Theme 
     }
 }


### PR DESCRIPTION

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no 
| Related issues?  |  ?

#### What's in this Pull Request?

If you try to use **site settings** handler, pnp-poweshell returns an error. I have removed that handler. If you try to use such handler, it returns an error:

`Could not export template from 'https://[tenant]/sites/docsetFix': Cannot bind parameter 'Handlers'. Cannot convert value "Theme,WebSettings,ComposedLook,SiteHeader,SiteFooter,SiteSettings,Features,PropertyBagEntries" to type "OfficeDevPnP.Core.Framework.Provisioning.Model.Handlers". Error: "Unable to match the identifier name Theme,WebSettings,ComposedLook,SiteHeader,SiteFooter,SiteSettings,Features,PropertyBagEntries to a valid enumerator name. Specify one of the following enumerator names and try again:
AuditSettings, ComposedLook, CustomActions, ExtensibilityProviders, Features, Fields, Files, Lists, Pages, Publishing, RegionalSettings, SearchSettings, SitePolicy, SupportedUILanguages, TermGroups, Workflows, SiteSecurity, ContentTypes, PropertyBagEntries, PageContents, WebSettings, Navigation, ImageRenditions, ApplicationLifecycleManagement, Tenant, WebApiPermissions, SiteHeader, SiteFooter, Theme, All"`
