### PR TITLE
Fixed IsChildOfDocumentSetContentType in ContentType Provisioning

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
@@ -325,7 +325,10 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             // The new CT is a DocumentSet, and the target should be, as well
             if (templateContentType.DocumentSetTemplate != null)
             {
-                if (!Microsoft.SharePoint.Client.DocumentSet.DocumentSetTemplate.IsChildOfDocumentSetContentType(web.Context, existingContentType).Value)
+                var isChildOfDocumentSetContentType = Microsoft.SharePoint.Client.DocumentSet.DocumentSetTemplate.IsChildOfDocumentSetContentType(web.Context, existingContentType);
+                web.Context.ExecuteQueryRetry();
+
+                if (!isChildOfDocumentSetContentType.Value)
                 {
                     scope.LogError(CoreResources.Provisioning_ObjectHandlers_ContentTypes_InvalidDocumentSet_Update_Request, existingContentType.Id, existingContentType.Name);
                 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no 
| Related issues?  | N/A

#### What's in this Pull Request?

Microsoft.SharePoint.Client.DocumentSet.DocumentSetTemplate.IsChildOfDocumentSetContentType requires an ExecuteQuery before it actually does something and returns a valid value. At present it would always return false, regardless if the content type did inherit from the document set content type. Confirmed by using Fiddler to look at the network traffic behind the execution.