### PR TITLE
Fix: Communication site creation infinte loop fix

### DIFF
--- a/Core/OfficeDevPnP.Core/Sites/SiteCollection.cs
+++ b/Core/OfficeDevPnP.Core/Sites/SiteCollection.cs
@@ -284,7 +284,18 @@ namespace OfficeDevPnP.Core.Sites
                         else
                         {
                             // Let's wait for the async provisioning of features, site scripts and content types to be done before we allow API's to further update the created site
-                            WaitForProvisioningIsComplete(responseContext.Web);
+                            if (responseContext == null)
+                            {
+                                try
+                                {
+                                    WaitForProvisioningIsComplete(responseContext.Web);
+                                }
+                                catch (Exception ex)
+                                {
+                                    throw ex;
+                                }
+                            }
+
                         }
                     }
                     else
@@ -471,7 +482,18 @@ namespace OfficeDevPnP.Core.Sites
                         else
                         {
                             // Let's wait for the async provisioning of features, site scripts and content types to be done before we allow API's to further update the created site
-                            WaitForProvisioningIsComplete(responseContext.Web);
+                            try
+                            {
+                                if (responseContext == null)
+                                {
+                                    WaitForProvisioningIsComplete(responseContext.Web);
+                                }
+                            }
+                            catch (Exception ex)
+                            {
+                                throw ex;
+                            }
+
                         }
                     }
                     else
@@ -514,7 +536,7 @@ namespace OfficeDevPnP.Core.Sites
                 }
                 while (!isProvisioningComplete && retryAttempt <= maxRetryCount);
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 // Eat the exception for now as not all tenants already have this feature
                 // TODO: remove try/catch once IsProvisioningComplete is globally deployed

--- a/Core/OfficeDevPnP.Core/Sites/SiteCollection.cs
+++ b/Core/OfficeDevPnP.Core/Sites/SiteCollection.cs
@@ -197,7 +197,7 @@ namespace OfficeDevPnP.Core.Sites
                         if (responseJson["SiteStatus"].Value<int>() == 2)
 #endif
                         {
-                            responseContext = clientContext.Clone(responseJson["SiteUrl"].ToString());
+                            return responseContext = clientContext.Clone(responseJson["SiteUrl"].ToString());
                         }
                         else
                         {
@@ -284,16 +284,13 @@ namespace OfficeDevPnP.Core.Sites
                         else
                         {
                             // Let's wait for the async provisioning of features, site scripts and content types to be done before we allow API's to further update the created site
-                            if (responseContext == null)
+                            try
                             {
-                                try
-                                {
-                                    WaitForProvisioningIsComplete(responseContext.Web);
-                                }
-                                catch (Exception ex)
-                                {
-                                    throw ex;
-                                }
+                                WaitForProvisioningIsComplete(responseContext.Web);
+                            }
+                            catch (Exception ex)
+                            {
+                                throw ex;
                             }
 
                         }
@@ -388,7 +385,7 @@ namespace OfficeDevPnP.Core.Sites
                                 if(responseJson["SiteStatus"].Value<int>() == 2)
 #endif
                                 {
-                                    responseContext = clientContext.Clone(responseJson["SiteUrl"].ToString());
+                                    return responseContext = clientContext.Clone(responseJson["SiteUrl"].ToString());
                                 }
                                 else
                                 {
@@ -484,10 +481,7 @@ namespace OfficeDevPnP.Core.Sites
                             // Let's wait for the async provisioning of features, site scripts and content types to be done before we allow API's to further update the created site
                             try
                             {
-                                if (responseContext == null)
-                                {
-                                    WaitForProvisioningIsComplete(responseContext.Web);
-                                }
+                                WaitForProvisioningIsComplete(responseContext.Web);
                             }
                             catch (Exception ex)
                             {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| Related issues?  | fixes https://github.com/SharePoint/PnP-PowerShell/issues/2327

#### What's in this Pull Request?

This PR fixes the issue in the latest version of PnP PowerShell wherein the communication site gets created but the control is not passed back to it.

@jansenbe  - can you check this one , a bit urgently :( , sorry ? In our tenants, the site is created correctly but it doesn't give the client context back because the property `IsProvisioningComplete` doesnt exist. I debugged the code, it is returning correct JSON with Status value as 2, but still throws error. So, in this PR added additional try/catch block before calling the `WaitForProvisioningIsComplete` method. 