### PR TITLE
Ensure null value is never set for MaterPageUrl and ColorPaletteUrl

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/BrandingExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/BrandingExtensions.cs
@@ -244,9 +244,16 @@ namespace Microsoft.SharePoint.Client
             backgroundUrl = System.Net.WebUtility.UrlDecode(backgroundUrl);
             masterUrl = System.Net.WebUtility.UrlDecode(masterUrl);
 
-            web.SetMasterPageByUrl(masterUrl, resetSubsitesToInherit, updateRootOnly);
-            web.SetCustomMasterPageByUrl(masterUrl, resetSubsitesToInherit, updateRootOnly);
-            web.SetThemeByUrl(paletteUrl, fontUrl, backgroundUrl, resetSubsitesToInherit, updateRootOnly);
+            if (!string.IsNullOrEmpty(masterUrl))
+            {
+                web.SetMasterPageByUrl(masterUrl, resetSubsitesToInherit, updateRootOnly);
+                web.SetCustomMasterPageByUrl(masterUrl, resetSubsitesToInherit, updateRootOnly);
+            }
+
+            if (!string.IsNullOrWhiteSpace(paletteUrl))
+            {
+                web.SetThemeByUrl(paletteUrl, fontUrl, backgroundUrl, resetSubsitesToInherit, updateRootOnly);
+            }
 
             // Update/create the "Current" reference in the composed looks gallery
             string currentLookName = GetLocalizedCurrentValue(web);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | N/A

#### What's in this Pull Request?

The current Composed look for a Modern team site collection is by default empty. 

![image](https://user-images.githubusercontent.com/9477416/75344456-ed707700-589a-11ea-8e54-087e76fe195a.png)

Extracting this Composed Look and provision it through the Composed Look ObjectHandler will throw the follow exceptions:

- Value cannot be null. Parameter name: masterPageServerRelativeUrl
- The 'colorPaletteUrl' argument cannot be null. Parameter name: colorPaletteUrl	

This PR ensures that the masterPageServerRelativeUrl and the colorPaletteUrl is never set to null.