### PR TITLE
Improve logging when waiting for a site collection to be created

### DIFF
--- a/Core/OfficeDevPnP.Core/Sites/SiteCollection.cs
+++ b/Core/OfficeDevPnP.Core/Sites/SiteCollection.cs
@@ -530,12 +530,22 @@ namespace OfficeDevPnP.Core.Sites
                     // Catch this...sometimes there's that "sharepoint push feature has not been ..." error
                 }
 
-                // Let's start polling for completion. We'll wait maximum 20 minutes for completion.               
+                // Let's start polling for completion. We'll wait maximum 20 minutes for completion.
+
+                Log.Debug(Constants.LOGGING_SOURCE, $"Starting to wait for site collection to be created");
+
+                var stopwatch = new Stopwatch();
+                stopwatch.Start();
+
                 var retryAttempt = 1;
                 do
                 {
+                    Log.Debug(Constants.LOGGING_SOURCE, $"Elapsed: {stopwatch.Elapsed.ToString(@"mm\:ss\.fff")} | Attempt {retryAttempt}/{maxRetryCount}");
+
                     if (retryAttempt > 1)
                     {
+                        Log.Debug(Constants.LOGGING_SOURCE, $"Elapsed: {stopwatch.Elapsed.ToString(@"mm\:ss\.fff")} | Waiting {retryDelay / 1000} seconds");
+
                         System.Threading.Thread.Sleep(retryDelay);
                     }
 
@@ -557,6 +567,9 @@ namespace OfficeDevPnP.Core.Sites
                     }
                 }
                 while (!isProvisioningComplete && retryAttempt <= maxRetryCount);
+
+                stopwatch.Stop();
+                Log.Debug(Constants.LOGGING_SOURCE, $"Elapsed: {stopwatch.Elapsed.ToString(@"mm\:ss\.fff")} | Finished");
             }
             catch (Exception)
             {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no
| Related issues?  | None
#### What's in this Pull Request?

When a site collection is created with a provisioning template with Apply-PnPTenantTemplate , the default waiting time of 20 minutes (max) is used to ensure the site collection has finished provisioning from SharePoint Online side. As no log message is displayed during this time, it might look to the user like the process is stuck.

This PR adds additional debug logs (enabled with [Set-PnPTraceLog](https://docs.microsoft.com/en-us/powershell/module/sharepoint-pnp/set-pnptracelog?view=sharepoint-ps) -On -Level Debug) to monitor the waiting of the site collection creation.

This is how it looks in the console:
![image](https://user-images.githubusercontent.com/1153754/76452448-71654b80-63d1-11ea-80c5-ea70851e89c5.png)

This is the text version:
>powershell.exe Information: 0 : 2020-03-11 18:40:06.0098	[OfficeDevPnP.Core]	[0]	[Debug]	Starting to wait for site collection to be created	0ms	
powershell.exe Information: 0 : 2020-03-11 18:40:06.0107	[OfficeDevPnP.Core]	[0]	[Debug]	Elapsed: 00:00.000 | Attempt 1/80	0ms	
powershell.exe Information: 0 : 2020-03-11 18:40:06.1305	[OfficeDevPnP.Core]	[0]	[Debug]	Elapsed: 00:00.119 | Attempt 2/80	0ms	
powershell.exe Information: 0 : 2020-03-11 18:40:06.1325	[OfficeDevPnP.Core]	[0]	[Debug]	Elapsed: 00:00.121 | Waiting 15 seconds	0ms	
powershell.exe Information: 0 : 2020-03-11 18:40:21.2806	[OfficeDevPnP.Core]	[0]	[Debug]	Elapsed: 00:15.269 | Attempt 3/80	0ms	
powershell.exe Information: 0 : 2020-03-11 18:40:21.2826	[OfficeDevPnP.Core]	[0]	[Debug]	Elapsed: 00:15.271 | Waiting 15 seconds	0ms

Full log from start to end of the waiting (12 minutes in total)
[log.txt](https://github.com/SharePoint/PnP-Sites-Core/files/4320190/log.txt)
