### PR TITLE
Fixed children content types not beeing updated

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
@@ -114,7 +114,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                             scope.LogPropertyUpdate("ReadOnly");
                             existingCT.ReadOnly = ct.ReadOnly;
 
-                            existingCT.Update(false);
+                            existingCT.Update(UpdateChildrenRequested(ct));
                             existingCT.Context.ExecuteQueryRetry();
                         }
                     }
@@ -122,6 +122,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             }
             WriteMessage($"Done processing Content Types", ProvisioningMessageType.Completed);
             return parser;
+        }
+
+        private static bool UpdateChildrenRequested(ContentType ct)
+        {
+            return !ct.FieldRefs.All(f => f.UpdateChildren == false);
         }
 
         private void UpdateContentType(
@@ -136,6 +141,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         {
             var isDirty = false;
             var reOrderFields = false;
+            var isChildrenDirty = false;
 
             if (existingContentType.Hidden != templateContentType.Hidden)
             {
@@ -150,12 +156,14 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 scope.LogPropertyUpdate("ReadOnly");
                 existingContentType.ReadOnly = templateContentType.ReadOnly;
                 isDirty = true;
+                isChildrenDirty = true;
             }
             if (existingContentType.Sealed != templateContentType.Sealed)
             {
                 scope.LogPropertyUpdate("Sealed");
                 existingContentType.Sealed = templateContentType.Sealed;
                 isDirty = true;
+                isChildrenDirty = true;
             }
             if (templateContentType.Description != null && existingContentType.Description != parser.ParseString(templateContentType.Description))
             {
@@ -168,6 +176,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 scope.LogPropertyUpdate("DocumentTemplate");
                 existingContentType.DocumentTemplate = parser.ParseString(templateContentType.DocumentTemplate);
                 isDirty = true;
+                isChildrenDirty = true;
             }
             if (existingContentType.Name != parser.ParseString(templateContentType.Name))
             {
@@ -232,8 +241,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 #endif
             if (isDirty)
             {
-                // Default to false as there is no reason to update children on CT property changes.
-                existingContentType.Update(false);
+                existingContentType.Update(isChildrenDirty && UpdateChildrenRequested(templateContentType));
                 web.Context.ExecuteQueryRetry();
             }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | #2270 

#### What's in this Pull Request?

Some properties for a content type supports pushing down to children. This was disabled by PR #2270. This PR changes it back so that children are updated if any of the properties that supports pushing down to children are changed and if any of the field references are set to update children content types.

Future versions of the provisioning schema should probably implement a content type level attribute for specifying if children are to be updated instead of relying on this to be specified on the field refs.
