### PR TITLE
Added message about false positive noscript detection

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/WebExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/WebExtensions.cs
@@ -314,7 +314,9 @@ namespace Microsoft.SharePoint.Client
 
 
         /// <summary>
-        /// Detects if the site in question has no script enabled or not. Detection is done by verifying if the AddAndCustomizePages permission is missing.
+        /// Performs a best effort detection of if the site in question has no script enabled or not.
+        /// Detection is done by verifying if the AddAndCustomizePages permission is missing.
+        /// Detection will return a false positive if the current user does not have the AddAndCustomizePages permission. 
         ///
         /// See https://support.office.com/en-us/article/Turn-scripting-capabilities-on-or-off-1f2c515f-5d7e-448a-9fd7-835da935584f
         /// for the effects of NoScript
@@ -328,8 +330,10 @@ namespace Microsoft.SharePoint.Client
         }
 
         /// <summary>
-        /// Detects if the site in question has no script enabled or not. Detection is done by verifying if the AddAndCustomizePages permission is missing.
-        ///
+        /// Performs a best effort detection of if the site in question has no script enabled or not.
+        /// Detection is done by verifying if the AddAndCustomizePages permission is missing.
+        /// Detection will return a false positive if the current user does not have the AddAndCustomizePages permission. 
+        /// 
         /// See https://support.office.com/en-us/article/Turn-scripting-capabilities-on-or-off-1f2c515f-5d7e-448a-9fd7-835da935584f
         /// for the effects of NoScript
         ///

--- a/Core/OfficeDevPnP.Core/Extensions/WebExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/WebExtensions.cs
@@ -315,7 +315,7 @@ namespace Microsoft.SharePoint.Client
 
         /// <summary>
         /// Performs a best effort detection of if the site in question has no script enabled or not.
-        /// Detection is done by verifying if the AddAndCustomizePages permission is missing.
+        /// Detection is done by verifying if the authenticated user has AddAndCustomizePages permission on the web.
         /// Detection will return a false positive if the current user does not have the AddAndCustomizePages permission. 
         ///
         /// See https://support.office.com/en-us/article/Turn-scripting-capabilities-on-or-off-1f2c515f-5d7e-448a-9fd7-835da935584f
@@ -331,7 +331,7 @@ namespace Microsoft.SharePoint.Client
 
         /// <summary>
         /// Performs a best effort detection of if the site in question has no script enabled or not.
-        /// Detection is done by verifying if the AddAndCustomizePages permission is missing.
+        /// Detection is done by verifying if the authenticated user has AddAndCustomizePages permission on the web.
         /// Detection will return a false positive if the current user does not have the AddAndCustomizePages permission. 
         /// 
         /// See https://support.office.com/en-us/article/Turn-scripting-capabilities-on-or-off-1f2c515f-5d7e-448a-9fd7-835da935584f


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| New sample?      | no
| Related issues?  | N/A

#### What's in this Pull Request?

Web.IsNoScriptSite() extension method is not a definitive answer to if the site in fact is enabled for NoScript. This can also return true for sites that does not have NoScript enabled and the current user (or app only credentials) does not have required permissions to modify data.

Modified the documentation to highlight this.