### PR TITLE
Only allow one e-mail address to receive access requests

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/WebExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/WebExtensions.cs
@@ -1246,6 +1246,7 @@ namespace Microsoft.SharePoint.Client
         /// </summary>
         /// <param name="web">The web to enable request access.</param>
         /// <param name="emails">The e-mail addresses to send access requests to.</param>
+        [Obsolete("Only one e-mail address can be set for receiving access requests, use the EnableRequestAccess with string email instead")]
         public static void EnableRequestAccess(this Web web, params string[] emails)
         {
             web.EnableRequestAccess(emails.AsEnumerable());
@@ -1256,6 +1257,7 @@ namespace Microsoft.SharePoint.Client
         /// </summary>
         /// <param name="web">The web to enable request access.</param>
         /// <param name="emails">The e-mail addresses to send access requests to.</param>
+        [Obsolete("Only one e-mail address can be set for receiving access requests, use the EnableRequestAccess with string email instead")]
         public static void EnableRequestAccess(this Web web, IEnumerable<string> emails)
         {
             // keep them unique, but keep order
@@ -1286,6 +1288,19 @@ namespace Microsoft.SharePoint.Client
                 Log.Warning(Constants.LOGGING_SOURCE, CoreResources.WebExtensions_RequestAccessEmailLimitExceeded, string.Join(", ", skippedEmails));
 
             web.RequestAccessEmail = sb.ToString();
+            web.Update();
+            web.Context.ExecuteQueryRetry();
+        }
+
+        /// <summary>
+        /// Enables request access for the specified e-mail address.
+        /// </summary>
+        /// <param name="web">The web to enable request access.</param>
+        /// <param name="email">The e-mail address to send access requests to.</param>
+        public static void EnableRequestAccess(this Web web, string email)
+        {
+            web.SetUseAccessRequestDefaultAndUpdate(false);
+            web.RequestAccessEmail = email;
             web.Update();
             web.Context.ExecuteQueryRetry();
         }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no 
| New sample?      | no
| Related issues?  | N/A

#### What's in this Pull Request?

As far as I can judge, you can only set one e-mail address to receive the access request e-mails. Updating the code to mark the current methods accepting multiple e-mail addresses as obsolete and adding new methods making it clear that only e-mail address can be set. Test it for yourself by providing multiple e-mail addresses either through the current code or the web UI. It will result in an error no matter if you use a comma or semicolon to separate multiple addresses.