### PR TITLE
Added option to set requesting access to a web to the default owners

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/WebExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/WebExtensions.cs
@@ -1242,6 +1242,17 @@ namespace Microsoft.SharePoint.Client
         }
 
         /// <summary>
+        /// Enables request access for the default owners group of the site.
+        /// </summary>
+        /// <param name="web">The web to enable request access.</param>
+        public static void EnableRequestAccess(this Web web)
+        {
+            web.SetUseAccessRequestDefaultAndUpdate(true);
+            web.Update();
+            web.Context.ExecuteQueryRetry();
+        }
+
+        /// <summary>
         /// Enables request access for the specified e-mail addresses.
         /// </summary>
         /// <param name="web">The web to enable request access.</param>
@@ -1285,6 +1296,7 @@ namespace Microsoft.SharePoint.Client
             if (skippedEmails.Count > 0)
                 Log.Warning(Constants.LOGGING_SOURCE, CoreResources.WebExtensions_RequestAccessEmailLimitExceeded, string.Join(", ", skippedEmails));
 
+            web.SetUseAccessRequestDefaultAndUpdate(false);
             web.RequestAccessEmail = sb.ToString();
             web.Update();
             web.Context.ExecuteQueryRetry();


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no 
| Related issues?  | N/A

#### What's in this Pull Request?

Added `EnableRequestAccess` method without providing e-mail addresses to instruct setting it back to the default owners of the site. After setting it to the default, trying to set it to a specific e-mail address again will set the e-mail address but will leave the selected option at the default owners in the web UI. To mitigate this, we always need to set `SetUseAccessRequestDefaultAndUpdate(false)` when setting `RequestAccessEmail`