### PR TITLE
Fixed incorrect implementation of content type id best match

### DIFF
--- a/Core/OfficeDevPnP.Core/Extensions/FieldAndContentTypeExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Extensions/FieldAndContentTypeExtensions.cs
@@ -1862,19 +1862,19 @@ namespace Microsoft.SharePoint.Client
         private static ContentTypeId BestMatch(string contentTypeId, IEnumerable<ContentType> contentTypeCollection)
         {
             ContentTypeId bestMatch = null;
-            int num = 0;
-            foreach (ContentType id2 in contentTypeCollection)
+            int bestMatchCommonBytes = 0;
+            foreach (ContentType contentType in contentTypeCollection)
             {
-                int num2 = id2.Id.CountCommonBytes(contentTypeId);
-                if (num2 > num)
+                int commonBytes = contentType.Id.CountCommonBytes(contentTypeId);
+                if (commonBytes > bestMatchCommonBytes)
                 {
-                    bestMatch = id2.Id;
-                    num = num2;
+                    bestMatch = contentType.Id;
+                    bestMatchCommonBytes = commonBytes;
                     continue;
                 }
-                if ((num2 == num) && (id2.Id.StringValue.Length < bestMatch.StringValue.Length))
+                if ((commonBytes == bestMatchCommonBytes) && (contentType.Id.StringValue.Length < bestMatch.StringValue.Length))
                 {
-                    bestMatch = id2.Id;
+                    bestMatch = contentType.Id;
                 }
             }
             return bestMatch;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | N/A

#### What's in this Pull Request?

Previous implementation of content type id BestMatch was incorrect. It did not check for a common parent and could therefore end up with not finding av best match even though a content type sharing the same parent existed. For example if an Item list content type on a list with id 0x010100C284F907FFBF7D45B2B102E254551281 and an Item list content type on a different list with id 0x010100CE36B052C59F4C46ADD8ADA2F8668F3D the previous implementation would not find any match. It should identify 0x010100CE36B052C59F4C46ADD8ADA2F8668F3D as the best match for 0x010100C284F907FFBF7D45B2B102E254551281.

Implementation of BestMatch in this PR has been taken from the server side implementation of the same functionality.