### PR TITLE
Improve error message when uploading a file with invalid characters in the file name

### DIFF
--- a/Core/OfficeDevPnP.Core/CoreResources.Designer.cs
+++ b/Core/OfficeDevPnP.Core/CoreResources.Designer.cs
@@ -514,7 +514,7 @@ namespace OfficeDevPnP.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The argument must be a single file name and cannot contain path characters..
+        ///   Looks up a localized string similar to The argument must be a single file name and cannot contain path characters. Value:&apos;{0}&apos;.
         /// </summary>
         internal static string FileFolderExtensions_UploadFile_The_argument_must_be_a_single_file_name_and_cannot_contain_path_characters_ {
             get {

--- a/Core/OfficeDevPnP.Core/CoreResources.resx
+++ b/Core/OfficeDevPnP.Core/CoreResources.resx
@@ -610,7 +610,7 @@
     <value>Destination file name is required.</value>
   </data>
   <data name="FileFolderExtensions_UploadFile_The_argument_must_be_a_single_file_name_and_cannot_contain_path_characters_" xml:space="preserve">
-    <value>The argument must be a single file name and cannot contain path characters.</value>
+    <value>The argument must be a single file name and cannot contain path characters. Value:'{0}'</value>
   </data>
   <data name="FileFolderExtensions_UploadFileWebDav_The_argument_must_be_a_single_file_name_and_cannot_contain_path_characters_" xml:space="preserve">
     <value>The argument must be a single file name and cannot contain path characters.</value>

--- a/Core/OfficeDevPnP.Core/Extensions/FileFolderExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/FileFolderExtensions.cs
@@ -1758,7 +1758,7 @@ namespace Microsoft.SharePoint.Client
                 throw new ArgumentException(CoreResources.FileFolderExtensions_UploadFile_Destination_file_name_is_required_, nameof(fileName));
 
             if (fileName.ContainsInvalidFileFolderChars())
-                throw new ArgumentException(CoreResources.FileFolderExtensions_UploadFile_The_argument_must_be_a_single_file_name_and_cannot_contain_path_characters_, nameof(fileName));
+                throw new ArgumentException(string.Format(CoreResources.FileFolderExtensions_UploadFile_The_argument_must_be_a_single_file_name_and_cannot_contain_path_characters_, fileName), nameof(fileName));
 
             // Create the file
             var newFileInfo = new FileCreationInformation()


### PR DESCRIPTION

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no
| Related issues?  | helps to troubleshoot https://github.com/SharePoint/PnP-PowerShell/issues/2513

#### What's in this Pull Request?

When applying a PnP Template that tries to upload files with invalid/unsupported characters in the file name, an error message is displayed. This PR includes the actual filename in the error message, making it easier to find where the issue is in the template (imagine having a template that uploads 100 files).
The updated resource file entry FileFolderExtensions_UploadFile_The_argument_must_be_a_single_file_name_and_cannot_contain_path_characters_ is used only in the single place I updated.

This is how the new error message looks:
![image](https://user-images.githubusercontent.com/1153754/76100914-d124b680-5fcd-11ea-9e80-45ca6669d48b.png)

How to reproduce template (the TargetFileName is set to "Test with bad characters%#.txt" with invalid characters) :
```xml
<?xml version="1.0"?>
<pnp:Provisioning xmlns:pnp="http://schemas.dev.office.com/PnP/2020/02/ProvisioningSchema">
  <pnp:Preferences Generator="OfficeDevPnP.Core, Version=3.18.2002.0, Culture=neutral, PublicKeyToken=null" />
  <pnp:Templates ID="CONTAINER-TEMPLATE-370F19144D864A43BACC2DD11021C3C6">
    <pnp:ProvisioningTemplate ID="TEMPLATE-370F19144D864A43BACC2DD11021C3C6" Version="1" BaseSiteTemplate="GROUP#0" Scope="RootSite">
      <pnp:Files>
        <pnp:File Src="test.docx"
                  Folder="Shared Documents"
                  TargetFileName="Test with bad characters%#.txt" 
                  />
      </pnp:Files>
    </pnp:ProvisioningTemplate>
  </pnp:Templates>
</pnp:Provisioning>
```