### PR TITLE
Fix Resx-Issue if names contain char handled by Regex.Escape

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
@@ -714,6 +714,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         public List<Tuple<string, string>> GetResourceTokenResourceValues(string tokenValue)
         {
             List<Tuple<string, string>> resourceValues = new List<Tuple<string, string>>();
+            tokenValue = $"{{{Regex.Escape(tokenValue.Trim(new char[] { '{', '}' }))}}}"; // since LocalizationToken are Regex.Escaped before load
             var resourceTokens = _tokens.Where(t => t is LocalizationToken && t.GetTokens().Contains(tokenValue));
             foreach (LocalizationToken resourceToken in resourceTokens)
             {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |  yes
| New feature?    | no
| New sample?      | no
| Related issues?  | View-/Listnames in Ressourcefiles containing for example char like () will not be replaced with text from Resx-File

#### What's in this Pull Request?
While the LocalizationToken Class loads the Names from Resx-File with Regex.Escape but GetResourceTokenResourceValues does not look for the Name Reges.Escape it will not find the translation and therefore not set it if the Name contains any Char handled by Regex.Escape.