### PR TITLE
Enabled uploading document set default documents on no script sites

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
@@ -550,25 +550,15 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     }
                 }
 
-                if (!isNoScriptSite)
+                foreach (var doc in templateContentType.DocumentSetTemplate.DefaultDocuments)
                 {
-                    foreach (var doc in templateContentType.DocumentSetTemplate.DefaultDocuments)
+                    Microsoft.SharePoint.Client.ContentType ct = existingCTs.FirstOrDefault(c => c.StringId == doc.ContentTypeId);
+                    if (ct != null)
                     {
-                        Microsoft.SharePoint.Client.ContentType ct = existingCTs.FirstOrDefault(c => c.StringId == doc.ContentTypeId);
-                        if (ct != null)
+                        using (Stream fileStream = connector.GetFileStream(doc.FileSourcePath))
                         {
-                            using (Stream fileStream = connector.GetFileStream(doc.FileSourcePath))
-                            {
-                                documentSetTemplate.DefaultDocuments.Add(doc.Name, ct.Id, ReadFullStream(fileStream));
-                            }
+                            documentSetTemplate.DefaultDocuments.Add(doc.Name, ct.Id, ReadFullStream(fileStream));
                         }
-                    }
-                }
-                else
-                {
-                    if (templateContentType.DocumentSetTemplate.DefaultDocuments.Any())
-                    {
-                        scope.LogWarning(CoreResources.Provisioning_ObjectHandlers_ContentTypes_SkipDocumentSetDefaultDocuments, name);
                     }
                 }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | N/A

#### What's in this Pull Request?

Uploading default documents for document set content types are supported on noscript sites (at least it works both in Online and SP2019).