### PR TITLE
fix User Deleted Templates Folder in SitePages on Export

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectClientSidePageContents.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectClientSidePageContents.cs
@@ -68,13 +68,20 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 }
                 if (sitePagesLibrary != null)
                 {
-                    var templateFolderName = string.Empty;
+                    var templateFolderName = OfficeDevPnP.Core.Pages.ClientSidePage.DefaultTemplatesFolder;// string.Empty;
                     var templateFolderString = sitePagesLibrary.GetPropertyBagValueString(TemplatesFolderGuid, null);
                     Guid.TryParse(templateFolderString, out Guid templateFolderGuid);
                     if (templateFolderGuid != Guid.Empty)
                     {
-                        var templateFolder = ((ClientContext)sitePagesLibrary.Context).Web.GetFolderById(templateFolderGuid);
-                        templateFolderName = templateFolder.EnsureProperty(f => f.Name);
+                        try
+                        {
+                            var templateFolder = ((ClientContext)sitePagesLibrary.Context).Web.GetFolderById(templateFolderGuid);
+                            templateFolderName = templateFolder.EnsureProperty(f => f.Name);
+                        }
+                        catch
+                        {
+                            //eat it and continue with default name
+                        }
                     }
                     CamlQuery query = new CamlQuery
                     {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |  yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
Fix handles the situation were the user deleted the Template Folder in SitePages and Property vti_TemplatesFolderGuid contains therefore the Folder UniqueId of an not existing folder. 

If we can not resolve Folder by it's uniqueid we fallback to fix the default Foldername.