### PR TITLE
Added list content type id token to support specifying list content t…

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFeatures.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFeatures.cs
@@ -121,10 +121,10 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             }
             if(parent is Site)
             {
-                parser.AddListTokens((parent as Site).RootWeb);
+                parser.RebuildListTokens((parent as Site).RootWeb);
             } else
             {
-                parser.AddListTokens(parent as Web);
+                parser.RebuildListTokens(parent as Web);
             }
             return parser;
         }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -157,6 +157,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     // We stop here unless we reached the last provisioning stop of the list
                     if (step == FieldAndListProvisioningStepHelper.Step.ListSettings)
                     {
+                        parser.RebuildListTokens(web);
+
                         #region Default Field Values
 
                         foreach (var listInfo in processedLists)
@@ -170,9 +172,10 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                         foreach (var listInfo in processedLists)
                         {
-                            parser.RebuildListTokens(web);
                             ProcessViews(web, parser, scope, listInfo);
                         }
+
+                        parser.RebuildListTokens(web);
 
                         #endregion Views
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -170,6 +170,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                         foreach (var listInfo in processedLists)
                         {
+                            parser.RebuildListTokens(web);
                             ProcessViews(web, parser, scope, listInfo);
                         }
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/ListContentTypeIdToken.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/ListContentTypeIdToken.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.SharePoint.Client;
+using OfficeDevPnP.Core.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitions
+{
+    [TokenDefinitionDescription(
+     Token = "{listContentTypeId:[listname],[contentTypeName]}",
+     Description = "Returns an id of the content type given its name for a given list",
+     Example = "{listContentTypeId:My List,Folder}",
+     Returns = "0x010100F0D7B2FF0128AD459168DFA77A2A1BD0")]
+    [TokenDefinitionDescription(
+     Token = "{listContentTypeId:[listname],[contentTypeId]}",
+     Description = "Returns an id of the content type given its direct parent id for a given list",
+     Example = "{listContentTypeId:My List,Folder}",
+     Returns = "0x0101")]
+    internal class ListContentTypeIdToken : TokenDefinition
+    {
+        private string _contentTypeId = null;
+
+        public ListContentTypeIdToken(Web web, string listTitle, string contentTypeName, ContentTypeId contentTypeId)
+            : base(web, $"{{listcontenttypeid:{Regex.Escape(listTitle)},{Regex.Escape(contentTypeName)}}}")
+        {
+            _contentTypeId = contentTypeId.StringValue;
+        }
+
+        public override string GetReplaceValue()
+        {
+            if (string.IsNullOrEmpty(CacheValue))
+            {
+                CacheValue = _contentTypeId;
+            }
+            return CacheValue;
+        }
+    }
+}

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
@@ -84,8 +84,10 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             _tokens.Add(new SiteToken(web));
 
             // remove list tokens
-            if (tokenIds.Contains("listid") || tokenIds.Contains("listurl") || tokenIds.Contains("viewid"))
-                AddListTokens(web); // tokens are remove in method
+            if (tokenIds.Contains("listid") || tokenIds.Contains("listurl") || tokenIds.Contains("viewid") || tokenIds.Contains("listcontenttypeid"))
+            {
+                RebuildListTokens(web);
+            }
             // remove content type tokens
             if (tokenIds.Contains("contenttypeid"))
                 AddContentTypeTokens(web);
@@ -226,7 +228,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 #endif
 
             if (tokenIds.Contains("listid") || tokenIds.Contains("listurl") || tokenIds.Contains("viewid"))
-                AddListTokens(web);
+                RebuildListTokens(web);
             if (tokenIds.Contains("contenttypeid"))
                 AddContentTypeTokens(web);
 
@@ -640,15 +642,16 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             }
         }
 
-        internal void AddListTokens(Web web)
+        internal void RebuildListTokens(Web web)
         {
             web.EnsureProperties(w => w.ServerRelativeUrl, w => w.Language);
 
             _tokens.RemoveAll(t => t.GetType() == typeof(ListIdToken));
             _tokens.RemoveAll(t => t.GetType() == typeof(ListUrlToken));
             _tokens.RemoveAll(t => t.GetType() == typeof(ListViewIdToken));
-
-            web.Context.Load(web.Lists, ls => ls.Include(l => l.Id, l => l.Title, l => l.RootFolder.ServerRelativeUrl, l => l.Views
+            _tokens.RemoveAll(t => t.GetType() == typeof(ListContentTypeIdToken));
+            
+            web.Context.Load(web.Lists, ls => ls.Include(l => l.Id, l => l.Title, l => l.RootFolder.ServerRelativeUrl, l => l.Views, l => l.ContentTypes
 #if !SP2013
             , l => l.TitleResource
 #endif
@@ -670,6 +673,12 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 foreach (var view in list.Views)
                 {
                     _tokens.Add(new ListViewIdToken(web, list.Title, view.Title, view.Id));
+                }
+                
+                foreach (var contentType in list.ContentTypes)
+                {
+                    _tokens.Add(new ListContentTypeIdToken(web, list.Title, contentType.Name, contentType.Id));
+                    _tokens.Add(new ListContentTypeIdToken(web, list.Title, contentType.Id.StringValue, contentType.Id));
                 }
             }
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
@@ -678,7 +678,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 foreach (var contentType in list.ContentTypes)
                 {
                     _tokens.Add(new ListContentTypeIdToken(web, list.Title, contentType.Name, contentType.Id));
-                    _tokens.Add(new ListContentTypeIdToken(web, list.Title, contentType.Id.StringValue, contentType.Id));
+                    _tokens.Add(new ListContentTypeIdToken(web, list.Title, contentType.Id.GetParentIdValue(), contentType.Id));
                 }
             }
 

--- a/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
+++ b/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
@@ -714,6 +714,7 @@
     <Compile Include="Framework\Provisioning\ObjectHandlers\TokenDefinitions\EveryoneToken.cs" />
     <Compile Include="Framework\Provisioning\ObjectHandlers\TokenDefinitions\EveryoneButExternalUsersToken.cs" />
     <Compile Include="Framework\Provisioning\ObjectHandlers\TokenDefinitions\FieldIdToken.cs" />
+    <Compile Include="Framework\Provisioning\ObjectHandlers\TokenDefinitions\ListContentTypeIdToken.cs" />
     <Compile Include="Framework\Provisioning\ObjectHandlers\TokenDefinitions\O365GroupIdToken.cs" />
     <Compile Include="Framework\Provisioning\ObjectHandlers\TokenDefinitions\SequenceSiteGroupIdToken.cs" />
     <Compile Include="Framework\Provisioning\ObjectHandlers\TokenDefinitions\SequenceSiteIdToken.cs" />


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no
| Related issues?  | N/A

#### What's in this Pull Request?

Added new token for specifying content type id for content type added to a list. This is required for specifying content types in the NewDocumentTemplates node for the default view.
The token can be used with both content type name or direct parent content type id.

Also changed name for AddListTokens method to better communicate what is being done in the method. It's not just adding tokens, it's also removing tokens. I think Rebuild is therefore better than Add. The method is also internal, so changes will have no impact on external code. This should be a safe change to do and makes the code cleaner.
