### PR TITLE
Fix for ALM handler when template doesn't use it

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectApplicationLifecycleManagement.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectApplicationLifecycleManagement.cs
@@ -147,7 +147,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 System.Threading.Thread.Sleep(5000); // sleep 5 seconds and try again
                 appMetadata = manager.GetAvailable(appId, Enums.AppCatalogScope.Tenant);
             }
-            if(appMetadata.AppCatalogVersion != appMetadata.InstalledVersion)
+            if (appMetadata.AppCatalogVersion != appMetadata.InstalledVersion)
             {
                 // We ran into a timeout
                 throw new Exception("App Install timeout hit, could not determine installed state");
@@ -165,7 +165,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 System.Threading.Thread.Sleep(5000); // sleep 5 seconds and try again
                 appMetadata = manager.GetAvailable(appId, Enums.AppCatalogScope.Tenant);
             }
-            if(appMetadata.InstalledVersion != null)
+            if (appMetadata.InstalledVersion != null)
             {
                 throw new Exception("App Uninstall timeout hit, could not determine uninstalled state.");
             }
@@ -180,9 +180,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         {
             if (!_willProvision.HasValue && template.ApplicationLifecycleManagement != null)
             {
-                _willProvision = (template.ApplicationLifecycleManagement.AppCatalog != null ||
-                                  template.ApplicationLifecycleManagement.Apps.Count > 0
-                                 );
+                _willProvision = (template.ApplicationLifecycleManagement.AppCatalog?.Packages != null && template.ApplicationLifecycleManagement.AppCatalog?.Packages.Count > 0) ||
+                                  template.ApplicationLifecycleManagement.Apps.Count > 0;
             }
             return (!web.IsSubSite() && _willProvision.Value);
         }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| Related issues?  | NA

#### What's in this Pull Request?

This PR adds additional check to the WillProvision method so that ALM handler is called only if necessary values are present in the template.