### PR TITLE
Add ability to exclude fields from content type hub when extracting provisioning template

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/TaxonomyExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/TaxonomyExtensions.cs
@@ -364,6 +364,20 @@ namespace Microsoft.SharePoint.Client
             return termStore;
         }
 
+        /// <summary>
+        /// Gets the URL of the content type syndication hub, if it exists.
+        /// </summary>
+        /// <param name="site">Site to be processed</param>
+        /// <returns>Returns the URL of the content type syndication hub</returns>
+        public static string GetContentTypePublishingHub(this Site site)
+        {
+            TaxonomySession session = TaxonomySession.GetTaxonomySession(site.Context);
+            var termStore = session.GetDefaultSiteCollectionTermStore();
+            site.Context.Load(termStore, s => s.ContentTypePublishingHub);
+            site.Context.ExecuteQueryRetry();
+
+            return termStore.ContentTypePublishingHub;
+        }
 
         /// <summary>
         /// Finds a termset by name

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ProvisioningTemplateCreationInformation.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ProvisioningTemplateCreationInformation.cs
@@ -31,6 +31,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         private List<ExtensibilityHandler> extensibilityHandlers = new List<ExtensibilityHandler>();
         private Handlers handlersToProcess = Handlers.All;
         private bool includeContentTypesFromSyndication = true;
+        private bool includeFieldsFromSyndication = true;
         private bool includeHiddenLists = false;
         private bool includeAllClientSidePages = false;
 
@@ -314,6 +315,19 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         {
             get { return includeContentTypesFromSyndication; }
             set { includeContentTypesFromSyndication = value; }
+        }
+
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to include fields from syndication (= content type hub) or not.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if the export should contains fields issued from syndication (= content type hub)
+        /// </value>
+        public bool IncludeFieldsFromSyndication
+        {
+            get { return includeFieldsFromSyndication; }
+            set { includeFieldsFromSyndication = value; }
         }
 
         /// <summary>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no
| Related issues?  | mentioned in #1222 

#### What's in this Pull Request?

This PR adds the ability to exclude fields that came from content type hub. For backwards compatibility, fields are included by default.