### PR TITLE
UnitTest SP2013: Fix - ResetFileToPreviousVersionTest 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,6 @@ FakesAssemblies/
 
 # VS Code Settings
 .vscode/
+
+# Output XML Files
+Core/OfficeDevPnP.Core.Tests/Resources/Templates/ProvisioningTemplate-*-OUT*.xml

--- a/Core/OfficeDevPnP.Core.Tests/Extensions/FileFolderExtensionsTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Extensions/FileFolderExtensionsTests.cs
@@ -35,6 +35,19 @@ namespace OfficeDevPnP.Core.Tests.AppModelExtensions
             if (documentLibrary == null)
             {
                 documentLibrary = clientContext.Web.CreateList(ListTemplateType.DocumentLibrary, DocumentLibraryName, false);
+#if SP2013 // SharePoint 2013 Server Side default behaviour does not create a library with major versioning enabled. 
+                documentLibrary.EnsureProperties(
+                    d => d.EnableVersioning,
+                    d => d.MajorVersionLimit);
+
+                if (documentLibrary.EnableVersioning == false)
+                {
+                    documentLibrary.EnableVersioning = true;
+                    documentLibrary.MajorVersionLimit = 10;
+                    documentLibrary.Update();
+                    clientContext.ExecuteQueryRetry();
+                }
+#endif
             }
 
             clientContext.Load(documentLibrary.RootFolder.Folders);


### PR DESCRIPTION
(enable versioing for document library)

| Q               | A
| --------------- | ---
| Bug fix?        | yes

#### What's in this Pull Request?

UnitTest 'ResetFileToPreviousVersionTest' for SP2013 failed, cause the document library is created without versioning (major version) enabled. This PR enables versioning for document library.

This PR also exculdes output xml files (see .gitignore)
```
# Output XML Files
Core/OfficeDevPnP.Core.Tests/Resources/Templates/ProvisioningTemplate-*-OUT*.xml
```
