### PR TITLE
Fixing broken API call for list webhook subscriptions.

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/ListExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/ListExtensions.cs
@@ -164,15 +164,15 @@ namespace Microsoft.SharePoint.Client
             // Get the access from the client context if not specified.
             accessToken = accessToken ?? list.Context.GetAccessToken();
 
-            // Ensure the list Id is known
-            Guid listId = list.EnsureProperty(l => l.Id);
+            // Ensure the list Id and Url are known
+            list.EnsureProperties(l => l.Id, l => l.ParentWeb, l => l.ParentWeb.Url);
 
             try
             {
-                return WebhookUtility.AddWebhookSubscriptionAsync(list.Context.Url,
+                return WebhookUtility.AddWebhookSubscriptionAsync(list.ParentWeb.Url,
                                WebHookResourceType.List, accessToken, list.Context as ClientContext, new WebhookSubscription()
                                {
-                                   Resource = listId.ToString(),
+                                   Resource = list.Id.ToString(),
                                    ExpirationDateTime = expirationDate,
                                    NotificationUrl = notificationUrl,
                                    ClientState = clientState

--- a/Core/OfficeDevPnP.Core/Utilities/Webhooks/WebhookUtility.cs
+++ b/Core/OfficeDevPnP.Core/Utilities/Webhooks/WebhookUtility.cs
@@ -33,7 +33,7 @@ namespace OfficeDevPnP.Core.Utilities
     internal static class WebhookUtility
     {
         private const string SubscriptionsUrlPart = "subscriptions";
-        private const string ListIdentifierFormat = @"{0}/_api/web/lists('{1}')";
+        private const string ListIdentifierFormat = @"{0}/_api/web/lists(guid'{1}')";
         public const int MaximumValidityInMonths = 6;
         public const int ExpirationDateTimeMaxDays = 180;
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | N/A

#### What's in this Pull Request?

Fixing broken API call for list webhook subscriptions:
- "missing "guid" prefix before list id.
For a correct construction of webhook api call see: https://docs.microsoft.com/en-us/sharepoint/dev/sp-add-ins/working-with-lists-and-list-items-with-rest.
Also it seems Sharepoint documention is either not up-to-date or incomplete ("guid" is not mentioned in their guide here: https://docs.microsoft.com/en-us/sharepoint/dev/apis/webhooks/webhooks-reference-implementation

Ensuring the URL of the list is correct, and is not taken from its context (which could hold an URL of a site collection or of a website which is higher up in the hierarchy):
- When creating a subsite in the subsite, and reusing the same ClientContext, the URL was not correct and would refer to the top site collection. So it would miss the entire path of the website, where the list is located (also would contain double slashes in the path). The fix ensures that the actual URL of the list is being used in API call.